### PR TITLE
Closes #308: referenceextraction_dataset_main_sqlite_sampletest fails

### DIFF
--- a/iis-workflows/iis-workflows-referenceextraction/src/test/resources/eu/dnetlib/iis/workflows/referenceextraction/dataset/data/document_to_dataset-old.json
+++ b/iis-workflows/iis-workflows-referenceextraction/src/test/resources/eu/dnetlib/iis/workflows/referenceextraction/dataset/data/document_to_dataset-old.json
@@ -1,0 +1,2 @@
+{"documentId":"WOS:000316614600026","datasetId":"oai:oai.datacite.org:1390724","confidenceLevel":0.8164966}
+{"documentId":"WOS:000316614600034","datasetId":"oai:oai.datacite.org:1457141","confidenceLevel":0.66332495}

--- a/iis-workflows/iis-workflows-referenceextraction/src/test/resources/eu/dnetlib/iis/workflows/referenceextraction/dataset/main_sqlite/sampletest/oozie_app/workflow.xml
+++ b/iis-workflows/iis-workflows-referenceextraction/src/test/resources/eu/dnetlib/iis/workflows/referenceextraction/dataset/main_sqlite/sampletest/oozie_app/workflow.xml
@@ -116,7 +116,7 @@
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_dataset,
 				eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet,
-				eu/dnetlib/iis/workflows/referenceextraction/dataset/data/document_to_dataset.json}</arg>
+				eu/dnetlib/iis/workflows/referenceextraction/dataset/data/document_to_dataset-old.json}</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-Idocument_to_dataset=${workingDir}/referenceextraction_dataset/document_to_dataset</arg>
 		</java>


### PR DESCRIPTION
Fixing #269 broke another test that used the same expected results file and
still produces the same results as before.
Resurrect the old version of `document_to_dataset.json` and use separate
expected result files for both tests.