### PR TITLE
Closes #375: join the `document project` and `project concept` output

### DIFF
--- a/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -194,8 +194,7 @@
             </property>
             <property>
                 <name>io.serializations</name>
-                <value>org.apache.hadoop.io.serializer.WritableSerialization,org.apache.hadoop.io.serializer.avro.AvroSpecificSerialization,org.apache.hadoop.io.serializer.avro.AvroReflectSerialization,org.apache.avro.hadoop.io.AvroSerialization
-                </value>
+                <value>org.apache.hadoop.io.serializer.WritableSerialization,org.apache.hadoop.io.serializer.avro.AvroSpecificSerialization,org.apache.hadoop.io.serializer.avro.AvroReflectSerialization,org.apache.avro.hadoop.io.AvroSerialization</value>
             </property>
             <property>
                 <name>rpc.engine.org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB</name>

--- a/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -1,652 +1,715 @@
 <workflow-app xmlns="uri:oozie:workflow:0.4" name="export_actionmanager_sequencefile">
 
-	<parameters>
-		<property>
-			<name>input_document_metadata</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_project</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_project_concepts</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_dataset</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_research_initiatives</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_pdb</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_to_document_classes</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_citations</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>input_document_similarity</name>
-			<value>$UNDEFINED$</value>
-		</property>
-		<property>
-			<name>output</name>
-		</property>
-		<!-- actionset id section -->
-		<property>
-			<name>action_set_id</name>
-			<value>$UNDEFINED$</value>
-			<description>default action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_similarities_standard</name>
-			<value>$UNDEFINED$</value>
-			<description>document_similarities_standard action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_affiliations</name>
-			<value>$UNDEFINED$</value>
-			<description>document_affiliations action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_classes</name>
-			<value>$UNDEFINED$</value>
-			<description>document_classes action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_referencedProjects</name>
-			<value>$UNDEFINED$</value>
-			<description>document_referencedProjects action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_referencedDatasets</name>
-			<value>$UNDEFINED$</value>
-			<description>document_referencedDatasets action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_referencedDocuments</name>
-			<value>$UNDEFINED$</value>
-			<description>document_referencedDocuments action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_research_initiative</name>
-			<value>$UNDEFINED$</value>
-			<description>document research initiative action-set identifier of exported data</description>
-		</property>
-		<property>
-			<name>action_set_id_document_pdb</name>
-			<value>$UNDEFINED$</value>
-			<description>document to protein databank action-set identifier of exported data</description>
-		</property>
-		<!-- -->
-		<!-- trust level threshold section -->
-		<property>
-			<name>trust_level_threshold</name>
-			<value>$UNDEFINED$</value>
-			<description>default trust level threshold of exported data</description>
-		</property>
-		<property>
-			<name>trust_level_threshold_document_classes</name>
-			<value>$UNDEFINED$</value>
-			<description>document_classes trust level threshold</description>
-		</property>
-		<property>
-			<name>trust_level_threshold_document_referencedProjects</name>
-			<value>$UNDEFINED$</value>
-			<description>document_referencedProjects trust level threshold</description>
-		</property>
-		<property>
-			<name>trust_level_threshold_document_referencedDatasets</name>
-			<value>$UNDEFINED$</value>
-			<description>document_referencedDatasets trust level threshold</description>
-		</property>
-		<property>
-			<name>trust_level_threshold_document_pdb</name>
-			<value>$UNDEFINED$</value>
-			<description>document to protein databank trust level threshold</description>
-		</property>
-		<property>
-			<name>documentssimilarity_threshold</name>
-			<value>$UNDEFINED$</value>
-			<description>documents similarity threshold value below which similarity export is omitted</description>
-		</property>
-		<property>
-			<name>referenceextraction_pdb_url_root</name>
-			<value>$UNDEFINED$</value>
-			<description>protein databank URL root part to be concatenated with pdb identifier when forming final URL</description>
-		</property>
-	</parameters>
+    <parameters>
+        <property>
+            <name>input_document_metadata</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_project</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_project_concepts</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_dataset</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_research_initiatives</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_pdb</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_to_document_classes</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_citations</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>input_document_similarity</name>
+            <value>$UNDEFINED$</value>
+        </property>
+        <property>
+            <name>output</name>
+        </property>
+        <!-- actionset id section -->
+        <property>
+            <name>action_set_id</name>
+            <value>$UNDEFINED$</value>
+            <description>default action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_similarities_standard</name>
+            <value>$UNDEFINED$</value>
+            <description>document_similarities_standard action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_affiliations</name>
+            <value>$UNDEFINED$</value>
+            <description>document_affiliations action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_classes</name>
+            <value>$UNDEFINED$</value>
+            <description>document_classes action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_referencedProjects</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedProjects action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_referencedDatasets</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedDatasets action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_referencedDocuments</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedDocuments action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_research_initiative</name>
+            <value>$UNDEFINED$</value>
+            <description>document research initiative action-set identifier of exported data</description>
+        </property>
+        <property>
+            <name>action_set_id_document_pdb</name>
+            <value>$UNDEFINED$</value>
+            <description>document to protein databank action-set identifier of exported data</description>
+        </property>
+        <!-- -->
+        <!-- trust level threshold section -->
+        <property>
+            <name>trust_level_threshold</name>
+            <value>$UNDEFINED$</value>
+            <description>default trust level threshold of exported data</description>
+        </property>
+        <property>
+            <name>trust_level_threshold_document_classes</name>
+            <value>$UNDEFINED$</value>
+            <description>document_classes trust level threshold</description>
+        </property>
+        <property>
+            <name>trust_level_threshold_document_referencedProjects</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedProjects trust level threshold</description>
+        </property>
+        <property>
+            <name>trust_level_threshold_document_referencedDatasets</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedDatasets trust level threshold</description>
+        </property>
+        <property>
+            <name>trust_level_threshold_document_pdb</name>
+            <value>$UNDEFINED$</value>
+            <description>document to protein databank trust level threshold</description>
+        </property>
+        <property>
+            <name>documentssimilarity_threshold</name>
+            <value>$UNDEFINED$</value>
+            <description>documents similarity threshold value below which similarity export is omitted</description>
+        </property>
+        <property>
+            <name>referenceextraction_pdb_url_root</name>
+            <value>$UNDEFINED$</value>
+            <description>protein databank URL root part to be concatenated with pdb identifier when forming final URL</description>
+        </property>
+    </parameters>
 
