### PR TITLE
Closes #541: Removing redundant reducers in exporter module

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -49,6 +49,9 @@
             <value>1</value>
             <description>Number of reducers to be used when exporting output. Affects number of output files.
                 When set to 0 reducing phase is omitted, input ordering is preserved and number of output files depends on number of mappers.
+                Used only for subset of inputs where large number of small files is provided, namely: 
+                input_document_to_project, input_document_to_dataset, input_document_to_document_classes, input_matched_doc_organizations.
+                For other inputs reducing phase is not executed.
             </description>
         </property>
         <!-- actionset id section -->
@@ -204,9 +207,10 @@
                 <name>mapreduce.reduce.speculative</name>
                 <value>false</value>
             </property>
+            <!-- not reducing by default -->
             <property>
                 <name>mapreduce.job.reduces</name>
-                <value>${reduce_tasks}</value>
+                <value>0</value>
             </property>
             <property>
                 <name>mapreduce.map.output.compress</name>
@@ -451,6 +455,11 @@
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
                     <value>${workingDir}/document_referencedProjects/${action_set_id_document_referencedProjects}</value>
                 </property>
+                <!-- reducing input with large number of small files -->
+                <property>
+                    <name>mapreduce.job.reduces</name>
+                    <value>${reduce_tasks}</value>
+                </property>
             </configuration>
         </map-reduce>
         <ok to="joining" />
@@ -478,6 +487,11 @@
                 <property>
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
                     <value>${output}/document_referencedDatasets/${action_set_id_document_referencedDatasets}</value>
+                </property>
+                <!-- reducing input with large number of small files -->
+                <property>
+                    <name>mapreduce.job.reduces</name>
+                    <value>${reduce_tasks}</value>
                 </property>
             </configuration>
         </map-reduce>
@@ -624,6 +638,11 @@
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
                     <value>${output}/document_classes/${action_set_id_document_classes}</value>
                 </property>
+                <!-- reducing input with large number of small files -->
+                <property>
+                    <name>mapreduce.job.reduces</name>
+                    <value>${reduce_tasks}</value>
+                </property>
             </configuration>
         </map-reduce>
         <ok to="joining" />
@@ -711,6 +730,11 @@
                 <property>
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
                     <value>${output}/matched_doc_organizations/${action_set_id_matched_doc_organizations}</value>
+                </property>
+                <!-- reducing input with large number of small files -->
+                <property>
+                    <name>mapreduce.job.reduces</name>
+                    <value>${reduce_tasks}</value>
                 </property>
             </configuration>
         </map-reduce>

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/import/oozie_app/workflow.xml
@@ -140,13 +140,6 @@
             <name>output_report_root_path</name>
             <description>base directory for storing reports</description>
         </property>
-        <property>
-            <name>content_split_size</name>
-            <value>0</value>
-            <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.
-            Whet set to 0 default value defined for cluster will be picked.</description>
-        </property>
 	</parameters>
 
     <global>
@@ -557,10 +550,6 @@
 					<name>output</name>
 					<value>${workingDir}/transformer_metadataextraction_documenttext/output</value>
 				</property>
-                <property>
-                    <name>combine_splits</name>
-                    <value>${content_split_size}</value>
-                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="transformers_common_union_document_text" />

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/main/oozie_app/workflow.xml
@@ -121,13 +121,6 @@
 			<value>500</value>
 			<description>maximum allowed pdf file size in Megabytes</description>
 		</property>
-        <property>
-            <name>content_split_size</name>
-            <value>536870912</value>
-            <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.
-            Whet set to 0 default value defined for cluster will be picked.</description>
-        </property>
 		<property>
 			<name>metadataextraction_default_cache_location</name>
 			<value>/cache/metadataextraction</value>
@@ -407,10 +400,6 @@
 					<name>output_document_to_dataset</name>
 					<value>${workingDir}/referenceextraction_dataset/document_datasets</value>
 				</property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
-                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="referenceextraction_joining" />
@@ -488,10 +477,6 @@
 					<name>output_document_to_project</name>
 					<value>${workingDir}/referenceextraction_project/document_projects</value>
 				</property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
-                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="transformers_project_toconcept" />

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -212,14 +212,6 @@
 			<description>flag indicating whole workingDir will be erased.
 				Notice: do not provide any output directory locationpointing to workingDir subdirectory!</description>
 		</property>
