### PR TITLE
Closes #522: Affiliation matching is failing due to running beyond physical memory limits

### DIFF
--- a/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/oozie_app/workflow.xml
@@ -55,6 +55,11 @@
             <value>64</value>
             <description>total number of executors</description>
         </property>
+        <property>
+            <name>sparkDriverOverhead</name>
+            <value>513</value>
+            <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
+        </property>
     </parameters>
 
     <global>
@@ -90,7 +95,7 @@
             <class>eu.dnetlib.iis.wf.affmatching.AffMatchingJob</class>
             <jar>${oozieTopWfApplicationPath}/lib/iis-wf-affmatching-${projectVersion}-uber.jar</jar>
             
-            <spark-opts>--executor-memory ${sparkExecutorMemory} --executor-cores ${sparkExecutorCores} --num-executors ${sparkNumExecutors}</spark-opts>
+            <spark-opts>--executor-memory ${sparkExecutorMemory} --executor-cores ${sparkExecutorCores} --num-executors ${sparkNumExecutors} --conf spark.yarn.driver.memoryOverhead=${sparkDriverOverhead}</spark-opts>
 
             <arg>-inputAvroOrgPath=${input_organizations}</arg>
             <arg>-inputAvroAffPath=${input_document_metadata}</arg>


### PR DESCRIPTION
Increase value of `spark.yarn.driver.memoryOverhead` so that more memory
is allocated from YARN for the driver and the workflow finishes.

The direct cause of the failure must be related to non-heap memory use since
Spark ran the driver with -Xmx1024 and it still used more than its 1.5GB
allocated with default overhead value.