-	<global>
-		<job-tracker>${jobTracker}</job-tracker>
-		<name-node>${nameNode}</name-node>
-		<configuration>
-			<property>
-				<name>mapred.job.queue.name</name>
-				<value>${queueName}</value>
-			</property>
-			<property>
-				<name>mapreduce.inputformat.class</name>
-				<value>org.apache.avro.mapreduce.AvroKeyInputFormat</value>
-			</property>
-			<property>
-				<name>mapreduce.outputformat.class</name>
-				<value>org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat</value>
-			</property>
-			<property>
-				<name>mapred.mapoutput.key.class</name>
-				<value>org.apache.hadoop.io.Text</value>
-			</property>
-			<property>
-				<name>mapred.mapoutput.value.class</name>
-				<value>org.apache.hadoop.io.Text</value>
-			</property>
-			<property>
-				<name>mapred.output.key.class</name>
-				<value>org.apache.hadoop.io.Text</value>
-			</property>
-			<property>
-				<name>mapred.output.value.class</name>
-				<value>org.apache.hadoop.io.Text</value>
-			</property>
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapred.job.queue.name</name>
+                <value>${queueName}</value>
+            </property>
+            <property>
+                <name>mapreduce.inputformat.class</name>
+                <value>org.apache.avro.mapreduce.AvroKeyInputFormat</value>
+            </property>
+            <property>
+                <name>mapreduce.outputformat.class</name>
+                <value>org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat</value>
+            </property>
+            <property>
+                <name>mapred.mapoutput.key.class</name>
+                <value>org.apache.hadoop.io.Text</value>
+            </property>
+            <property>
+                <name>mapred.mapoutput.value.class</name>
+                <value>org.apache.hadoop.io.Text</value>
+            </property>
+            <property>
+                <name>mapred.output.key.class</name>
+                <value>org.apache.hadoop.io.Text</value>
+            </property>
+            <property>
+                <name>mapred.output.value.class</name>
+                <value>org.apache.hadoop.io.Text</value>
+            </property>
 
