### PR TITLE
Closes #323: There are commons-lang3 duplicates defined in main pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -774,12 +774,6 @@
 			</dependency>
 			
 			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.1</version>
-			</dependency>
-			
-			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>2.1</version>


### PR DESCRIPTION
Removing 3.1 version, leaving 3.4 untouched.