### PR TITLE
Closes #379: Avoid generating excessive number of sequence files during export

### DIFF
--- a/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-workflows/iis-workflows-export-actionmanager/src/main/resources/eu/dnetlib/iis/workflows/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -187,11 +187,6 @@
                 <name>mapred.output.compression.type</name>
                 <value>BLOCK</value>
             </property>
-
-            <property>
-                <name>mapred.reduce.tasks</name>
-                <value>0</value>
-            </property>
             <property>
                 <name>io.serializations</name>
                 <value>org.apache.hadoop.io.serializer.WritableSerialization,org.apache.hadoop.io.serializer.avro.AvroSpecificSerialization,org.apache.hadoop.io.serializer.avro.AvroReflectSerialization,org.apache.avro.hadoop.io.AvroSerialization</value>


### PR DESCRIPTION
Simply reintroducing reducing phase. 

This way outcome produced by mappers, which was exported up until now, will be merged.