### PR TITLE
Closes #625: Execution report for exported webcrawl

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/oozie_app/workflow.xml
@@ -1,0 +1,90 @@
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="export_actionmanager_entity_document">
+    
+    <parameters>
+        <property>
+            <name>input</name>
+            <description>Input containing eu.dnetlib.iis.export.auxiliary.schemas.Identifier avro records listing document identifiers</description>
+        </property>
+        <property>
+            <name>mdstore_service_location</name>
+            <description>MDStore service holding XML metadata records to be exported as actions</description>
+        </property>
+        <property>
+            <name>mdstore_id</name>
+            <description>MDStore holding publications to be exported</description>
+        </property>
+        <property>
+            <name>action_set_id_entity_document</name>
+            <description>Identifier of action set holding document entities.
+            It also defines ${output_root} subdirectory name where all document related actions are exported.</description>
+        </property>
+        <property>
+            <name>output_root</name>
+            <description>root directory for storing ${action_set_id_entity_document} subdirectory with exported documents</description>
+        </property>
+        <property>
+            <name>output_report_root_path</name>
+            <description>base directory for storing reports</description>
+        </property>
+        <property>
+            <name>output_report_relative_path</name>
+            <value>export_document_entities</value>
+            <description>directory for storing report (relative to output_report_root_path)</description>
+        </property>
+    </parameters>
+    
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapreduce.job.queuename</name>
+                <value>${queueName}</value>
+            </property>
+            <property>
+                <name>oozie.launcher.mapred.job.queue.name</name>
+                <value>${oozieLauncherQueueName}</value>
+            </property>
+        </configuration>
+    </global>
+
+    <start to="exporter-document-entities" />
+
+    <action name="exporter-document-entities">
+        <java>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.wf.export.actionmanager.entity.DocumentExporterProcess</arg>
+            <arg>-Iinput=${input}</arg>
+            <arg>-Pmdstore.facade.factory.classname=eu.dnetlib.iis.wf.export.actionmanager.entity.facade.WebServiceMDStoreFacadeFactory</arg>
+            <arg>-Pexport.entity.mdstore.service.location=${mdstore_service_location}</arg>
+            <arg>-Pexport.entity.mdstore.id=${mdstore_id}</arg>
+            <arg>-Pexport.action.setid=${action_set_id_entity_document}</arg>
+            <arg>-Pexport.seq.file.output.dir.root=${output_root}</arg>
+            <arg>-Pexport.seq.file.output.dir.name=${action_set_id_entity_document}</arg>
+            <capture-output />
+        </java>
+        <ok to="report" />
+        <error to="fail" />
+    </action>
+    
+    <action name="report">
+        <java>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.common.report.ReportGenerator</arg>
+            <arg>-Preport.export.entity.document.total=${wf:actionData('exporter-document-entities')['TOTAL_ENTITIES_COUNTER']}</arg>
+            <arg>-Preport.export.entity.document.missing=${wf:actionData('exporter-document-entities')['MISSING_ENTITIES_COUNTER']}</arg>
+            <arg>-Oreport=${output_report_root_path}/${output_report_relative_path}</arg>
+        </java>
+        <ok to="end" />
+        <error to="fail" />
+    </action>
+
+    <kill name="fail">
+        <message>Unfortunately, the process failed -- error message:
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
+    </kill>
+    
+    <end name="end" />
+    
+</workflow-app>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/input/document_identifier.json
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/input/document_identifier.json
@@ -1,1 +1,2 @@
 {"id":"docId1"}
+{"id":"notExistingDocId"}

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/oozie_app/workflow.xml
@@ -52,12 +52,25 @@
             <arg>-Pexport.action.setid=document-entity-id</arg>
             <arg>-Pexport.seq.file.output.dir.root=${workingDir}/output/</arg>
             <arg>-Pexport.seq.file.output.dir.name=documents</arg>
+            <capture-output />
         </java>
-        <ok to="consumer" />
+        <ok to="report" />
         <error to="fail" />
     </action>
 
-    <action name="consumer">
+    <action name="report">
+        <java>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.common.report.ReportGenerator</arg>
+            <arg>-Preport.export.entity.document.total=${wf:actionData('exporter-document-entities')['TOTAL_ENTITIES_COUNTER']}</arg>
+            <arg>-Preport.export.entity.document.missing=${wf:actionData('exporter-document-entities')['MISSING_ENTITIES_COUNTER']}</arg>
+            <arg>-Oreport=${workingDir}/report</arg>
+        </java>
+        <ok to="document-consumer" />
+        <error to="fail" />
+    </action>
+
+    <action name="document-consumer">
         <java>
             <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
             <arg>eu.dnetlib.iis.wf.export.actionmanager.sequencefile.TestingConsumer</arg>
