### PR TITLE
Closes #551: Eliminate large number of small files

### DIFF
--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
@@ -546,6 +546,10 @@
 					<name>output</name>
 					<value>${workingDir}/transformer_metadataextraction_documenttext/output</value>
 				</property>
+                <property>
+                    <name>combine_splits</name>
+                    <value>335544320</value>
+                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="transformers_common_union_document_text" />

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
@@ -138,9 +138,10 @@
 		</property>
          <property>
             <name>content_split_size</name>
-            <value>536870912</value>
+            <value>0</value>
             <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.</description>
+            Introduced for files compaction limiting excessive files number.
+            Whet set to 0 default value defined for cluster will be picked.</description>
         </property>
 	</parameters>
 

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
@@ -136,6 +136,12 @@
 			<name>output_faults</name>
 			<description>processing faults output directory</description>
 		</property>
+         <property>
+            <name>content_split_size</name>
+            <value>536870912</value>
+            <description>plaintext and extracted metadata large records split size. 
+            Introduced for files compaction limiting excessive files number.</description>
+        </property>
 	</parameters>
 
     <global>
@@ -548,7 +554,7 @@
 				</property>
                 <property>
                     <name>combine_splits</name>
-                    <value>335544320</value>
+                    <value>${content_split_size}</value>
                 </property>
 			</configuration>
 		</sub-workflow>

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
@@ -121,6 +121,12 @@
 			<value>500</value>
 			<description>maximum allowed pdf file size in Megabytes</description>
 		</property>
+        <property>
+            <name>content_split_size</name>
+            <value>536870912</value>
+            <description>plaintext and extracted metadata large records split size. 
+            Introduced for files compaction limiting excessive files number.</description>
+        </property>
 		<property>
 			<name>metadataextraction_default_cache_location</name>
 			<value>/cache/metadataextraction</value>

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
@@ -125,7 +125,8 @@
             <name>content_split_size</name>
             <value>536870912</value>
             <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.</description>
+            Introduced for files compaction limiting excessive files number.
+            Whet set to 0 default value defined for cluster will be picked.</description>
         </property>
 		<property>
 			<name>metadataextraction_default_cache_location</name>

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
@@ -402,6 +402,10 @@
 					<name>output_document_to_dataset</name>
 					<value>${workingDir}/referenceextraction_dataset/document_datasets</value>
 				</property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
+                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="referenceextraction_joining" />
@@ -479,6 +483,10 @@
 					<name>output_document_to_project</name>
 					<value>${workingDir}/referenceextraction_project/document_projects</value>
 				</property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
+                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="transformers_project_toconcept" />

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -206,7 +206,6 @@
             <name>output_report_root_path</name>
             <description>base directory for storing reports</description>
         </property>
-        
 		<property>
 			<name>remove_sideproducts</name>
 			<value>true</value>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -213,6 +213,13 @@
 			<description>flag indicating whole workingDir will be erased.
 				Notice: do not provide any output directory locationpointing to workingDir subdirectory!</description>
 		</property>
+        
+        <property>
+            <name>content_split_size</name>
+            <value>536870912</value>
+            <description>plaintext and extracted metadata large records split size. 
+            Introduced for files compaction limiting excessive files number.</description>
+        </property>
 	</parameters>
 
 	<global>
@@ -826,7 +833,7 @@
 				</property>
                 <property>
                     <name>combine_splits</name>
-                    <value>335544320</value>
+                    <value>${content_split_size}</value>
                 </property>
 			</configuration>
 		</sub-workflow>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -824,6 +824,10 @@
 					<name>schema</name>
 					<value>eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata</value>
 				</property>
+                <property>
+                    <name>combine_splits</name>
+                    <value>335544320</value>
+                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="import_joining" />

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -215,9 +215,10 @@
         
         <property>
             <name>content_split_size</name>
-            <value>536870912</value>
+            <value>0</value>
             <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.</description>
+            Introduced for files compaction limiting excessive files number.
+            Whet set to 0 default value defined for cluster will be picked.</description>
         </property>
 	</parameters>
 

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -168,6 +168,12 @@
             <description>maximum allowed pdf file size in Megabytes</description>
         </property>
         <property>
+            <name>content_split_size</name>
+            <value>536870912</value>
+            <description>plaintext and extracted metadata large records split size. 
+            Introduced for files compaction limiting excessive files number.</description>
+        </property>
+        <property>
             <name>metadataextraction_default_cache_location</name>
             <value>/cache/metadataextraction</value>
             <description>metadata extraction HDFS cache location</description>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -171,7 +171,8 @@
             <name>content_split_size</name>
             <value>536870912</value>
             <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.</description>
