### PR TITLE
Closes #320: Ensure large files are used as metadata cache input

### DIFF
--- a/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cache_builder/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cache_builder/oozie_app/workflow.xml
@@ -323,6 +323,10 @@
 					<name>schema</name>
 					<value>eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata</value>
 				</property>
+				<property>
+					<name>combine_splits</name>
+					<value>335544320</value>
+				</property>
 			</configuration>
 		</sub-workflow>
 		<ok to="write-new-cache-id_for_merging" />

--- a/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cached/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cached/oozie_app/workflow.xml
@@ -319,6 +319,10 @@
 					<name>schema</name>
 					<value>eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata</value>
 				</property>
+				<property>
+					<name>combine_splits</name>
+					<value>335544320</value>
+				</property>
 			</configuration>
 		</sub-workflow>
 		<ok to="write-new-cache-id_for_merging" />

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/common/union/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/common/union/oozie_app/workflow.xml
@@ -13,6 +13,12 @@
 		<property>
 			<name>schema</name>
 		</property>
+		<property>
+			<name>combine_splits</name>
+			<!-- zero will use the Pig default -->
+			<value>0</value>
+			<description>Value for pig.maxCombinedSplitSize Pig property</description>
+		</property>
 	</parameters>
     
     <global>
@@ -49,6 +55,12 @@
 			<prepare>
 				<delete path="${nameNode}${output}" />
 			</prepare>
+			<configuration>
+				<property>
+					<name>pig.maxCombinedSplitSize</name>
+					<value>${combine_splits}</value>
+				</property>
+			</configuration>
             <!-- Path to PIG script the workflow executes. -->
             <script>lib/scripts/union.pig</script>
             


### PR DESCRIPTION
The actual metadata cache directory is usually (except on initialization)
created with Pig union, using a common union workflow.
As union is a map-only operation we cannot control the output file sizes
by changing the number of reducers, but we can use the pig.maxCombinedSplitSize
property to make Pig mappers combine the inputs.

Add a parameter for setting the property to the union workflow (defaulting to standard
Pig behaviour).
Use it in cache workflows to make union create large files, up to 320MB.