### PR TITLE
Closes #282: Missing error propagation from madIS tools to the workflow

### DIFF
--- a/iis-workflows/iis-workflows-documentsclassification/src/main/resources/eu/dnetlib/iis/workflows/documentsclassification/main/oozie_app/lib/scripts/classify_documents.sh
+++ b/iis-workflows/iis-workflows-documentsclassification/src/main/resources/eu/dnetlib/iis/workflows/documentsclassification/main/oozie_app/lib/scripts/classify_documents.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+set -o pipefail
 scripts/madis/mexec.py -d scripts/taxonomies.db -f scripts/classify.sql | scripts/complete_taxonomies.py


### PR DESCRIPTION
Use the bash pipefail option in a script, so that failure on the left-hand side of a pipeline is treated as failure of the pipeline.