### PR TITLE
Marekhorst 991 prevent mining modules from occupying cluster resources for too long

### DIFF
--- a/iis-wf/iis-wf-documentsclassification/src/main/java/eu/dnetlib/iis/wf/documentsclassification/DocumentClassificationJob.java
+++ b/iis-wf/iis-wf-documentsclassification/src/main/java/eu/dnetlib/iis/wf/documentsclassification/DocumentClassificationJob.java
@@ -57,7 +57,7 @@ public class DocumentClassificationJob {
                     .loadJavaRDD(sc, params.inputAvroPath, ExtractedDocumentMetadataMergedWithOriginal.class);
             
             JavaRDD<ExtractedDocumentMetadataMergedWithOriginal> repartDocuments = 
-                    (StringUtils.isNotBlank(params.numberOfPartitions) && !WorkflowRuntimeParameters.UNDEFINED_NONEMPTY_VALUE.equals(params.numberOfPartitions))
+                    shouldRepartition(params.numberOfPartitions)
                     ? rawDocuments.repartition(Integer.parseInt(params.numberOfPartitions))
                     : rawDocuments;
             
@@ -86,6 +86,14 @@ public class DocumentClassificationJob {
     }
 
     //------------------------ PRIVATE --------------------------
+    
+    
+    /**
+     * Checks whether partitioning should be perfomed based on the parameter value.
+     */
+    private static boolean shouldRepartition(String numberOfPartitions) {
+        return (StringUtils.isNotBlank(numberOfPartitions) && !WorkflowRuntimeParameters.UNDEFINED_NONEMPTY_VALUE.equals(numberOfPartitions));
+    }
     
     private static String getScriptPath() {
         String path = SparkFiles.get("scripts");

--- a/iis-wf/iis-wf-documentsclassification/src/main/resources/eu/dnetlib/iis/wf/documentsclassification/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-documentsclassification/src/main/resources/eu/dnetlib/iis/wf/documentsclassification/oozie_app/workflow.xml
@@ -53,6 +53,13 @@
             <name>spark2EventLogDir</name>
             <description>spark 2.* event log dir location</description>
         </property>
+        <property>
+            <name>numberOfPartitions</name>
+            <value>$UNDEFINED$</value>
+            <description>number of partitions the input data should be sliced into. 
+            Affects the number of tasks executed on the input data and each task execution time (more tasks less time each executor takes). 
+            Relying on default value when $UNDEFINED$.</description>
+        </property>
     </parameters>
 
     <global>
@@ -105,6 +112,8 @@
             <arg>-inputAvroPath=${input_documents}</arg>
             <arg>-outputAvroPath=${output_document_to_document_classes}</arg>
             <arg>-scriptDirPath=${wf:conf('oozie.wf.application.path')}/lib/scripts</arg>
+            <arg>-numberOfPartitions=${numberOfPartitions}</arg>
+            
             <arg>-outputReportPath=${output_report_root_path}/${output_report_relative_path}</arg>
             
         </spark>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -332,7 +332,13 @@
             <value>${sparkExecutorMemory}</value>
             <description>memory for individual executor</description>
         </property>
-        
+        <property>
+            <name>textUnionBlockSize</name>
+            <value>32m</value>
+            <description>DocumentText datastore block size affecting number of tasks issued by each text mining module.
+            Introduced to prevent long lasting tasks from occupying cluster resources for too long.</description>
+        </property>
+
         <!-- output ports -->
         <property>
             <name>output_merged_metadata</name>
@@ -464,6 +470,10 @@
                 <property>
                     <name>union_count_report_key</name>
                     <value>processing.merging.documentText</value>
+                </property>
+                <property>
+                    <name>dfs_blocksize</name>
+                    <value>${textUnionBlockSize}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -224,6 +224,11 @@
             <value>${sparkExecutorCores}</value>
             <description>number of cores used by single executor</description>
         </property>
+        <property>
+            <name>documentsclassificationNumberOfPartitions</name>
+            <value>$UNDEFINED$</value>
+            <description>number of cores used by single executor</description>
+        </property>
         <!-- spark related: affiliation matching -->
         <property>
             <name>affiliationmatchingSparkExecutorMemory</name>
@@ -1354,6 +1359,10 @@
                 <property>
                     <name>sparkExecutorCores</name>
                     <value>${documentsclassificationSparkExecutorCores}</value>
+                </property>
+                <property>
+                    <name>numberOfPartitions</name>
+                    <value>${documentsclassificationNumberOfPartitions}</value>
                 </property>
             </configuration>
         </sub-workflow>

--- a/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/common/union/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/main/resources/eu/dnetlib/iis/wf/transformers/common/union/oozie_app/workflow.xml
@@ -20,6 +20,11 @@
             <description>Value for pig.maxCombinedSplitSize Pig property</description>
         </property>
         <property>
+            <name>dfs_blocksize</name>
+            <value>128m</value>
+            <description>output datastore blocksize</description>
+        </property>
+        <property>
             <name>output_report</name>
             <value>$UNDEFINED$</value>
             <description>directory for storing report</description>
@@ -69,6 +74,10 @@
                 <property>
                     <name>pig.maxCombinedSplitSize</name>
                     <value>${combine_splits}</value>
+                </property>
+                <property>
+                    <name>dfs.blocksize</name>
+                    <value>${dfs_blocksize}</value>
                 </property>
                 <property>
                     <name>oozie.action.external.stats.write</name>


### PR DESCRIPTION
Detailed description is already available in #991 comments. 

This PR consists of 2 commits related to:
* documents classification madis module (spark action)
* PIG union transformer producing `DocumentText` input for all text mining madis modules (streaming actions)

Those two should cover all the cases where single madis task occupies cluster resources for a very long time.

`documentsclassificationNumberOfPartitions` is set to `$UNDEFINED$` by default (which means the repartitioning will NOT be applied) and is intended to be overridden in `config-default.xml` configuration file already available on IIS cluster.

I could not apply the same approach for PIG module because apparently there is no `dfs.blocksize` value which could instruct PIG to rely on cluster defaults. This is why default value is set explicitly to `128m` (cluster default) and overridden to `32m` in specific union function usage. This should result in 4x more madis tasks crunching the text input.