-			<property>
-				<name>mapred.reduce.tasks.speculative.execution</name>
-				<value>false</value>
-			</property>
-			<property>
-				<name>mapred.map.tasks.speculative.execution</name>
-				<value>false</value>
-			</property>
-			<property>
-				<name>mapreduce.map.speculative</name>
-				<value>false</value>
-			</property>
-			<property>
-				<name>mapreduce.reduce.speculative</name>
-				<value>false</value>
-			</property>
+            <property>
+                <name>mapred.reduce.tasks.speculative.execution</name>
+                <value>false</value>
+            </property>
+            <property>
+                <name>mapred.map.tasks.speculative.execution</name>
+                <value>false</value>
+            </property>
+            <property>
+                <name>mapreduce.map.speculative</name>
+                <value>false</value>
+            </property>
+            <property>
+                <name>mapreduce.reduce.speculative</name>
+                <value>false</value>
+            </property>
 
-			<property>
-				<name>mapred.compress.map.output</name>
-				<value>true</value>
-			</property>
-			<property>
-				<name>mapred.output.compress</name>
-				<value>true</value>
-			</property>
-			<property>
-				<name>mapred.output.compression.type</name>
-				<value>BLOCK</value>
-			</property>
+            <property>
+                <name>mapred.compress.map.output</name>
+                <value>true</value>
+            </property>
+            <property>
+                <name>mapred.output.compress</name>
+                <value>true</value>
+            </property>
+            <property>
+                <name>mapred.output.compression.type</name>
+                <value>BLOCK</value>
+            </property>
 
