### PR TITLE
Closes #210: ingest all article identifiers in PMC ingester module

### DIFF
--- a/iis-workflows/iis-workflows-ingest-pmc/src/main/java/eu/dnetlib/iis/workflows/ingest/pmc/metadata/PmcXmlHandler.java
+++ b/iis-workflows/iis-workflows-ingest-pmc/src/main/java/eu/dnetlib/iis/workflows/ingest/pmc/metadata/PmcXmlHandler.java
@@ -3,7 +3,6 @@ package eu.dnetlib.iis.workflows.ingest.pmc.metadata;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Stack;
 
 import org.apache.commons.lang.StringUtils;
@@ -68,8 +67,6 @@ public class PmcXmlHandler extends DefaultHandler {
 	private static final String PUB_ID_TYPE = "pub-id-type";
 	private static final String ATTR_ARTICLE_TYPE = "article-type";
 	
-	public static final String PUB_ID_TYPE_PMID = "pmid";
-	
 	private Stack<String> parents;
 	
 	private StringBuilder currentValue = new StringBuilder();
@@ -99,6 +96,9 @@ public class PmcXmlHandler extends DefaultHandler {
 	public PmcXmlHandler(ExtractedDocumentMetadata.Builder builder) {
 		super();
 		this.builder = builder;
+		if (!this.builder.hasExternalIdentifiers()) {
+			this.builder.setExternalIdentifiers(new HashMap<CharSequence, CharSequence>());
+		}
 	}
 	
 	@Override
@@ -168,10 +168,9 @@ public class PmcXmlHandler extends DefaultHandler {
 				builder.setJournal(this.currentValue.toString().trim());	
 			}
 		} else if (isWithinElement(qName, ELEM_ARTICLE_ID, ELEM_ARTICLE_META) &&
-				PUB_ID_TYPE_PMID.equals(this.currentArticleIdType)) {
-			Map<CharSequence,CharSequence> idMapping = new HashMap<CharSequence, CharSequence>();
-			idMapping.put(PUB_ID_TYPE_PMID, this.currentValue.toString().trim());
-			builder.setExternalIdentifiers(idMapping);
+				this.currentArticleIdType != null) {
+			builder.getExternalIdentifiers().put(this.currentArticleIdType, 
+					this.currentValue.toString().trim());
 		} else if (isWithinElement(qName, ELEM_FPAGE, ELEM_ARTICLE_META)) {
 			if (builder.getPages()==null) {
 				builder.setPages(Range.newBuilder().build());

--- a/iis-workflows/iis-workflows-ingest-pmc/src/test/java/eu/dnetlib/iis/workflows/ingest/pmc/metadata/PmcXmlHandlerTest.java
+++ b/iis-workflows/iis-workflows-ingest-pmc/src/test/java/eu/dnetlib/iis/workflows/ingest/pmc/metadata/PmcXmlHandlerTest.java
@@ -106,10 +106,9 @@ public class PmcXmlHandlerTest {
 		ExtractedDocumentMetadata meta = metaBuilder.build();
 		assertEquals("research-article", meta.getEntityType());
 		assertEquals("Frontiers in Neuroscience", meta.getJournal());
-		assertNull(meta.getExternalIdentifiers());
-
+		assertEquals(1, meta.getExternalIdentifiers().size());
+		assertEquals("10.3389/fnins.2014.00351", meta.getExternalIdentifiers().get("doi"));
 		assertNull(meta.getPages());
-
 		assertNotNull(meta.getReferences());
 		assertEquals(130, meta.getReferences().size());
 		// checking first reference
@@ -274,8 +273,11 @@ public class PmcXmlHandlerTest {
 	private void checkJats10Metadata(ExtractedDocumentMetadata meta) throws Exception {
 		assertEquals("research-article", meta.getEntityType());
 		assertEquals("BMC Systems Biology", meta.getJournal());
-		assertEquals(1, meta.getExternalIdentifiers().size());
+		assertEquals(4, meta.getExternalIdentifiers().size());
 		assertEquals("19943949", meta.getExternalIdentifiers().get("pmid"));
+		assertEquals("1752-0509-3-111", meta.getExternalIdentifiers().get("publisher-id"));
+		assertEquals("2789071", meta.getExternalIdentifiers().get("pmc"));
+		assertEquals("10.1186/1752-0509-3-111", meta.getExternalIdentifiers().get("doi"));
 		assertEquals("111", meta.getPages().getStart());
 		assertEquals("111", meta.getPages().getEnd());
 

--- a/iis-workflows/iis-workflows-ingest-pmc/src/test/resources/eu/dnetlib/iis/workflows/ingest/pmc/metadata/sampledataproducer/data/metadata.json
+++ b/iis-workflows/iis-workflows-ingest-pmc/src/test/resources/eu/dnetlib/iis/workflows/ingest/pmc/metadata/sampledataproducer/data/metadata.json
@@ -1,6 +1,8 @@
 {
   "id": "50|od_______908::c84fe76a7bc6232a6732dab8c72ef9ea",
   "externalIdentifiers": {
+          "pmcid": "1401509",
+          "doi": "10.1093/nar/gkl023",
           "pmid": "16528104"
   },
   "entityType": "research-article",
@@ -1202,6 +1204,7 @@
   "id": "50|od_______908::14ddacb589be0a68489f89818647f27a",
   
   "externalIdentifiers": {
+          "pmcid": "2591554",
           "pmid": "5490870"
   },
   "entityType": "research-article",


### PR DESCRIPTION
Up until now only `pmid` identifiers were supported.

This is simple change.