### PR TITLE
Spark context creation exception fix

### DIFF
--- a/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDTestUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDTestUtilsTest.java
@@ -27,7 +27,8 @@ public class RDDTestUtilsTest {
     @BeforeClass
     public static void beforeClass() {
         SparkConf conf = new SparkConf();
-        conf.setMaster("local[1]");
+        conf.setMaster("local");
+        conf.set("spark.driver.host", "localhost");
         conf.setAppName("RDDTestUtilsTest");
         sc = new JavaSparkContext(conf);
         configuration = new Configuration();

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDTestUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDTestUtilsTest.java
@@ -29,6 +29,7 @@ public class RDDTestUtilsTest {
         SparkConf conf = new SparkConf();
         conf.setMaster("local");
         conf.set("spark.driver.host", "localhost");
+        conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
         conf.setAppName("RDDTestUtilsTest");
         sc = new JavaSparkContext(conf);
         configuration = new Configuration();

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
@@ -33,6 +33,7 @@ public class RDDUtilsTest {
         SparkConf conf = new SparkConf();
         conf.setMaster("local");
         conf.set("spark.driver.host", "localhost");
+        conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
         conf.setAppName("RDDUtilsTest");
         sc = new JavaSparkContext(conf);
         configuration = new Configuration();

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
@@ -32,8 +32,8 @@ public class RDDUtilsTest {
     public static void beforeClass() {
         SparkConf conf = new SparkConf();
         conf.setMaster("local");
+        conf.set("spark.driver.host", "localhost");
         conf.setAppName("RDDUtilsTest");
-        conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
         sc = new JavaSparkContext(conf);
         configuration = new Configuration();
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExportCounterReporterTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExportCounterReporterTest.java
@@ -43,8 +43,9 @@ public class PatentExportCounterReporterTest {
     public static void before() {
         SparkConf conf = new SparkConf();
         conf.setMaster("local");
-        conf.setAppName("PatentExportCounterReporterTest");
+        conf.set("spark.driver.host", "localhost");
         conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+        conf.setAppName("PatentExportCounterReporterTest");
         sc = new JavaSparkContext(conf);
     }
 


### PR DESCRIPTION
This PR fixes exception raising when creating spark context used in unit tests for the following test classes: `RDDUtilsTest`, `RDDTestUtilsTest`, `PatentExportCounterReporterTest`.