### PR TITLE
Closes #94: version.properties contains git details instead of svn ones

### DIFF
--- a/iis-workflows/pom.xml
+++ b/iis-workflows/pom.xml
@@ -289,18 +289,25 @@
 									</includePropertyKeysFromFiles>
 								</configuration>
 							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>pl.project13.maven</groupId>
+						<artifactId>git-commit-id-plugin</artifactId>
+						<version>2.1.11</version>
+						<executions>
 							<execution>
-								<id>write-version-properties</id>
-								<phase>prepare-package</phase>
 								<goals>
-									<goal>write-project-properties</goal>
+									<goal>revision</goal>
 								</goals>
-								<configuration>
-									<outputFile>target/${oozie.package.file.name}/${oozieAppDir}/version.properties</outputFile>
-									<include>svn.revision,svn.repository,svn.path</include>
-								</configuration>
 							</execution>
 						</executions>
+						<configuration>
+							<verbose>true</verbose>
+							<dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+							<generateGitPropertiesFile>true</generateGitPropertiesFile>
+							<generateGitPropertiesFilename>target/${oozie.package.file.name}/${oozieAppDir}/version.properties</generateGitPropertiesFilename>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
After recent IIS deployment I realized we lack git details in `version.properties` file. This patch fixes this issue.