-			<property>
-				<name>mapred.reduce.tasks</name>
-				<value>0</value>
-			</property>
-			<property>
-				<name>io.serializations</name>
-				<value>org.apache.hadoop.io.serializer.WritableSerialization,org.apache.hadoop.io.serializer.avro.AvroSpecificSerialization,org.apache.hadoop.io.serializer.avro.AvroReflectSerialization,org.apache.avro.hadoop.io.AvroSerialization</value>
-			</property>
-			<property>
-				<name>rpc.engine.org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB</name>
-				<value>org.apache.hadoop.ipc.ProtobufRpcEngine</value>
-			</property>
-			<property>
-				<name>mapred.mapper.new-api</name>
-				<value>true</value>
-			</property>
-			<property>
-				<name>mapred.reducer.new-api</name>
-				<value>true</value>
-			</property>
-			<property>
-				<name>mapreduce.map.class</name>
-				<value>eu.dnetlib.iis.workflows.export.actionmanager.sequencefile.SequenceFileExporterMapper</value>
-			</property>
-			<!-- actionset related -->
-			<property>
-				<name>export.action.setid</name>
-				<value>${action_set_id}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_similarities_standard</name>
-				<value>${action_set_id_document_similarities_standard}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_affiliations</name>
-				<value>${action_set_id_document_affiliations}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_classes</name>
-				<value>${action_set_id_document_classes}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_referencedProjects</name>
-				<value>${action_set_id_document_referencedProjects}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_referencedDatasets</name>
-				<value>${action_set_id_document_referencedDatasets}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_referencedDocuments</name>
-				<value>${action_set_id_document_referencedDocuments}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_research_initiative</name>
-				<value>${action_set_id_document_research_initiative}</value>
-			</property>
-			<property>
-				<name>export.action.setid.document_pdb</name>
-				<value>${action_set_id_document_pdb}</value>
-			</property>
-			<!-- trust level threshold related -->
-			<property>
-				<name>export.trust.level.threshold</name>
-				<value>${trust_level_threshold}</value>
-			</property>
-			<property>
-				<name>export.trust.level.threshold.document_classes</name>
-				<value>${trust_level_threshold_document_classes}</value>
-			</property>
-			<property>
-				<name>export.trust.level.threshold.document_referencedProjects</name>
-				<value>${trust_level_threshold_document_referencedProjects}</value>
-			</property>
-			<property>
-				<name>export.trust.level.threshold.document_referencedDatasets</name>
-				<value>${trust_level_threshold_document_referencedDatasets}</value>
-			</property>
-			<property>
-				<name>export.trust.level.threshold.document_pdb</name>
-				<value>${trust_level_threshold_document_pdb}</value>
-			</property>
-		</configuration>
-	</global>
+            <property>
+                <name>mapred.reduce.tasks</name>
+                <value>0</value>
+            </property>
+            <property>
+                <name>io.serializations</name>
+                <value>org.apache.hadoop.io.serializer.WritableSerialization,org.apache.hadoop.io.serializer.avro.AvroSpecificSerialization,org.apache.hadoop.io.serializer.avro.AvroReflectSerialization,org.apache.avro.hadoop.io.AvroSerialization
+                </value>
+            </property>
+            <property>
+                <name>rpc.engine.org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB</name>
+                <value>org.apache.hadoop.ipc.ProtobufRpcEngine</value>
+            </property>
+            <property>
+                <name>mapred.mapper.new-api</name>
+                <value>true</value>
+            </property>
+            <property>
+                <name>mapred.reducer.new-api</name>
+                <value>true</value>
+            </property>
+            <property>
+                <name>mapreduce.map.class</name>
+                <value>eu.dnetlib.iis.workflows.export.actionmanager.sequencefile.SequenceFileExporterMapper</value>
+            </property>
+            <!-- actionset related -->
+            <property>
+                <name>export.action.setid</name>
+                <value>${action_set_id}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_similarities_standard</name>
+                <value>${action_set_id_document_similarities_standard}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_affiliations</name>
+                <value>${action_set_id_document_affiliations}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_classes</name>
+                <value>${action_set_id_document_classes}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_referencedProjects</name>
+                <value>${action_set_id_document_referencedProjects}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_referencedDatasets</name>
+                <value>${action_set_id_document_referencedDatasets}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_referencedDocuments</name>
+                <value>${action_set_id_document_referencedDocuments}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_research_initiative</name>
+                <value>${action_set_id_document_research_initiative}</value>
+            </property>
+            <property>
+                <name>export.action.setid.document_pdb</name>
+                <value>${action_set_id_document_pdb}</value>
+            </property>
+            <!-- trust level threshold related -->
+            <property>
+                <name>export.trust.level.threshold</name>
+                <value>${trust_level_threshold}</value>
+            </property>
+            <property>
+                <name>export.trust.level.threshold.document_classes</name>
+                <value>${trust_level_threshold_document_classes}</value>
+            </property>
+            <property>
+                <name>export.trust.level.threshold.document_referencedProjects</name>
+                <value>${trust_level_threshold_document_referencedProjects}</value>
+            </property>
+            <property>
+                <name>export.trust.level.threshold.document_referencedDatasets</name>
+                <value>${trust_level_threshold_document_referencedDatasets}</value>
+            </property>
+            <property>
+                <name>export.trust.level.threshold.document_pdb</name>
+                <value>${trust_level_threshold_document_pdb}</value>
+            </property>
+        </configuration>
+    </global>
 
-	<start to="generate-schema" />
+    <start to="generate-schema" />
 
-	<!-- watch out for oozie.action.max.output.data limit set in oozie-site.xml 
-		it cannot be exceeded when capturing output of schemas generated as properties. 
-		When exceeded: either limit can be raised or multiple schema generating actions 
-		defined. -->
-	<action name="generate-schema">
-		<java>
-			<main-class>eu.dnetlib.iis.core.javamapreduce.hack.AvroSchemaGenerator
-			</main-class>
-			<arg>eu.dnetlib.iis.export.schemas.DocumentMetadata</arg>
-			<arg>eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject</arg>
-			<arg>eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet</arg>
-			<arg>eu.dnetlib.iis.export.schemas.DocumentToConceptIds</arg>
-			<arg>eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses</arg>
-			<arg>eu.dnetlib.iis.export.schemas.Citations</arg>
-			<arg>eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity</arg>
-			<capture-output />
-		</java>
-		<ok to="prepare" />
-		<error to="fail" />
-	</action>
+    <!-- watch out for oozie.action.max.output.data limit set in oozie-site.xml it cannot be exceeded when capturing output of schemas generated as properties. When exceeded: either limit can be raised 
+        or multiple schema generating actions defined. -->
+    <action name="generate-schema">
+        <java>
+            <main-class>eu.dnetlib.iis.core.javamapreduce.hack.AvroSchemaGenerator
+            </main-class>
+            <arg>eu.dnetlib.iis.export.schemas.DocumentMetadata</arg>
+            <arg>eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject</arg>
+            <arg>eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet</arg>
+            <arg>eu.dnetlib.iis.export.schemas.DocumentToConceptIds</arg>
+            <arg>eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses</arg>
+            <arg>eu.dnetlib.iis.export.schemas.Citations</arg>
+            <arg>eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity</arg>
+            <capture-output />
+        </java>
+        <ok to="prepare" />
+        <error to="fail" />
+    </action>
 
