### PR TITLE
Przemyslawjacewicz 973 integrate patents reference extraction author removal mapping fixes

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -9,6 +9,7 @@ import eu.dnetlib.data.mapreduce.util.OafDecoder;
 import eu.dnetlib.data.proto.*;
 import eu.dnetlib.data.transform.xml.AbstractDNetXsltFunctions;
 import eu.dnetlib.iis.common.InfoSpaceConstants;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import eu.dnetlib.iis.common.java.stream.ListUtils;
 import eu.dnetlib.iis.common.java.stream.StreamUtils;
 import eu.dnetlib.iis.common.utils.DateTimeUtils;
@@ -20,6 +21,7 @@ import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
 import eu.dnetlib.iis.wf.export.actionmanager.entity.ConfidenceLevelUtils;
 import eu.dnetlib.iis.wf.export.actionmanager.module.AlgorithmName;
 import eu.dnetlib.iis.wf.export.actionmanager.module.BuilderModuleHelper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
@@ -87,6 +89,10 @@ public class PatentExporterJob {
         sparkConf.set("spark.kryo.registrator", "pl.edu.icm.sparkutils.avro.AvroCompatibleKryoRegistrator");
 
         try (JavaSparkContext sc = new JavaSparkContext(sparkConf)) {
+            HdfsUtils.remove(sc.hadoopConfiguration(), params.outputRelationPath);
+            HdfsUtils.remove(sc.hadoopConfiguration(), params.outputEntityPath);
+            HdfsUtils.remove(sc.hadoopConfiguration(), params.outputReportPath);
+
             Float trustLevelThreshold = ConfidenceLevelUtils.evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
 
             JavaRDD<DocumentToPatent> documentToPatents = avroLoader
@@ -388,34 +394,46 @@ public class PatentExporterJob {
     private static ResultProtos.Result.Metadata buildOafEntityResultMetadata(Patent patent) {
         ResultProtos.Result.Metadata.Builder builder = ResultProtos.Result.Metadata.newBuilder();
 
-        if (Objects.nonNull(patent.getApplnTitle())) {
-            builder.addTitle(buildOafEntityResultMetadataTitle(patent));
+        if (StringUtils.isNotBlank(patent.getApplnTitle())) {
+            builder.addTitle(buildOafEntityResultMetadataTitle(patent.getApplnTitle()));
         }
 
-        if (Objects.nonNull(patent.getApplnAbstract())) {
-            builder.addDescription(buildOafEntityResultMetadataDescription(patent));
+        if (StringUtils.isNotBlank(patent.getApplnAbstract())) {
+            builder.addDescription(buildOafEntityResultMetadataDescription(patent.getApplnAbstract()));
+        }
+
+        if (StringUtils.isNotBlank(patent.getEarliestPublnDate())) {
+            builder.setDateofacceptance(buildOafEntityResultMetadataDateofacceptance(patent.getEarliestPublnDate()));
+        }
+
+        if (StringUtils.isNotBlank(patent.getApplnFilingDate())) {
+            builder.addRelevantdate(buildOafEntityResultMetadataRelevantdate(patent.getApplnFilingDate()));
+        }
+
+        if (Objects.nonNull(patent.getIpcClassSymbol())) {
+            builder.addAllSubject(buildOafEntityResultMetadataSubjects(patent.getIpcClassSymbol()));
+        }
+
+        if (Objects.nonNull(patent.getHolderCountry())) {
+            builder.addAllAuthor(buildOafEntityResultMetadataAuthors(patent.getHolderCountry()));
+            builder.addAllCountry(buildOafEntityResultMetadataCountries(patent.getHolderCountry()));
         }
 
         return builder
-                .addAllSubject(buildOafEntityResultMetadataSubjects(patent))
-                .setDateofacceptance(buildOafEntityResultMetadataDateofacceptance(patent))
-                .addRelevantdate(buildOafEntityResultMetadataRelevantdate(patent))
-                .addAllAuthor(buildOafEntityResultMetadataAuthors(patent))
-                .addAllCountry(buildOafEntityResultMetadataCountries(patent))
                 .setResulttype(OAF_ENTITY_RESULT_METADATA_RESULTTYPE)
                 .build();
     }
 
-    private static FieldTypeProtos.StructuredProperty buildOafEntityResultMetadataTitle(Patent patent) {
+    private static FieldTypeProtos.StructuredProperty buildOafEntityResultMetadataTitle(CharSequence applnTitle) {
         return FieldTypeProtos.StructuredProperty.newBuilder()
-                .setValue(patent.getApplnTitle().toString())
+                .setValue(applnTitle.toString())
                 .setQualifier(OAF_ENTITY_RESULT_METADATA_TITLE_QUALIFIER)
                 .build();
     }
 
-    private static FieldTypeProtos.StringField buildOafEntityResultMetadataDescription(Patent patent) {
+    private static FieldTypeProtos.StringField buildOafEntityResultMetadataDescription(CharSequence applnAbstract) {
         return FieldTypeProtos.StringField.newBuilder()
-                .setValue(patent.getApplnAbstract().toString())
+                .setValue(applnAbstract.toString())
                 .build();
     }
 
@@ -427,8 +445,9 @@ public class PatentExporterJob {
         return appendMd5(PATENT_RESULT_OPENAIRE_ID_PREFIX, applnAuth.toString() + applnNr.toString());
     }
 
-    private static List<FieldTypeProtos.StructuredProperty> buildOafEntityResultMetadataSubjects(Patent patent) {
-        return patent.getIpcClassSymbol().stream()
+    private static List<FieldTypeProtos.StructuredProperty> buildOafEntityResultMetadataSubjects(List<CharSequence> ipcClassSymbols) {
+        return ipcClassSymbols.stream()
+                .filter(StringUtils::isNotBlank)
                 .map(PatentExporterJob::buildOafEntityResultMetadataSubject)
                 .collect(Collectors.toList());
     }
@@ -440,39 +459,44 @@ public class PatentExporterJob {
                 .build();
     }
 
-    private static FieldTypeProtos.StringField buildOafEntityResultMetadataDateofacceptance(Patent patent) {
+    private static FieldTypeProtos.StringField buildOafEntityResultMetadataDateofacceptance(CharSequence earliestPublnDate) {
         return FieldTypeProtos.StringField.newBuilder()
-                .setValue(patent.getEarliestPublnDate().toString())
+                .setValue(earliestPublnDate.toString())
                 .build();
     }
 
-    private static FieldTypeProtos.StructuredProperty buildOafEntityResultMetadataRelevantdate(Patent patent) {
+    private static FieldTypeProtos.StructuredProperty buildOafEntityResultMetadataRelevantdate(CharSequence applnFilingDate) {
         return FieldTypeProtos.StructuredProperty.newBuilder()
-                .setValue(patent.getApplnFilingDate().toString())
+                .setValue(applnFilingDate.toString())
                 .setQualifier(OAF_ENTITY_RESULT_METADATA_RELEVANTDATE_QUALIFIER)
                 .build();
     }
 
-    private static List<FieldTypeProtos.Author> buildOafEntityResultMetadataAuthors(Patent patent) {
-        return ListUtils.zipWithIndex(patent.getHolderCountry()).stream()
+    private static List<FieldTypeProtos.Author> buildOafEntityResultMetadataAuthors(List<HolderCountry> holderCountries) {
+        List<CharSequence> personNames = holderCountries.stream()
+                .map(HolderCountry::getPersonName)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toList());
+        return ListUtils.zipWithIndex(personNames).stream()
                 .map(pair -> {
                     Integer rank = pair.getLeft() + 1;
-                    HolderCountry holderCountry = pair.getRight();
-                    return buildOafEntityResultMetadataAuthor(holderCountry, rank);
+                    CharSequence personName = pair.getRight();
+                    return buildOafEntityResultMetadataAuthor(personName, rank);
                 })
                 .collect(Collectors.toList());
     }
 
-    private static FieldTypeProtos.Author buildOafEntityResultMetadataAuthor(HolderCountry holderCountry, Integer rank) {
+    private static FieldTypeProtos.Author buildOafEntityResultMetadataAuthor(CharSequence personName, Integer rank) {
         return FieldTypeProtos.Author.newBuilder()
-                .setFullname(holderCountry.getPersonName().toString())
+                .setFullname(personName.toString())
                 .setRank(rank)
                 .build();
     }
 
-    private static List<FieldTypeProtos.Qualifier> buildOafEntityResultMetadataCountries(Patent patent) {
-        return patent.getHolderCountry().stream()
-                .map(z -> z.getPersonCtryCode().toString())
+    private static List<FieldTypeProtos.Qualifier> buildOafEntityResultMetadataCountries(List<HolderCountry> holderCountries) {
+        return holderCountries.stream()
+                .map(HolderCountry::getPersonCtryCode)
+                .filter(StringUtils::isNotBlank)
                 .distinct()
                 .sorted()
                 .map(PatentExporterJob::buildOafEntityResultMetadataCountry)

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -49,12 +49,15 @@ import java.util.stream.Collectors;
  */
 public class PatentExporterJob {
     private static final String EPO = "EPO";
+    private static final String EUROPEAN_PATENT_OFFICE__PATSTAT = "European Patent Office/PATSTAT";
     private static final String CLASS_EPO_ID = "epo_id";
     private static final String CLASS_EPO_NR_EPODOC = "epo_nr_epodoc";
     private static final String IPC = "IPC";
+    private static final String INTERNATIONAL_PATENT_CLASSIFICATION = "International Patent Classification";
+    private static final String PATENT_ENTITY_ID_PREFIX = "epopatstat__";
     private static final String INFERENCE_PROVENANCE = buildInferenceProvenance();
     private static final String PATENT_DATASOURCE_OPENAIRE_ID_PREFIX = InfoSpaceConstants.ROW_PREFIX_DATASOURCE + InfoSpaceConstants.OPENAIRE_ENTITY_ID_PREFIX + InfoSpaceConstants.ID_NAMESPACE_SEPARATOR;
-    private static final String PATENT_RESULT_OPENAIRE_ID_PREFIX = InfoSpaceConstants.ROW_PREFIX_RESULT + InfoSpaceConstants.OPENAIRE_ENTITY_ID_PREFIX + InfoSpaceConstants.ID_NAMESPACE_SEPARATOR;
+    private static final String PATENT_RESULT_OPENAIRE_ID_PREFIX = InfoSpaceConstants.ROW_PREFIX_RESULT + PATENT_ENTITY_ID_PREFIX + InfoSpaceConstants.ID_NAMESPACE_SEPARATOR;
     private static final String PATENT_ID_PREFIX_EPO = buildRowPrefixDatasourceOpenaireEntityIdPrefixEpo();
     private static final ResultResultProtos.ResultResult OAFREL_RESULTRESULT = buildOafRelResultResult();
     private static final FieldTypeProtos.KeyValue OAF_ENTITY_COLLECTEDFROM = buildOafEntityPatentKeyValue();
@@ -190,7 +193,7 @@ public class PatentExporterJob {
     private static FieldTypeProtos.KeyValue buildOafEntityPatentKeyValue() {
         return FieldTypeProtos.KeyValue.newBuilder()
                 .setKey(PATENT_ID_PREFIX_EPO)
-                .setValue(EPO)
+                .setValue(EUROPEAN_PATENT_OFFICE__PATSTAT)
                 .build();
     }
 
@@ -224,7 +227,7 @@ public class PatentExporterJob {
     private static FieldTypeProtos.Qualifier buildOafEntityResultMetadataSubjectQualifier() {
         return FieldTypeProtos.Qualifier.newBuilder()
                 .setClassid(IPC)
-                .setClassname(IPC)
+                .setClassname(INTERNATIONAL_PATENT_CLASSIFICATION)
                 .setSchemeid(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_CLASSIFICATION_TAXONOMIES)
                 .setSchemename(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_CLASSIFICATION_TAXONOMIES)
                 .build();

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
@@ -127,12 +127,12 @@ public class PatentExporterJobTest {
                 RelTypeProtos.SubRelType.relationship.name(), ResultResultProtos.ResultResult.Relationship.RelName.isRelatedTo.name());
         actualRelationActions.forEach(action -> verifyAction(action, RELATION_ACTION_SET_ID, expectedRelationTargetColumnFamily));
         List<Pair<String, String>> expectedRelationsTargetRowKeyAndTargetColumnPairs = Arrays.asList(
-                Pair.of("document1", "50|openaire____::9fce164deeabdfd83f697e45b1aeea3d"),
-                Pair.of("50|openaire____::9fce164deeabdfd83f697e45b1aeea3d", "document1"),
-                Pair.of("document2", "50|openaire____::9fce164deeabdfd83f697e45b1aeea3d"),
-                Pair.of("50|openaire____::9fce164deeabdfd83f697e45b1aeea3d", "document2"),
-                Pair.of("document2", "50|openaire____::702195de7e0ff019d206b3eef73f0f21"),
-                Pair.of("50|openaire____::702195de7e0ff019d206b3eef73f0f21", "document2"));
+                Pair.of("document1", "50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d"),
+                Pair.of("50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d", "document1"),
+                Pair.of("document2", "50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d"),
+                Pair.of("50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d", "document2"),
+                Pair.of("document2", "50|epopatstat__::702195de7e0ff019d206b3eef73f0f21"),
+                Pair.of("50|epopatstat__::702195de7e0ff019d206b3eef73f0f21", "document2"));
         List<Pair<String, String>> actualRelationsTargetRowKeyAndTargetColumnPairs = actualRelationActions.stream()
                 .map(x -> Pair.of(x.getTargetRowKey(), x.getTargetColumn()))
                 .sorted()
@@ -152,8 +152,8 @@ public class PatentExporterJobTest {
 
         String expectedEntityTargetColumn = new String(InfoSpaceConstants.QUALIFIER_BODY, StandardCharsets.UTF_8);
         List<Pair<String, String>> expectedEntityTargetRowKeyAndTargetColumnPairs = Arrays.asList(
-                Pair.of("50|openaire____::9fce164deeabdfd83f697e45b1aeea3d", expectedEntityTargetColumn),
-                Pair.of("50|openaire____::702195de7e0ff019d206b3eef73f0f21", expectedEntityTargetColumn));
+                Pair.of("50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d", expectedEntityTargetColumn),
+                Pair.of("50|epopatstat__::702195de7e0ff019d206b3eef73f0f21", expectedEntityTargetColumn));
         List<Pair<String, String>> actualEntityTargetRowKeyAndTargetColumnPairs = actualEntityActions.stream()
                 .map(x -> Pair.of(x.getTargetRowKey(), x.getTargetColumn()))
                 .sorted()

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/document_to_patent.json
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/document_to_patent.json
@@ -1,5 +1,5 @@
-{"documentId":"document1","patentId":"patent1","confidenceLevel":0.9,"textsnippet":"text snippet for relation document1 and patent1"}
-{"documentId":"document2","patentId":"patent1","confidenceLevel":0.8,"textsnippet":"text snippet for relation document2 and patent1"}
-{"documentId":"document2","patentId":"patent2","confidenceLevel":0.7,"textsnippet":"text snippet for relation document2 and patent2"}
-{"documentId":"document2","patentId":"patent2","confidenceLevel":0.6,"textsnippet":"text snippet for relation document2 and patent2"}
-{"documentId":"document3","patentId":"patent3","confidenceLevel":0.1,"textsnippet":"text snippet for relation document3 and patent3"}
+{"documentId":"document1","patentId":"patent1","confidenceLevel":0.9,"textsnippet":null}
+{"documentId":"document2","patentId":"patent1","confidenceLevel":0.8,"textsnippet":null}
+{"documentId":"document2","patentId":"patent2","confidenceLevel":0.7,"textsnippet":null}
+{"documentId":"document2","patentId":"patent2","confidenceLevel":0.6,"textsnippet":null}
+{"documentId":"document3","patentId":"patent3","confidenceLevel":0.1,"textsnippet":null}

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/nullcheck/document_to_patent.json
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/nullcheck/document_to_patent.json
@@ -1,0 +1,2 @@
+{"documentId":"document1","patentId":"patent1","confidenceLevel":0.9,"textsnippet":null}
+{"documentId":"document2","patentId":"patent2","confidenceLevel":0.9,"textsnippet":null}

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/nullcheck/patent.json
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/input/nullcheck/patent.json
@@ -1,0 +1,2 @@
+{"appln_id":"patent1","appln_auth":"EP","appln_nr":"patent1","appln_filing_date":null,"appln_nr_epodoc":"EP20000103094","earliest_publn_date":null,"appln_abstract":null,"appln_title":null,"ipc_class_symbol":null,"holder_country":null}
+{"appln_id":"patent2","appln_auth":"EP","appln_nr":"patent2","appln_filing_date":null,"appln_nr_epodoc":"EP20000103094","earliest_publn_date":null,"appln_abstract":null,"appln_title":null,"ipc_class_symbol":null,"holder_country":[{"person_name":null,"person_ctry_code":null}]}

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
@@ -1,4 +1,4 @@
-targetColumn=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+targetColumn=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 targetColumnFamily=resultResult_relationship_isRelatedTo
 targetRowKey=document1
 rawSet=patent-actionset-id
@@ -12,7 +12,7 @@ $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
 $targetValue.rel.source=document1
-$targetValue.rel.target=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+$targetValue.rel.target=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 $targetValue.rel.child=false
 
 $targetValue.rel.resultResult.relationship.relMetadata.semantics.classid=isRelatedTo

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
@@ -1,4 +1,4 @@
-targetColumn=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+targetColumn=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 targetColumnFamily=resultResult_relationship_isRelatedTo
 targetRowKey=document2
 rawSet=patent-actionset-id
@@ -12,7 +12,7 @@ $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
 $targetValue.rel.source=document2
-$targetValue.rel.target=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+$targetValue.rel.target=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 $targetValue.rel.child=false
 
 $targetValue.rel.resultResult.relationship.relMetadata.semantics.classid=isRelatedTo

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
@@ -1,4 +1,4 @@
-targetColumn=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+targetColumn=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 targetColumnFamily=resultResult_relationship_isRelatedTo
 targetRowKey=document2
 rawSet=patent-actionset-id
@@ -12,7 +12,7 @@ $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
 $targetValue.rel.source=document2
-$targetValue.rel.target=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+$targetValue.rel.target=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 $targetValue.rel.child=false
 
 $targetValue.rel.resultResult.relationship.relMetadata.semantics.classid=isRelatedTo

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
@@ -1,6 +1,6 @@
 targetColumn=body
 targetColumnFamily=result
-targetRowKey=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+targetRowKey=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 rawSet=patent-entity-actionset-id
 actionType=aac
 agent.id=iis
@@ -9,7 +9,7 @@ agent.type=service
 
 $targetValue.kind=entity
 $targetValue.entity.type=result
-$targetValue.entity.id=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+$targetValue.entity.id=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 $targetValue.entity.dateofcollection=2019-11-20T23:59:00.000Z
 $targetValue.entity.dateoftransformation=2019-11-20T23:59:00.000Z
 
@@ -35,13 +35,13 @@ $targetValue.entity.result.metadata.descriptionList[0].value=This is an abstract
 
 $targetValue.entity.result.metadata.subjectList[0].value=G06K   7/00
 $targetValue.entity.result.metadata.subjectList[0].qualifier.classid=IPC
-$targetValue.entity.result.metadata.subjectList[0].qualifier.classname=IPC
+$targetValue.entity.result.metadata.subjectList[0].qualifier.classname=International Patent Classification
 $targetValue.entity.result.metadata.subjectList[0].qualifier.schemeid=dnet:subject_classification_typologies
 $targetValue.entity.result.metadata.subjectList[0].qualifier.schemename=dnet:subject_classification_typologies
 
 $targetValue.entity.result.metadata.subjectList[1].value=G06K  17/00
 $targetValue.entity.result.metadata.subjectList[1].qualifier.classid=IPC
-$targetValue.entity.result.metadata.subjectList[1].qualifier.classname=IPC
+$targetValue.entity.result.metadata.subjectList[1].qualifier.classname=International Patent Classification
 $targetValue.entity.result.metadata.subjectList[1].qualifier.schemeid=dnet:subject_classification_typologies
 $targetValue.entity.result.metadata.subjectList[1].qualifier.schemename=dnet:subject_classification_typologies
 
@@ -81,9 +81,9 @@ $targetValue.entity.result.instanceList[0].instancetype.schemename=dnet:publicat
 
 $targetValue.entity.result.instanceList[0].urlList[0]=https://register.epo.org/application?number=EP00103094
 $targetValue.entity.result.instanceList[0].hostedby.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.result.instanceList[0].hostedby.value=EPO
+$targetValue.entity.result.instanceList[0].hostedby.value=European Patent Office/PATSTAT
 $targetValue.entity.result.instanceList[0].collectedfrom.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.result.instanceList[0].collectedfrom.value=EPO
+$targetValue.entity.result.instanceList[0].collectedfrom.value=European Patent Office/PATSTAT
 
 $targetValue.entity.collectedfromList[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.collectedfromList[0].value=EPO
+$targetValue.entity.collectedfromList[0].value=European Patent Office/PATSTAT

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
@@ -1,6 +1,6 @@
 targetColumn=document1
 targetColumnFamily=resultResult_relationship_isRelatedTo
-targetRowKey=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+targetRowKey=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 rawSet=patent-actionset-id
 actionType=aac
 agent.id=iis
@@ -11,7 +11,7 @@ $targetValue.kind=relation
 $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
-$targetValue.rel.source=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+$targetValue.rel.source=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 $targetValue.rel.target=document1
 $targetValue.rel.child=false
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
@@ -1,6 +1,6 @@
 targetColumn=document2
 targetColumnFamily=resultResult_relationship_isRelatedTo
-targetRowKey=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+targetRowKey=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 rawSet=patent-actionset-id
 actionType=aac
 agent.id=iis
@@ -11,7 +11,7 @@ $targetValue.kind=relation
 $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
-$targetValue.rel.source=50|openaire____::9fce164deeabdfd83f697e45b1aeea3d
+$targetValue.rel.source=50|epopatstat__::9fce164deeabdfd83f697e45b1aeea3d
 $targetValue.rel.target=document2
 $targetValue.rel.child=false
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
@@ -1,6 +1,6 @@
 targetColumn=body
 targetColumnFamily=result
-targetRowKey=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+targetRowKey=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 rawSet=patent-entity-actionset-id
 actionType=aac
 agent.id=iis
@@ -9,7 +9,7 @@ agent.type=service
 
 $targetValue.kind=entity
 $targetValue.entity.type=result
-$targetValue.entity.id=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+$targetValue.entity.id=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 $targetValue.entity.dateofcollection=2019-11-20T23:59:00.000Z
 $targetValue.entity.dateoftransformation=2019-11-20T23:59:00.000Z
 
@@ -35,13 +35,13 @@ $targetValue.entity.result.metadata.descriptionList[0].value=This is an abstract
 
 $targetValue.entity.result.metadata.subjectList[0].value=B01J  23/46
 $targetValue.entity.result.metadata.subjectList[0].qualifier.classid=IPC
-$targetValue.entity.result.metadata.subjectList[0].qualifier.classname=IPC
+$targetValue.entity.result.metadata.subjectList[0].qualifier.classname=International Patent Classification
 $targetValue.entity.result.metadata.subjectList[0].qualifier.schemeid=dnet:subject_classification_typologies
 $targetValue.entity.result.metadata.subjectList[0].qualifier.schemename=dnet:subject_classification_typologies
 
 $targetValue.entity.result.metadata.subjectList[1].value=B01J  31/24
 $targetValue.entity.result.metadata.subjectList[1].qualifier.classid=IPC
-$targetValue.entity.result.metadata.subjectList[1].qualifier.classname=IPC
+$targetValue.entity.result.metadata.subjectList[1].qualifier.classname=International Patent Classification
 $targetValue.entity.result.metadata.subjectList[1].qualifier.schemeid=dnet:subject_classification_typologies
 $targetValue.entity.result.metadata.subjectList[1].qualifier.schemename=dnet:subject_classification_typologies
 
@@ -81,9 +81,9 @@ $targetValue.entity.result.instanceList[0].instancetype.schemename=dnet:publicat
 
 $targetValue.entity.result.instanceList[0].urlList[0]=https://register.epo.org/application?number=EP01119799
 $targetValue.entity.result.instanceList[0].hostedby.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.result.instanceList[0].hostedby.value=EPO
+$targetValue.entity.result.instanceList[0].hostedby.value=European Patent Office/PATSTAT
 $targetValue.entity.result.instanceList[0].collectedfrom.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.result.instanceList[0].collectedfrom.value=EPO
+$targetValue.entity.result.instanceList[0].collectedfrom.value=European Patent Office/PATSTAT
 
 $targetValue.entity.collectedfromList[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
-$targetValue.entity.collectedfromList[0].value=EPO
+$targetValue.entity.collectedfromList[0].value=European Patent Office/PATSTAT

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
@@ -1,6 +1,6 @@
 targetColumn=document2
 targetColumnFamily=resultResult_relationship_isRelatedTo
-targetRowKey=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+targetRowKey=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 rawSet=patent-actionset-id
 actionType=aac
 agent.id=iis
@@ -11,7 +11,7 @@ $targetValue.kind=relation
 $targetValue.rel.relType=resultResult
 $targetValue.rel.subRelType=relationship
 $targetValue.rel.relClass=isRelatedTo
-$targetValue.rel.source=50|openaire____::702195de7e0ff019d206b3eef73f0f21
+$targetValue.rel.source=50|epopatstat__::702195de7e0ff019d206b3eef73f0f21
 $targetValue.rel.target=document2
 $targetValue.rel.child=false
 

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/input/PatentReferenceExtractionInputTransformerJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/input/PatentReferenceExtractionInputTransformerJob.java
@@ -3,6 +3,7 @@ package eu.dnetlib.iis.wf.referenceextraction.patent.input;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import eu.dnetlib.iis.referenceextraction.patent.schemas.Patent;
 import eu.dnetlib.iis.referenceextraction.patent.schemas.PatentReferenceExtractionInput;
 import org.apache.spark.SparkConf;
@@ -11,13 +12,15 @@ import org.apache.spark.api.java.JavaSparkContext;
 import pl.edu.icm.sparkutils.avro.SparkAvroLoader;
 import pl.edu.icm.sparkutils.avro.SparkAvroSaver;
 
+import java.io.IOException;
+
 public class PatentReferenceExtractionInputTransformerJob {
     private static final SparkAvroLoader sparkAvroLoader = new SparkAvroLoader();
     private static final SparkAvroSaver sparkAvroSaver = new SparkAvroSaver();
 
     //------------------------ LOGIC --------------------------
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         JobParameters params = new JobParameters();
         JCommander jcommander = new JCommander(params);
         jcommander.parse(args);
@@ -27,6 +30,8 @@ public class PatentReferenceExtractionInputTransformerJob {
         conf.set("spark.kryo.registrator", "pl.edu.icm.sparkutils.avro.AvroCompatibleKryoRegistrator");
 
         try (JavaSparkContext sc = new JavaSparkContext(conf)) {
+            HdfsUtils.remove(sc.hadoopConfiguration(), params.outputPath);
+
             JavaRDD<PatentReferenceExtractionInput> convertedRDD = sparkAvroLoader.loadJavaRDD(sc, params.inputPath, Patent.class)
                     .map(PatentReferenceExtractionInputTransformerJob::convert);
             sparkAvroSaver.saveJavaRDD(convertedRDD, PatentReferenceExtractionInput.SCHEMA$, params.outputPath);

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/oozie_app/workflow.xml
@@ -40,7 +40,11 @@
             <name>patent-referenceextraction-input-transformer</name>
             <class>eu.dnetlib.iis.wf.referenceextraction.patent.input.PatentReferenceExtractionInputTransformerJob</class>
             <jar>${oozieTopWfApplicationPath}/lib/iis-wf-referenceextraction-${projectVersion}.jar</jar>
-            <spark-opts>--executor-memory ${sparkExecutorMemory} --executor-cores ${sparkExecutorCores} --driver-memory=${sparkDriverMemory}</spark-opts>
+            <spark-opts>
+                --executor-memory ${sparkExecutorMemory}
+                --executor-cores ${sparkExecutorCores}
+                --driver-memory ${sparkDriverMemory}
+            </spark-opts>
             <arg>-inputPath=${input_patent}</arg>
             <arg>-outputPath=${workingDir}/patent</arg>
         </spark>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main_sqlite/oozie_app/workflow.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0"?>
-<!-- Note that documentation placed in comments in this file uses the
-"markdown" syntax (along with its way of dividing text into sections). -->
 <workflow-app xmlns="uri:oozie:workflow:0.4" name="referenceextraction_patent_main_sqlite">
-	
-	<parameters>
-		<property>
-			<name>input_document_text</name>
-			<description>input document text</description>
-		</property>
-		<property>
-			<name>input_patent_db</name>
-			<description>patents SQLite DB path</description>
-		</property>
-		<property>
-			<name>output_document_to_patent</name>
-			<description>output document to patent</description>
-		</property>
-	</parameters>
+
+    <parameters>
+        <property>
+            <name>input_document_text</name>
+            <description>input document text</description>
+        </property>
+        <property>
+            <name>input_patent_db</name>
+            <description>patents SQLite DB path</description>
+        </property>
+        <property>
+            <name>output_document_to_patent</name>
+            <description>output document to patent</description>
+        </property>
+    </parameters>
 
     <global>
         <job-tracker>${jobTracker}</job-tracker>
@@ -32,20 +30,19 @@
             </property>
         </configuration>
     </global>
-    
-    
-	<start to="generate-schema" />
 
-	<action name="generate-schema">
-	    <java>
-	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-	        <arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
-	        <arg>eu.dnetlib.iis.referenceextraction.patent.schemas.DocumentToPatent</arg>
-	        <capture-output />
-	    </java>
-	    <ok to="main" />
-	    <error to="fail" />
-	</action>
+    <start to="generate-schema"/>
+
+    <action name="generate-schema">
+        <java>
+            <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
+            <arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
+            <arg>eu.dnetlib.iis.referenceextraction.patent.schemas.DocumentToPatent</arg>
+            <capture-output/>
+        </java>
+        <ok to="main"/>
+        <error to="fail"/>
+    </action>
 
     <action name="main">
         <map-reduce>
@@ -53,18 +50,9 @@
                 <delete path="${nameNode}${output_document_to_patent}"/>
             </prepare>
             <streaming>
-            	<!-- Here, we give the relative path to the script and pass it
-            	the parameters of the workflow node. The script is held
-            	in a directory having the same name as the workflow node.
-
-            	The parameters should be passed as **named** arguments. This
-            	convention of passing them as named arguments makes the code
-            	more readable/maintainable.
-            	 -->
                 <mapper>scripts/madis/mexec.py -d patent.db -f scripts/patents.sql</mapper>
             </streaming>
             <configuration>
-            	<!-- # Standard settings for our framework -->
                 <property>
                     <name>mapred.output.format.class</name>
                     <value>com.cloudera.science.avro.streaming.AvroAsJSONOutputFormat</value>
@@ -79,7 +67,7 @@
                     <name>mapreduce.job.reduces</name>
                     <value>0</value>
                 </property>
-                
+
                 <!-- INPUT -->
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -91,23 +79,22 @@
                     <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.metadataextraction.schemas.DocumentText']}</value>
                 </property>
 
-				<!-- OUTPUT -->
+                <!-- OUTPUT -->
                 <property>
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
                     <value>${output_document_to_patent}</value>
-                </property>          
+                </property>
 
                 <property>
                     <name>output.schema.literal</name>
                     <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.patent.schemas.DocumentToPatent']}</value>
                 </property>
 
-				<!-- this one is requred due to the large amount of time taken 
-					by process storing plaintexts into the database -->
-				<property>
-					<name>mapreduce.task.timeout</name>
-					<value>14400000</value>
-				</property>
+                <!-- this one is required due to the large amount of time taken by process storing plaintexts into the database -->
+                <property>
+                    <name>mapreduce.task.timeout</name>
+                    <value>14400000</value>
+                </property>
             </configuration>
             <file>${input_patent_db}#patent.db</file>
         </map-reduce>
@@ -117,8 +104,8 @@
 
     <kill name="fail">
         <message>Unfortunately, the process failed -- error message:
-        			[${wf:errorMessage(wf:lastErrorNode())}]
-        		</message>
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
     </kill>
 
     <end name="end"/>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/sqlite_builder/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/sqlite_builder/oozie_app/workflow.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
-<!-- Note that documentation placed in comments in this file uses the
-"markdown" syntax (along with its way of dividing text into sections). -->
 <workflow-app xmlns="uri:oozie:workflow:0.4" name="referenceextraction_patent_sqlite_builder">
-	
-	<parameters>
-		<property>
-			<name>input_patent</name>
-			<description>input patents datastore</description>
-		</property>
-		<property>
-			<name>output_patent_db</name>
-			<description>output patents SQLite DB path</description>
-		</property>
-	</parameters>
+
+    <parameters>
+        <property>
+            <name>input_patent</name>
+            <description>input patents datastore</description>
+        </property>
+        <property>
+            <name>output_patent_db</name>
+            <description>output patents SQLite DB path</description>
+        </property>
+    </parameters>
 
     <global>
         <job-tracker>${jobTracker}</job-tracker>
@@ -28,18 +26,13 @@
             </property>
         </configuration>
     </global>
-    
-    
-	<start to="sqlite_builder" />
+
+    <start to="sqlite_builder"/>
 
     <action name="sqlite_builder">
         <java>
-            <!-- This is simple wrapper for the Java code -->
             <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
-            <!-- The business Java code that gets to be executed -->
             <arg>eu.dnetlib.iis.wf.referenceextraction.patent.PatentDBBuilder</arg>
-            <!-- All input and output ports have to be bound to paths in 
-            HDFS, working directory has to be specified as well -->
             <arg>-Ipatents=${input_patent}</arg>
             <arg>-Opatents_db=${output_patent_db}</arg>
             <arg>-PscriptLocation=scripts/buildpatentdb.sql</arg>
@@ -47,11 +40,11 @@
         <ok to="end"/>
         <error to="fail"/>
     </action>
-    
+
     <kill name="fail">
         <message>Unfortunately, the process failed -- error message:
-        			[${wf:errorMessage(wf:lastErrorNode())}]
-        		</message>
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
     </kill>
 
     <end name="end"/>

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest/oozie_app/workflow.xml
@@ -66,7 +66,6 @@
                     <name>output_report_root_path</name>
                     <value>${workingDir}/referenceextraction_patent/report</value>
                 </property>
-                <!-- sparkDriverMemory, sparkExecutorMemory, sparkExecutorCores are provided by environment (since git#889) -->
             </configuration>
         </sub-workflow>
         <ok to="consumer"/>

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest_empty_patent_input/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest_empty_patent_input/oozie_app/workflow.xml
@@ -66,7 +66,6 @@
                     <name>output_report_root_path</name>
                     <value>${workingDir}/referenceextraction_patent/report</value>
                 </property>
-                <!-- sparkDriverMemory, sparkExecutorMemory, sparkExecutorCores are provided by environment (since git#889) -->
             </configuration>
         </sub-workflow>
         <ok to="consumer"/>

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest_empty_text_input/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main/sampletest_empty_text_input/oozie_app/workflow.xml
@@ -66,7 +66,6 @@
                     <name>output_report_root_path</name>
                     <value>${workingDir}/referenceextraction_patent/report</value>
                 </property>
-                <!-- sparkDriverMemory, sparkExecutorMemory, sparkExecutorCores are provided by environment (since git#889) -->
             </configuration>
         </sub-workflow>
         <ok to="consumer"/>


### PR DESCRIPTION
This PR follows up patent integration into IIS with additional changes
  - explicit output dir removal for spark jobs
  - handling of patent nullable fields in exporter
  - update patent mapping into OAF model
  - minor updates to formatting of workflow files

Notes: patent mining scripts do not use document or patent authors.