-        
-        <property>
-            <name>content_split_size</name>
-            <value>0</value>
-            <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.
-            Whet set to 0 default value defined for cluster will be picked.</description>
-        </property>
 	</parameters>
 
 	<global>
@@ -831,10 +823,6 @@
 					<name>schema</name>
 					<value>eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata</value>
 				</property>
-                <property>
-                    <name>combine_splits</name>
-                    <value>${content_split_size}</value>
-                </property>
 			</configuration>
 		</sub-workflow>
 		<ok to="import_joining" />

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -168,13 +168,6 @@
             <description>maximum allowed pdf file size in Megabytes</description>
         </property>
         <property>
-            <name>content_split_size</name>
-            <value>536870912</value>
-            <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.
-            Whet set to 0 default value defined for cluster will be picked.</description>
-        </property>
-        <property>
             <name>metadataextraction_default_cache_location</name>
             <value>/cache/metadataextraction</value>
             <description>metadata extraction HDFS cache location</description>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -183,13 +183,6 @@
             <name>output_report_root_path</name>
             <description>base directory for storing reports</description>
         </property>
-        <property>
-            <name>content_split_size</name>
-            <value>0</value>
-            <description>plaintext and extracted metadata large records split size. 
-            Introduced for files compaction limiting excessive files number.
-            Whet set to 0 default value defined for cluster will be picked.</description>
-        </property>
     </parameters>
 
     <global>
@@ -226,10 +219,6 @@
                     <name>output</name>
                     <value>${workingDir}/transformer_metadataextraction_documenttext/out</value>
                 </property>
-                <property>
-                    <name>combine_splits</name>
-                    <value>${content_split_size}</value>
-                </property>
             </configuration>
         </sub-workflow>
         <ok to="transformers_common_union_document_text" />
@@ -260,10 +249,6 @@
                 <property>
                     <name>schema</name>
                     <value>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</value>
-                </property>
-                <property>
-                    <name>combine_splits</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -334,10 +319,6 @@
                     <name>output_document_to_project</name>
                     <!-- referenceextraction_project directory is created at subworkflow prepare phase -->
                     <value>${output_document_to_project}</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -461,10 +442,6 @@
                     <!-- referenceextraction_dataset directory is created at subworkflow prepare phase -->
                     <value>${output_document_to_dataset}</value>
                 </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
-                </property>
             </configuration>
         </sub-workflow>
         <ok to="joining" />
@@ -518,10 +495,6 @@
                 <property>
                     <name>output</name>
                     <value>${workingDir}/referenceextraction_pdb/output</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -600,10 +573,6 @@
                 <property>
                     <name>output</name>
                     <value>${workingDir}/referenceextraction_software_url/output</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -686,10 +655,6 @@
                     <name>output_document_to_research_initiative</name>
                     <value>${workingDir}/referenceextraction_researchinitiative/output</value>
                 </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
-                </property>
             </configuration>
         </sub-workflow>
         <ok to="referenceextraction_researchinitiative_wos" />
@@ -712,10 +677,6 @@
                 <property>
                     <name>output_document_to_research_initiative</name>
                     <value>${workingDir}/referenceextraction_researchinitiative_wos/output</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>
@@ -860,10 +821,6 @@
                 <property>
                     <name>output_merged_metadata</name>
                     <value>${workingDir}/transformers_metadatamerger/output_merged_metadata</value>
-                </property>
-                <property>
-                    <name>combine_splits</name>
-                    <value>${content_split_size}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main/oozie_app/workflow.xml
@@ -16,12 +16,6 @@
 			<name>output_document_to_dataset</name>
 			<description>output document to dataset</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
 	<start to="sqlite_builder" />
@@ -101,10 +95,6 @@
                 <property>
                     <name>output_document_to_dataset</name>
                     <value>${output_document_to_dataset}</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${split_minsize}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/main_sqlite/oozie_app/workflow.xml
@@ -16,12 +16,6 @@
 			<name>output_document_to_dataset</name>
 			<description>output document to dataset</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
     <global>
@@ -118,11 +112,6 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-				
-                <property>
-                    <name>mapreduce.input.fileinputformat.split.minsize</name>
-                    <value>${split_minsize}</value>
-                </property>
             </configuration>
             <file>${input_dataset_db}#dataset.db</file>
             

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
@@ -12,12 +12,6 @@
 			<name>output</name>
 			<description>output document to pdb concept</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
     <global>