+            Introduced for files compaction limiting excessive files number.
+            Whet set to 0 default value defined for cluster will be picked.</description>
         </property>
         <property>
             <name>metadataextraction_default_cache_location</name>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -181,9 +181,10 @@
         </property>
         <property>
             <name>content_split_size</name>
-            <value>536870912</value>
+            <value>0</value>
             <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.</description>
+            Introduced for files compaction limiting excessive files number.
+            Whet set to 0 default value defined for cluster will be picked.</description>
         </property>
     </parameters>
 

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -250,6 +250,10 @@
                     <name>schema</name>
                     <value>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</value>
                 </property>
+                <property>
+                    <name>combine_splits</name>
+                    <value>335544320</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="forking" />

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -215,6 +215,10 @@
                     <name>output</name>
                     <value>${workingDir}/transformer_metadataextraction_documenttext/out</value>
                 </property>
+                <property>
+                    <name>combine_splits</name>
+                    <value>335544320</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="transformers_common_union_document_text" />
@@ -817,6 +821,10 @@
                 <property>
                     <name>output_merged_metadata</name>
                     <value>${workingDir}/transformers_metadatamerger/output_merged_metadata</value>
+                </property>
+                <property>
+                    <name>combine_splits</name>
+                    <value>335544320</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -179,6 +179,12 @@
             <name>output_matched_doc_organizations</name>
             <description>output matched document organizations directory</description>
         </property>
+        <property>
+            <name>content_split_size</name>
+            <value>536870912</value>
+            <description>plaintext and extracted metadata large records split size. 
+            Introduced for files compaction limiting excessive files number.</description>
+        </property>
     </parameters>
 
     <global>
@@ -217,7 +223,7 @@
                 </property>
                 <property>
                     <name>combine_splits</name>
-                    <value>335544320</value>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -252,7 +258,7 @@
                 </property>
                 <property>
                     <name>combine_splits</name>
-                    <value>335544320</value>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -828,7 +834,7 @@
                 </property>
                 <property>
                     <name>combine_splits</name>
-                    <value>335544320</value>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -330,6 +330,10 @@
                     <!-- referenceextraction_project directory is created at subworkflow prepare phase -->
                     <value>${output_document_to_project}</value>
                 </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="transformers_project_toconcept" />
@@ -452,6 +456,10 @@
                     <!-- referenceextraction_dataset directory is created at subworkflow prepare phase -->
                     <value>${output_document_to_dataset}</value>
                 </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="joining" />
@@ -505,6 +513,10 @@
                 <property>
                     <name>output</name>
                     <value>${workingDir}/referenceextraction_pdb/output</value>
+                </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -583,6 +595,10 @@
                 <property>
                     <name>output</name>
                     <value>${workingDir}/referenceextraction_software_url/output</value>
+                </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -665,6 +681,10 @@
                     <name>output_document_to_research_initiative</name>
                     <value>${workingDir}/referenceextraction_researchinitiative/output</value>
                 </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="referenceextraction_researchinitiative_wos" />
@@ -687,6 +707,10 @@
                 <property>
                     <name>output_document_to_research_initiative</name>
                     <value>${workingDir}/referenceextraction_researchinitiative_wos/output</value>
+                </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main/oozie_app/workflow.xml
@@ -16,6 +16,12 @@
 			<name>output_document_to_dataset</name>
 			<description>output document to dataset</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
 	<start to="sqlite_builder" />
@@ -95,6 +101,10 @@
                 <property>
                     <name>output_document_to_dataset</name>
                     <value>${output_document_to_dataset}</value>
+                </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${split_minsize}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main_sqlite/oozie_app/workflow.xml
@@ -16,6 +16,12 @@
 			<name>output_document_to_dataset</name>
 			<description>output document to dataset</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
     <global>
@@ -113,6 +119,10 @@
 					<value>1800000</value>
 				</property>
 				
+                <property>
+                    <name>mapreduce.input.fileinputformat.split.minsize</name>
+                    <value>${split_minsize}</value>
+                </property>
             </configuration>
             <file>${input_dataset_db}#dataset.db</file>
             

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
@@ -12,6 +12,12 @@
 			<name>output</name>
 			<description>output document to pdb concept</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
     <global>
@@ -109,6 +115,10 @@
 					<value>1800000</value>
 				</property>
 				
+                <property>
+                    <name>mapreduce.input.fileinputformat.split.minsize</name>
+                    <value>${split_minsize}</value>
+                </property>
             </configuration>
             
         </map-reduce>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main/oozie_app/workflow.xml
