### PR TITLE
Closes #128: Turn on caching in citationmatching-direct

### DIFF
--- a/iis-workflows/iis-workflows-citationmatching-direct/src/main/java/eu/dnetlib/iis/workflows/citationmatching/direct/CitationMatchingDirectJob.java
+++ b/iis-workflows/iis-workflows-citationmatching-direct/src/main/java/eu/dnetlib/iis/workflows/citationmatching/direct/CitationMatchingDirectJob.java
@@ -57,7 +57,7 @@ public class CitationMatchingDirectJob {
             
             
             JavaRDD<DocumentMetadata> simplifiedDocuments = documents.map(document -> documentToDirectCitationMetadataConverter.convert(document));
-//            simplifiedDocumentsMetadata = simplifiedDocumentsMetadata.cache(); // FIXME: https://github.com/openaire/iis/issues/128
+            simplifiedDocuments = simplifiedDocuments.cache();
             
             
             JavaRDD<Citation> directDoiCitations = externalIdCitationMatcher.matchCitations(simplifiedDocuments, "doi", new PickFirstDocumentFunction());


### PR DESCRIPTION
This requires fixes in spark-utils project