-	<action name="prepare">
-		<fs>
-			<delete path="${nameNode}${output}" />
-			<mkdir path="${nameNode}${output}" />
-		</fs>
-		<ok to="forking" />
-		<error to="fail" />
-	</action>
+    <action name="prepare">
+        <fs>
+            <delete path="${nameNode}${output}" />
+            <mkdir path="${nameNode}${output}" />
+        </fs>
+        <ok to="forking" />
+        <error to="fail" />
+    </action>
 
-	<fork name="forking">
-		<path start="decision-exporter-document-metadata" />
-		<path start="decision-exporter-document-to-dataset" />
-		<path start="decision-exporter-document-to-project" />
-		<path start="decision-exporter-document-to-project-concepts" />
-		<path start="decision-exporter-document-to-researchinitiatives" />
-		<path start="decision-exporter-document-to-pdb" />
-		<path start="decision-exporter-document-to-documentclasses" />
-		<path start="decision-exporter-citation" />
-		<path start="decision-exporter-document-similiarity" />
-	</fork>
+    <fork name="forking">
+        <path start="decision-exporter-document-metadata" />
+        <path start="decision-exporter-document-to-dataset" />
+        <path start="decision-exporter-document-to-project" />
+        <path start="decision-exporter-document-to-project-concepts" />
+        <path start="decision-exporter-document-to-researchinitiatives" />
+        <path start="decision-exporter-document-to-pdb" />
+        <path start="decision-exporter-document-to-documentclasses" />
+        <path start="decision-exporter-citation" />
+        <path start="decision-exporter-document-similiarity" />
+    </fork>
 
