### PR TITLE
Closes #425: Upgrade CDH 5.4.7 to 5.5.2 version compatible with new production cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1121,7 +1121,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring.version>[4.0.0.RELEASE]</spring.version>
 
-        <iis.cdh.version>cdh5.4.7</iis.cdh.version>
+        <iis.cdh.version>cdh5.5.2</iis.cdh.version>
 
         <iis.hbase.version>1.0.0-${iis.cdh.version}</iis.hbase.version>
         <iis.oozie.version>4.1.0-${iis.cdh.version}</iis.oozie.version>
@@ -1129,7 +1129,7 @@
         <iis.hive.version>1.1.0-${iis.cdh.version}</iis.hive.version>
         <iis.avro.version>1.7.6-${iis.cdh.version}</iis.avro.version>
         <iis.hadoop.version>2.6.0-${iis.cdh.version}</iis.hadoop.version>
-        <iis.spark.version>1.3.0-${iis.cdh.version}</iis.spark.version>
+        <iis.spark.version>1.5.0-${iis.cdh.version}</iis.spark.version>
         <iis.coansys.version>1.10-rc3-SNAPSHOT</iis.coansys.version>
         <scala.version>2.10.6</scala.version>
     </properties>


### PR DESCRIPTION
Integration test for the primary workflow passed on the new cluster after this upgrade.
