### PR TITLE
Closes #124: fix identifiers deduplication in direct citation matching

### DIFF
--- a/iis-workflows/iis-workflows-citationmatching-direct/src/main/java/eu/dnetlib/iis/workflows/citationmatching/direct/udfs/DeduplicateIdsWithDocumentType.java
+++ b/iis-workflows/iis-workflows-citationmatching-direct/src/main/java/eu/dnetlib/iis/workflows/citationmatching/direct/udfs/DeduplicateIdsWithDocumentType.java
@@ -12,7 +12,7 @@ import org.apache.pig.impl.logicalLayer.schema.Schema;
 import com.google.common.collect.Lists;
 
 /**
- * Deduplicates bag of tuples where tuple[0] is pmid, tuple[1] is document type.
+ * Deduplicates bag of tuples where tuple[0] is oaid, tuple[1] is pmid document type.
  * 'research-article' type has precedence over any other type when more than one entry provided.
  * Identifiers are sorted lexicographically.
  *
@@ -45,7 +45,7 @@ public class DeduplicateIdsWithDocumentType extends EvalFunc<DataBag> {
         	}
         	count++;
         }
-		if (count==1) {
+		if (firstTuple!=null) {
 			return BagFactory.getInstance().newDefaultBag(
     				Lists.<Tuple>newArrayList(firstTuple));
 		}

--- a/iis-workflows/iis-workflows-citationmatching-direct/src/main/resources/eu/dnetlib/iis/workflows/citationmatching/direct/oozie_app/lib/scripts/transformer/transformer.pig
+++ b/iis-workflows/iis-workflows-citationmatching-direct/src/main/resources/eu/dnetlib/iis/workflows/citationmatching/direct/oozie_app/lib/scripts/transformer/transformer.pig
@@ -18,7 +18,6 @@ doi_to_oaid_nondedup = filter doi_to_oaid_with_nulls by originalId is not null;
 doi_to_oaid_nondedup_groupped = group doi_to_oaid_nondedup by originalId;
 doi_to_oaid = foreach doi_to_oaid_nondedup_groupped {
     first_record = LIMIT doi_to_oaid_nondedup 1;
---	FIXME it works but what if empty bag was returned?!
     generate group as originalId, flatten(first_record.newId) as newId;
 }
 
@@ -29,9 +28,8 @@ pmid_to_oaid_with_nulls = foreach documentMetadata generate externalIdentifiers#
 pmid_to_oaid_nondedup = filter pmid_to_oaid_with_nulls by originalId is not null;
 pmid_to_oaid_nondedup_groupped = group pmid_to_oaid_nondedup by originalId;
 pmid_to_oaid = foreach pmid_to_oaid_nondedup_groupped {
-     idsWithPublicationType = foreach pmid_to_oaid_nondedup generate originalId, newId, publicationTypeName;
+     idsWithPublicationType = foreach pmid_to_oaid_nondedup generate newId, publicationTypeName;
      dedupIdsWithPublicationType = DeduplicateIdsWithDocumentType(idsWithPublicationType);
---	 FIXME it works, but what if null was returned?!    
      generate group as originalId, flatten(dedupIdsWithPublicationType.newId) as newId;
  }
 

--- a/iis-workflows/iis-workflows-citationmatching-direct/src/test/resources/eu/dnetlib/iis/workflows/citationmatching/direct/sampledataproducer/data/citation.json
+++ b/iis-workflows/iis-workflows-citationmatching-direct/src/test/resources/eu/dnetlib/iis/workflows/citationmatching/direct/sampledataproducer/data/citation.json
@@ -1,5 +1,5 @@
 {
   "sourceDocumentId": "50|od_______908::c84fe76a7bc6232a6732dab8c72ef9ea",
   "position": 50,
-  "destinationDocumentId": "50|od_______908::14ddacb589be0a68489f89818647f27a"
+  "destinationDocumentId": "50|od_______908::14ddacb589be0a68489f89818647f27a_bis"
 }

--- a/iis-workflows/iis-workflows-citationmatching-direct/src/test/resources/eu/dnetlib/iis/workflows/citationmatching/direct/sampledataproducer/data/metadata.json
+++ b/iis-workflows/iis-workflows-citationmatching-direct/src/test/resources/eu/dnetlib/iis/workflows/citationmatching/direct/sampledataproducer/data/metadata.json
@@ -27,3 +27,11 @@
   "publicationTypeName": null,
   "references": []
 }
+{
+  "id": "50|od_______908::14ddacb589be0a68489f89818647f27a_bis",
+  "externalIdentifiers": {
+          "pmid": "5490870"
+  },
+  "publicationTypeName": "research-article",
+  "references": []
+}


### PR DESCRIPTION
I've fixed all the issues mentioned in #124 and extended test with checking duplicates and verifying `research-article` publication type precedence over other types.

@madryk you were the original reporter, can you please verify those changes?