### PR TITLE
Closes #344: Fix the way export outcome is distcped when output directory already exists

### DIFF
--- a/iis-workflows/iis-workflows-top/src/main/resources/eu/dnetlib/iis/workflows/top/common/export/oozie_app/workflow.xml
+++ b/iis-workflows/iis-workflows-top/src/main/resources/eu/dnetlib/iis/workflows/top/common/export/oozie_app/workflow.xml
@@ -361,6 +361,7 @@
 			<job-tracker>${jobTracker}</job-tracker>
 			<name-node>${nameNode}</name-node>
 			<arg>-pb</arg>
+			<arg>-overwrite</arg>
 			<arg>${nameNode}${workingDir}/output</arg>
 			<arg>${output_remote_location}</arg>
 		</distcp>


### PR DESCRIPTION
This is small one. 
To be applied on `master` branch, then I will merge it with `cdh5`.