### PR TITLE
Closes #613: Make PMC metadata ingestion always enabled in primary workflow

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -7,11 +7,6 @@
 			<description>flag indicating dataset import should be enabled</description>
 		</property>
 		<property>
-			<name>active_ingest_pmc</name>
-			<value>false</value>
-			<description>flag indicating pmc metadata and citations ingestions should be performed</description>
-		</property>
-		<property>
 			<name>active_import_concept</name>
 			<value>false</value>
 			<description>flag indicating concept import should be executed</description>
@@ -660,7 +655,7 @@
 				</property>
 				<property>
 					<name>ingest_metadata</name>
-					<value>${active_ingest_pmc eq "true"}</value>
+					<value>true</value>
 				</property>
 			</configuration>
 		</sub-workflow>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -16,11 +16,6 @@
         </property>
         <!-- processing modes -->
         <property>
-            <name>active_metadataextraction_export</name>
-            <value>false</value>
-            <description>flag indicating metadata extraction export should be enabled</description>
-        </property>
-        <property>
             <name>active_referenceextraction_project</name>
             <value>false</value>
             <description>flag indicating project reference extraction should be enabled</description>
@@ -356,11 +351,6 @@
                 <property>
                     <name>active_import_concept</name>
                     <value>${active_referenceextraction_project}</value>
-                </property>
-                <property>
-                    <name>active_ingest_pmc</name>
-                    <!-- enabling when either citation matching is enabled or metadata export which may include pmc affiliations -->
-                    <value>${active_citationmatching eq "true" or active_metadataextraction_export eq "true"}</value>
                 </property>
                 <!-- import metadata related -->
                 <property>


### PR DESCRIPTION
Also removing support for `active_metadataextraction_export` obsolete flag