### PR TITLE
Closes #444: Extend primary integration test with software url reference extraction

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -600,7 +600,7 @@
         <error to="fail" />
     </action>
 
-    <action name="skip-referenceextraction_pdb">
+    <action name="skip-referenceextraction_software_url">
         <java>
             <prepare>
                 <!-- notice: directory have to aligned with skipped action output -->

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/metadataextraction/document_text_classpath.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/metadataextraction/document_text_classpath.json
@@ -1,3 +1,4 @@
 {"id": "id-2", "classpathLocation": "eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-2.txt"}
 {"id": "id-10", "classpathLocation": "eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-10.txt"}
 {"id": "id-20", "classpathLocation": "eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-20.txt"}
+{"id": "id-30", "classpathLocation": "eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-30.txt"}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-30.txt
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/text/id-30.txt
@@ -1,0 +1,11 @@
+This is sample text containing link to madis library: 
+
+https://github.com/madgik/madis 
+
+This should be picked up by reference extraction algorithm.
+
+Madis is heavily used in IIS:
+
+https://github.com/openaire/iis
+
+Information Inference Service.

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -217,6 +217,10 @@
 					<name>active_referenceextraction_researchinitiative</name>
 					<value>true</value>
 				</property>
+                <property>
+                    <name>active_referenceextraction_software_url</name>
+                    <value>true</value>
+                </property>
 				<property>
 					<name>active_referenceextraction_pdb</name>
 					<value>false</value>
@@ -294,6 +298,10 @@
 					<name>output_document_to_research_initiatives</name>
 					<value>${workingDir}/exported/document_to_research_initiatives</value>
 				</property>
+                <property>
+                    <name>output_document_to_software_urls</name>
+                    <value>${workingDir}/exported/document_to_software_urls</value>
+                </property>
 				<property>
 					<name>output_document_to_pdb</name>
 					<value>${workingDir}/exported/document_to_pdb</value>
@@ -350,6 +358,11 @@
 				eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/document_to_research_initiatives.json}
 			</arg>
 			<arg>-Idocument_to_research_initiatives=${workingDir}/exported/document_to_research_initiatives</arg>
+            <arg>-C{document_to_software_urls,
+                eu.dnetlib.iis.export.schemas.DocumentToSoftwareUrls,
+                eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/document_to_software_urls.json}
+            </arg>
+            <arg>-Idocument_to_software_urls=${workingDir}/exported/document_to_software_urls</arg>
 			<arg>-C{citation,
 				eu.dnetlib.iis.export.schemas.Citations,
 				eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/citations.json}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/citations.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/citations.json
@@ -21,7 +21,7 @@
       "position": 9,
       "rawText": "F. Bach. Exploring large feature spaces with hierarchical multiple kernel learning. In Advances in Neural Information Processing Systems (NIPS), 2008.",
       "destinationDocumentId": "id-4",
-      "confidenceLevel": 0.7486356,
+      "confidenceLevel": 0.7619504,
       "externalDestinationDocumentIds": {}
     }
   ]

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/document_to_software_urls.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/document_to_software_urls.json
@@ -1,0 +1,1 @@
+{"documentId": "id-30", "softwareUrls": [{"softwareUrl": "https://github.com/madgik/madis", "repositoryName": "GitHub", "confidenceLevel": 0.8}, {"softwareUrl": "https://github.com/openaire/iis", "repositoryName": "GitHub", "confidenceLevel": 0.8}]}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/matched_organization.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/matched_organization.json
@@ -1,15 +1,15 @@
 {
-    "documentId":"id-2",
-    "organizationId":"20|WIS",
-    "matchStrength":0.06451613
+  "documentId": "id-2",
+  "organizationId": "20|WIS",
+  "matchStrength": 0.06451613
 }
 {
-    "documentId":"id-4",
-    "organizationId":"20|UW",
-    "matchStrength":0.06451613
+  "documentId": "id-4",
+  "organizationId": "20|UCB",
+  "matchStrength": 0.06451613
 }
 {
-    "documentId":"id-4",
-    "organizationId":"20|UCB",
-    "matchStrength":0.9677419
+  "documentId": "id-4",
+  "organizationId": "20|UW",
+  "matchStrength": 0.9677419
 }


### PR DESCRIPTION
I had to also fix other issues unrelated to #444 (see last two commits) so the test could succeed.