-	<decision name="decision-exporter-document-metadata">
-		<switch>
-			<case to="joining">${input_document_metadata eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-metadata" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-metadata">
+        <switch>
+            <case to="joining">${input_document_metadata eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-metadata" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-project">
-		<switch>
-			<case to="joining">${input_document_to_project eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-project" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-project">
+        <switch>
+            <case to="skip_exporter-document-to-project">${input_document_to_project eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-project" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-dataset">
-		<switch>
-			<case to="joining">${input_document_to_dataset eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-dataset" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-dataset">
+        <switch>
+            <case to="joining">${input_document_to_dataset eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-dataset" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-project-concepts">
-		<switch>
-			<case to="joining">${input_document_to_project_concepts eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-project-concepts" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-project-concepts">
+        <switch>
+            <case to="skip_exporter-document-to-project-concepts">${input_document_to_project_concepts eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-project-concepts" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-researchinitiatives">
-		<switch>
-			<case to="joining">${input_document_to_research_initiatives eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-researchinitiatives" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-researchinitiatives">
+        <switch>
+            <case to="joining">${input_document_to_research_initiatives eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-researchinitiatives" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-pdb">
-		<switch>
-			<case to="joining">${input_document_to_pdb eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-pdb" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-pdb">
+        <switch>
+            <case to="joining">${input_document_to_pdb eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-pdb" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-to-documentclasses">
-		<switch>
-			<case to="joining">${input_document_to_document_classes eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-to-documentclasses" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-to-documentclasses">
+        <switch>
+            <case to="joining">${input_document_to_document_classes eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-to-documentclasses" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-citation">
-		<switch>
-			<case to="joining">${input_citations eq "$UNDEFINED$"}</case>
-			<default to="exporter-citation" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-citation">
+        <switch>
+            <case to="joining">${input_citations eq "$UNDEFINED$"}</case>
+            <default to="exporter-citation" />
+        </switch>
+    </decision>
 
-	<decision name="decision-exporter-document-similiarity">
-		<switch>
-			<case to="joining">${input_document_similarity eq "$UNDEFINED$"}</case>
-			<default to="exporter-document-similiarity" />
-		</switch>
-	</decision>
+    <decision name="decision-exporter-document-similiarity">
+        <switch>
+            <case to="joining">${input_document_similarity eq "$UNDEFINED$"}</case>
+            <default to="exporter-document-similiarity" />
+        </switch>
+    </decision>
 
-	<action name="exporter-document-metadata">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_affiliations" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentAffiliationsActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentMetadata']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_metadata}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_affiliations/${action_set_id_document_affiliations}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-metadata">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_affiliations" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentAffiliationsActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentMetadata']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_metadata}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_affiliations/${action_set_id_document_affiliations}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-project">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_referencedProjects" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToProjectActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_project}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_referencedProjects/${action_set_id_document_referencedProjects}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-project">
+        <map-reduce>
+            <prepare>
+                <delete path="${nameNode}${workingDir}/document_referencedProjects" />
+                <mkdir path="${nameNode}${workingDir}/document_referencedProjects" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToProjectActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_project}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${workingDir}/document_referencedProjects/${action_set_id_document_referencedProjects}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-dataset">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_referencedDatasets" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToDataSetActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_dataset}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_referencedDatasets/${action_set_id_document_referencedDatasets}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-dataset">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_referencedDatasets" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToDataSetActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_dataset}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_referencedDatasets/${action_set_id_document_referencedDatasets}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-project-concepts">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_to_project_concepts" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToProjectConceptsActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_project_concepts}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_to_project_concepts/${action_set_id_document_referencedProjects}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-project-concepts">
+        <map-reduce>
+            <prepare>
+                <delete path="${nameNode}${workingDir}/document_to_project_concepts" />
+                <mkdir path="${nameNode}${workingDir}/document_to_project_concepts" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToProjectConceptsActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_project_concepts}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${workingDir}/document_to_project_concepts/${action_set_id_document_referencedProjects}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-researchinitiatives">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_research_initiative" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToConceptIdsActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_research_initiatives}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_research_initiative/${action_set_id_document_research_initiative}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-researchinitiatives">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_research_initiative" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToConceptIdsActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_research_initiatives}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_research_initiative/${action_set_id_document_research_initiative}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-pdb">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_pdb" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToPdbActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_pdb}</value>
-				</property>
-				<property>
-					<name>export.referenceextraction.pdb.url.root</name>
-					<value>${referenceextraction_pdb_url_root}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_pdb/${action_set_id_document_pdb}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-pdb">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_pdb" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToPdbActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_pdb}</value>
+                </property>
+                <property>
+                    <name>export.referenceextraction.pdb.url.root</name>
+                    <value>${referenceextraction_pdb_url_root}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_pdb/${action_set_id_document_pdb}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-to-documentclasses">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_classes" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToDocumentClassesActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_to_document_classes}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_classes/${action_set_id_document_classes}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-to-documentclasses">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_classes" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentToDocumentClassesActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_to_document_classes}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_classes/${action_set_id_document_classes}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-citation">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_referencedDocuments" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.CitationsActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.Citations']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_citations}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_referencedDocuments/${action_set_id_document_referencedDocuments}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-citation">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_referencedDocuments" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.CitationsActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.Citations']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_citations}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_referencedDocuments/${action_set_id_document_referencedDocuments}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<action name="exporter-document-similiarity">
-		<map-reduce>
-			<prepare>
-				<mkdir path="${nameNode}${output}/document_similarities_standard" />
-			</prepare>
-			<configuration>
-				<property>
-					<name>export.action.builder.factory.classname</name>
-					<value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentSimilarityActionBuilderModuleFactory</value>
-				</property>
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity']}</value>
-				</property>
-				<property>
-					<name>mapred.input.dir</name>
-					<value>${input_document_similarity}</value>
-				</property>
-				<property>
-					<name>mapred.output.dir</name>
-					<value>${output}/document_similarities_standard/${action_set_id_document_similarities_standard}</value>
-				</property>
-				<property>
-					<name>export.documentssimilarity.threshold</name>
-					<value>${documentssimilarity_threshold}</value>
-				</property>
-			</configuration>
-		</map-reduce>
-		<ok to="joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-similiarity">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_similarities_standard" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>export.action.builder.factory.classname</name>
+                    <value>eu.dnetlib.iis.workflows.export.actionmanager.module.DocumentSimilarityActionBuilderModuleFactory</value>
+                </property>
+                <property>
+                    <name>avro.schema.input.key</name>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity']}</value>
+                </property>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${input_document_similarity}</value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_similarities_standard/${action_set_id_document_similarities_standard}</value>
+                </property>
+                <property>
+                    <name>export.documentssimilarity.threshold</name>
+                    <value>${documentssimilarity_threshold}</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<join name="joining" to="end" />
+    <action name="skip_exporter-document-to-project">
+        <fs>
+            <delete path="${nameNode}${workingDir}/document_referencedProjects/${action_set_id_document_referencedProjects}" />
+            <mkdir path="${nameNode}${workingDir}/document_referencedProjects/${action_set_id_document_referencedProjects}" />
+        </fs>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
 
-	<kill name="fail">
-		<message>Unfortunately, the process failed -- error message:
-			[${wf:errorMessage(wf:lastErrorNode())}]
-		</message>
-	</kill>
-	<end name="end" />
+    <action name="skip_exporter-document-to-project-concepts">
+        <fs>
+            <delete path="${nameNode}${workingDir}/document_to_project_concepts/${action_set_id_document_referencedProjects}" />
+            <mkdir path="${nameNode}${workingDir}/document_to_project_concepts/${action_set_id_document_referencedProjects}" />
+        </fs>
+        <ok to="joining" />
+        <error to="fail" />
+    </action>
+
+    <join name="joining" to="decision-merge_document-to-project" />
+
+    <decision name="decision-merge_document-to-project">
+        <switch>
+            <case to="end">${input_document_to_project eq "$UNDEFINED$" and input_document_to_project_concepts eq "$UNDEFINED$"}</case>
+            <default to="merge_document-to-project" />
+        </switch>
+    </decision>
+
+    <action name="merge_document-to-project">
+        <map-reduce>
+            <prepare>
+                <mkdir path="${nameNode}${output}/document_referencedProjects" />
+            </prepare>
+            <configuration>
+                <property>
+                    <name>mapred.input.dir</name>
+                    <value>${workingDir}/document_referencedProjects/${action_set_id_document_referencedProjects},${workingDir}/document_to_project_concepts/${action_set_id_document_referencedProjects}
+                    </value>
+                </property>
+                <property>
+                    <name>mapred.output.dir</name>
+                    <value>${output}/document_referencedProjects/${action_set_id_document_referencedProjects}</value>
+                </property>
+                <property>
+                    <name>mapreduce.inputformat.class</name>
+                    <value>org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat</value>
+                </property>
+                <property>
+                    <name>mapred.input.key.class</name>
+                    <value>org.apache.hadoop.io.Text</value>
+                </property>
+                <property>
+                    <name>mapred.input.value.class</name>
+                    <value>org.apache.hadoop.io.Text</value>
+                </property>
+                <property>
+                    <name>mapreduce.map.class</name>
+                    <value>org.apache.hadoop.mapreduce.Mapper</value>
+                </property>
+            </configuration>
+        </map-reduce>
+        <ok to="end" />
+        <error to="fail" />
+    </action>
+
+    <kill name="fail">
+        <message>Unfortunately, the process failed -- error message:
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
+    </kill>
+    <end name="end" />
 
 </workflow-app>


### PR DESCRIPTION
when exporting IIS outcome as sequence files.

Redmine:1522#note-34

To be merged with `master` branch first, then with `cdh5`.

I have fixed indentation what unfortunately makes comparison difficult. Major change is related to introducing `merge_document-to-project` action merging two directories containing sequence files into one.