@@ -71,10 +84,22 @@
                 /eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/output/document_hasAuthor_person1.expectations
             </arg>
         </java>
-        <ok to="end" />
+        <ok to="report-consumer" />
         <error to="fail" />
     </action>
 
+    <action name="report-consumer">
+        <java>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
+            <arg>-C{report,
+                eu.dnetlib.iis.common.schemas.ReportEntry,
+                eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/output/report.json}</arg>
+            <arg>-Ireport=${workingDir}/report</arg>
+        </java>
+        <ok to="end" />
+        <error to="fail" />
+    </action>
 
     <kill name="fail">
         <message>Unfortunately, the process failed -- error message:

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/output/report.json
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/document/default/output/report.json
@@ -1,0 +1,2 @@
+{"key":"export.entity.document.total", "type":"COUNTER", "value": "1"}
+{"key":"export.entity.document.missing", "type":"COUNTER", "value": "1"}

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/export/oozie_app/import.txt
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/export/oozie_app/import.txt
@@ -1,5 +1,6 @@
 ## This is a classpath-based import file (this header is required)
 export_actionmanager_sequencefile classpath eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app
 export_actionmanager_entity_dataset classpath eu/dnetlib/iis/wf/export/actionmanager/entity/dataset/oozie_app
+export_actionmanager_entity_document classpath eu/dnetlib/iis/wf/export/actionmanager/entity/document/oozie_app
 transformers_export_identifier_document_to_dataset classpath eu/dnetlib/iis/wf/transformers/export/identifier/documenttodataset/oozie_app
 transformers_export_identifier_document_to_project classpath eu/dnetlib/iis/wf/transformers/export/identifier/documenttoproject/oozie_app

--- a/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/export/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-preprocessing/src/main/resources/eu/dnetlib/iis/wf/preprocessing/export/oozie_app/workflow.xml
@@ -191,21 +191,33 @@
 		<error to="fail" />
 	</action>
 
-	<action name="exporter-document-entities">
-		<java>
-			<main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
-			<arg>eu.dnetlib.iis.wf.export.actionmanager.entity.DocumentExporterProcess</arg>
-			<arg>-Iinput=${workingDir}/identifier/documents</arg>
-            <arg>-Pmdstore.facade.factory.classname=eu.dnetlib.iis.wf.export.actionmanager.entity.facade.WebServiceMDStoreFacadeFactory</arg>
-			<arg>-Pexport.entity.mdstore.service.location=${mdstore_service_location}</arg>
-			<arg>-Pexport.entity.mdstore.id=${wos_mdstore_id}</arg>
-			<arg>-Pexport.action.setid=${action_set_id_entity_wos}</arg>
-			<arg>-Pexport.seq.file.output.dir.root=${workingDir}/output/entities_document</arg>
-			<arg>-Pexport.seq.file.output.dir.name=${action_set_id_entity_wos}</arg>
-		</java>
-		<ok to="export_entities_joining" />
-		<error to="fail" />
-	</action>
+    <action name="exporter-document-entities">
+        <sub-workflow>
+            <app-path>${wf:appPath()}/export_actionmanager_entity_document</app-path>
+            <propagate-configuration />
+            <configuration>
+                <property>
+                    <name>input</name>
+                    <value>${workingDir}/identifier/documents</value>
+                </property>
+                <property>
+                    <name>mdstore_id</name>
+                    <value>${wos_mdstore_id}</value>
+                </property>
+                <property>
+                    <name>action_set_id_entity_document</name>
+                    <value>${action_set_id_entity_wos}</value>
+                </property>
+                <property>
+                    <name>output_root</name>
+                    <value>${workingDir}/output/entities_document</value>
+                </property>
+                <!-- all the other required properties are automatically propagated -->
+            </configuration>
+        </sub-workflow>
+        <ok to="export_entities_joining" />
+        <error to="fail" />
+    </action>
 	<!-- end of publication entities export section -->
 
 	<join name="export_entities_joining" to="distcp_output" />


### PR DESCRIPTION
- introducing document entity exporter subworkflow replacing direct java action definition in preprocessing and primary workflows
- enabling workflows to support document entity exporter counters
- verifying counters in integration test