@@ -114,11 +108,6 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-				
-                <property>
-                    <name>mapreduce.input.fileinputformat.split.minsize</name>
-                    <value>${split_minsize}</value>
-                </property>
             </configuration>
             
         </map-reduce>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main/oozie_app/workflow.xml
@@ -16,12 +16,6 @@
 			<name>output_document_to_project</name>
 			<description>output document to project</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
 	<start to="sqlite_builder" />
@@ -101,10 +95,6 @@
                 <property>
                     <name>output_document_to_project</name>
                     <value>${output_document_to_project}</value>
-                </property>
-                <property>
-                    <name>split_minsize</name>
-                    <value>${split_minsize}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
@@ -16,12 +16,6 @@
 			<name>output_document_to_project</name>
 			<description>output document to project</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
     <global>
@@ -118,11 +112,6 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-                
-                <property>
-                    <name>mapreduce.input.fileinputformat.split.minsize</name>
-                    <value>${split_minsize}</value>
-                </property>
             </configuration>
             <file>${input_project_db}#project.db</file>
             

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main/oozie_app/workflow.xml
@@ -12,12 +12,6 @@
 			<name>output_document_to_research_initiative</name>
 			<description>output document to research initiative</description>
 		</property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
 	</parameters>
 
     <global>
@@ -114,11 +108,6 @@
 					<name>mapreduce.task.timeout</name>
 					<value>1800000</value>
 				</property>
-                
-				<property>
-                    <name>mapreduce.input.fileinputformat.split.minsize</name>
-                    <value>${split_minsize}</value>
-                </property>
             </configuration>
             
         </map-reduce>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
@@ -10,12 +10,6 @@
             <name>output</name>
             <description>output document to software links</description>
         </property>
-        <property>
-            <name>split_minsize</name>
-            <!-- zero means relying on default value -->
-            <value>0</value>
-            <description>minimum split size for streaming</description>
-        </property>
     </parameters>
 
     <global>
@@ -104,11 +98,6 @@
                 <property>
                     <name>mapreduce.task.timeout</name>
                     <value>1800000</value>
-                </property>
-                
-                <property>
-                    <name>mapreduce.input.fileinputformat.split.minsize</name>
-                    <value>${split_minsize}</value>
                 </property>
             </configuration>
 

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadataextraction/documenttext/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadataextraction/documenttext/oozie_app/workflow.xml
@@ -9,12 +9,6 @@
 			<name>output</name>
 			<description>output containing document text</description>
 		</property>
-        <property>
-            <name>combine_splits</name>
-            <!-- zero will use the Pig default -->
-            <value>0</value>
-            <description>Value for pig.maxCombinedSplitSize Pig property</description>
-        </property>
 	</parameters>
     
     <global>
@@ -52,12 +46,6 @@
 			<prepare>
 				<delete path="${nameNode}${output}" />
 			</prepare>
-            <configuration>
-                <property>
-                    <name>pig.maxCombinedSplitSize</name>
-                    <value>${combine_splits}</value>
-                </property>
-            </configuration>
             <!-- Path to PIG script the workflow executes. -->
             <script>lib/scripts/transformer/transformer.pig</script>
             

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadatamerger/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/metadatamerger/oozie_app/workflow.xml
@@ -13,12 +13,6 @@
 			<name>output_merged_metadata</name>
 			<description>output directory</description>
 		</property>
-        <property>
-            <name>combine_splits</name>
-            <!-- zero will use the Pig default -->
-            <value>0</value>
-            <description>Value for pig.maxCombinedSplitSize Pig property</description>
-        </property>
 	</parameters>
     
     <global>
@@ -57,12 +51,6 @@
 			<prepare>
 				<delete path="${nameNode}${output_merged_metadata}" />
 			</prepare>
-            <configuration>
-                <property>
-                    <name>pig.maxCombinedSplitSize</name>
-                    <value>${combine_splits}</value>
-                </property>
-            </configuration>
             <!-- Path to PIG script the workflow executes. -->
             <script>lib/scripts/merger/merger.pig</script>
 


### PR DESCRIPTION
Key change is in:

`...main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml`

file. The rest reverts #551 change due to referenceextraction performance decrease.