@@ -16,6 +16,12 @@
 			<name>output_document_to_project</name>
 			<description>output document to project</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
 	<start to="sqlite_builder" />
@@ -95,6 +101,10 @@
                 <property>
                     <name>output_document_to_project</name>
                     <value>${output_document_to_project}</value>
+                </property>
+                <property>
+                    <name>split_minsize</name>
+                    <value>${split_minsize}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
@@ -16,6 +16,12 @@
 			<name>output_document_to_project</name>
 			<description>output document to project</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
     <global>
@@ -112,7 +118,11 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-
+                
+                <property>
+                    <name>mapreduce.input.fileinputformat.split.minsize</name>
+                    <value>${split_minsize}</value>
+                </property>
             </configuration>
             <file>${input_project_db}#project.db</file>
             

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main/oozie_app/workflow.xml
@@ -12,6 +12,12 @@
 			<name>output_document_to_research_initiative</name>
 			<description>output document to research initiative</description>
 		</property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
 	</parameters>
 
     <global>
@@ -108,7 +114,11 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-				
+                
+				<property>
+                    <name>mapreduce.input.fileinputformat.split.minsize</name>
+                    <value>${split_minsize}</value>
+                </property>
             </configuration>
             
         </map-reduce>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
@@ -10,6 +10,12 @@
             <name>output</name>
             <description>output document to software links</description>
         </property>
+        <property>
+            <name>split_minsize</name>
+            <!-- zero means relying on default value -->
+            <value>0</value>
+            <description>minimum split size for streaming</description>
+        </property>
     </parameters>
 
     <global>
@@ -99,7 +105,11 @@
                     <name>mapreduce.task.timeout</name>
                     <value>1800000</value>
                 </property>
-
+                
+                <property>
+                    <name>mapreduce.input.fileinputformat.split.minsize</name>
+                    <value>${split_minsize}</value>
+                </property>
             </configuration>
 
         </map-reduce>

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadataextraction/documenttext/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadataextraction/documenttext/oozie_app/workflow.xml
@@ -9,6 +9,12 @@
 			<name>output</name>
 			<description>output containing document text</description>
 		</property>
+        <property>
+            <name>combine_splits</name>
+            <!-- zero will use the Pig default -->
+            <value>0</value>
+            <description>Value for pig.maxCombinedSplitSize Pig property</description>
+        </property>
 	</parameters>
     
     <global>
@@ -46,6 +52,12 @@
 			<prepare>
 				<delete path="${nameNode}${output}" />
 			</prepare>
+            <configuration>
+                <property>
+                    <name>pig.maxCombinedSplitSize</name>
+                    <value>${combine_splits}</value>
+                </property>
+            </configuration>
             <!-- Path to PIG script the workflow executes. -->
             <script>lib/scripts/transformer/transformer.pig</script>
             

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadatamerger/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadatamerger/oozie_app/workflow.xml
@@ -13,6 +13,12 @@
 			<name>output_merged_metadata</name>
 			<description>output directory</description>
 		</property>
+        <property>
+            <name>combine_splits</name>
+            <!-- zero will use the Pig default -->
+            <value>0</value>
+            <description>Value for pig.maxCombinedSplitSize Pig property</description>
+        </property>
 	</parameters>
     
     <global>
@@ -51,6 +57,12 @@
 			<prepare>
 				<delete path="${nameNode}${output_merged_metadata}" />
 			</prepare>
+            <configuration>
+                <property>
+                    <name>pig.maxCombinedSplitSize</name>
+                    <value>${combine_splits}</value>
+                </property>
+            </configuration>
             <!-- Path to PIG script the workflow executes. -->
             <script>lib/scripts/merger/merger.pig</script>
 


### PR DESCRIPTION
After introducing 512MB split size for large datastores (with large records) generated from PDF/PMC contents I managed to limit files count in the following way:

|original|512MB|subworkflow name|
| ------------- |:-------------:| ------:|
|1155|284|primary_import/extracted_document_metadata|
|1155|281|transformer_metadataextraction_documenttext|
|1140|224|transformers_common_union_document_text|
|735|185|transformers_metadatamerger|
|1140|224|referenceextraction_dataset|
|1140|224|referenceextraction_project|
|735|458|documentsclassification|

I have decided to define single shared `content_split_size` placeholder so we could adjust content split size in single place (top level `primary` or `preprocessing` workflow). Properties in streaming and PIG subworkflows are named differently what allows us overriding default `0` value only in the desired context, when large datastores are handled (e.g. we do not alter default split size for union subworkflow when it is dealing with "casual" records not the large ones produced from PDF/PMC contents).