### PR TITLE
Marekhorst 1041 remove source field support from software heritage sqlite database builder script

### DIFF
--- a/iis-schemas/src/main/avro/eu/dnetlib/iis/referenceextraction/softwareurl/SoftwareHeritageOrigin.avdl
+++ b/iis-schemas/src/main/avro/eu/dnetlib/iis/referenceextraction/softwareurl/SoftwareHeritageOrigin.avdl
@@ -2,8 +2,11 @@
 protocol IIS{
 
     record SoftwareHeritageOrigin {
+    	// this field should be dropped but due to the following issue:
+    	// https://issues.apache.org/jira/browse/PIG-3358
+    	// we need to keep dummy 2nd field in this record definition 
         // SH origin
-        string origin;
+        union { null , string } origin = null;
         // SH url
         string url;
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginEntry.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginEntry.java
@@ -7,39 +7,9 @@ package eu.dnetlib.iis.wf.importer.software.origins;
  */
 public class SoftwareHeritageOriginEntry {
 
-    private String id;
-
-    private String originVisitsUrl;
-    
-    private String type;
-    
     private String url;
 
     
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getOriginVisitsUrl() {
-        return originVisitsUrl;
-    }
-
-    public void setOriginVisitsUrl(String originVisitsUrl) {
-        this.originVisitsUrl = originVisitsUrl;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
     public String getUrl() {
         return url;
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporter.java
@@ -260,7 +260,6 @@ public class SoftwareHeritageOriginsImporter implements eu.dnetlib.iis.common.ja
 
     protected static SoftwareHeritageOrigin convertEntry(SoftwareHeritageOriginEntry source) {
         SoftwareHeritageOrigin.Builder resultBuilder = SoftwareHeritageOrigin.newBuilder();
-        resultBuilder.setOrigin(source.getType());
         resultBuilder.setUrl(source.getUrl());
         return resultBuilder.build();
     }

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporterTest.java
@@ -173,14 +173,13 @@ public class SoftwareHeritageOriginsImporterTest {
     @Test
     public void testConvertEntry() throws Exception {
         // given
-        SoftwareHeritageOriginEntry source = buildSoftwareHeritageOriginEntry("someId", "someType", "someUrl");
+        SoftwareHeritageOriginEntry source = buildSoftwareHeritageOriginEntry("someUrl");
         
         // execute
         SoftwareHeritageOrigin result = SoftwareHeritageOriginsImporter.convertEntry(source);
         
         // assert
         assertNotNull(result);
-        assertEquals(source.getType(), result.getOrigin());
         assertEquals(source.getUrl(), result.getUrl());
     }
     
@@ -188,8 +187,8 @@ public class SoftwareHeritageOriginsImporterTest {
     public void testParsePage() throws Exception {
         // given
         Gson gson = new Gson();
-        SoftwareHeritageOriginEntry entry1 = buildSoftwareHeritageOriginEntry("id1", "type1", "someUrl1");
-        SoftwareHeritageOriginEntry entry2 = buildSoftwareHeritageOriginEntry("id2", "type2", "someUrl2");
+        SoftwareHeritageOriginEntry entry1 = buildSoftwareHeritageOriginEntry("someUrl1");
+        SoftwareHeritageOriginEntry entry2 = buildSoftwareHeritageOriginEntry("someUrl2");
 
         // execute
         SoftwareHeritageOriginEntry[] results = SoftwareHeritageOriginsImporter.parsePage(
@@ -198,13 +197,7 @@ public class SoftwareHeritageOriginsImporterTest {
         // assert
         assertNotNull(results);
         assertEquals(2, results.length);
-        assertEquals(entry1.getId(), results[0].getId());
-        assertEquals(entry1.getOriginVisitsUrl(), results[0].getOriginVisitsUrl());
-        assertEquals(entry1.getType(), results[0].getType());
         assertEquals(entry1.getUrl(), results[0].getUrl());
-        assertEquals(entry2.getId(), results[1].getId());
-        assertEquals(entry2.getOriginVisitsUrl(), results[1].getOriginVisitsUrl());
-        assertEquals(entry2.getType(), results[1].getType());
         assertEquals(entry2.getUrl(), results[1].getUrl());
     }
     
@@ -290,7 +283,7 @@ public class SoftwareHeritageOriginsImporterTest {
         HttpEntity httpEntity = mock(HttpEntity.class);
         when(httpResponse.getEntity()).thenReturn(httpEntity);
         // preparing page contents
-        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("id1", "type1", "someUrl1");
+        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("someUrl1");
         Gson gson = new Gson();
         String pageContents = gson.toJson(new SoftwareHeritageOriginEntry[] {entry});
         InputStream pageInputStream = new ByteArrayInputStream(pageContents.getBytes());
@@ -306,7 +299,6 @@ public class SoftwareHeritageOriginsImporterTest {
         assertEquals(1, origins.size());
         SoftwareHeritageOrigin origin = origins.get(0);
         assertNotNull(origin);
-        assertEquals(entry.getType(), origin.getOrigin());
         assertEquals(entry.getUrl(), origin.getUrl());
         verifyReport(1, SoftwareHeritageOriginsImporter.COUNTER_NAME_TOTAL);
     }
@@ -324,8 +316,8 @@ public class SoftwareHeritageOriginsImporterTest {
         when(statusLine.getStatusCode()).thenReturn(200);
         
         Gson gson = new Gson();
-        SoftwareHeritageOriginEntry entry1 = buildSoftwareHeritageOriginEntry("id1", "type1", "someUrl1");
-        SoftwareHeritageOriginEntry entry2 = buildSoftwareHeritageOriginEntry("id2", "type2", "someUrl2");
+        SoftwareHeritageOriginEntry entry1 = buildSoftwareHeritageOriginEntry("someUrl1");
+        SoftwareHeritageOriginEntry entry2 = buildSoftwareHeritageOriginEntry("someUrl2");
         
         //1st response
         {
@@ -365,10 +357,8 @@ public class SoftwareHeritageOriginsImporterTest {
         List<SoftwareHeritageOrigin> origins = originCaptor.getAllValues();
         assertEquals(2, origins.size());
         assertNotNull(origins.get(0));
-        assertEquals(entry1.getType(), origins.get(0).getOrigin());
         assertEquals(entry1.getUrl(), origins.get(0).getUrl());
         assertNotNull(origins.get(1));
-        assertEquals(entry2.getType(), origins.get(1).getOrigin());
         assertEquals(entry2.getUrl(), origins.get(1).getUrl());
         verifyReport(2, SoftwareHeritageOriginsImporter.COUNTER_NAME_TOTAL);
     }
@@ -384,7 +374,7 @@ public class SoftwareHeritageOriginsImporterTest {
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse, httpResponse2);
 
         Gson gson = new Gson();
-        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("id1", "type1", "someUrl1");
+        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("someUrl1");
         
         //1st response
         {
@@ -425,7 +415,6 @@ public class SoftwareHeritageOriginsImporterTest {
         List<SoftwareHeritageOrigin> origins = originCaptor.getAllValues();
         assertEquals(1, origins.size());
         assertNotNull(origins.get(0));
-        assertEquals(entry.getType(), origins.get(0).getOrigin());
         assertEquals(entry.getUrl(), origins.get(0).getUrl());
         verifyReport(1, SoftwareHeritageOriginsImporter.COUNTER_NAME_TOTAL);
         
@@ -442,7 +431,7 @@ public class SoftwareHeritageOriginsImporterTest {
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse, httpResponse2);
 
         Gson gson = new Gson();
-        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("id1", "type1", "someUrl1");
+        SoftwareHeritageOriginEntry entry = buildSoftwareHeritageOriginEntry("someUrl1");
         
         //1st response
         {
@@ -483,7 +472,6 @@ public class SoftwareHeritageOriginsImporterTest {
         List<SoftwareHeritageOrigin> origins = originCaptor.getAllValues();
         assertEquals(1, origins.size());
         assertNotNull(origins.get(0));
-        assertEquals(entry.getType(), origins.get(0).getOrigin());
         assertEquals(entry.getUrl(), origins.get(0).getUrl());
         verifyReport(1, SoftwareHeritageOriginsImporter.COUNTER_NAME_TOTAL);
     }
@@ -635,19 +623,10 @@ public class SoftwareHeritageOriginsImporterTest {
         };
     }
     
-    private SoftwareHeritageOriginEntry buildSoftwareHeritageOriginEntry(
-            String id, String originVisitsUrl, String type, String url) {
+    private SoftwareHeritageOriginEntry buildSoftwareHeritageOriginEntry(String url) {
         SoftwareHeritageOriginEntry entry = new SoftwareHeritageOriginEntry();
-        entry.setId(id);
-        entry.setOriginVisitsUrl(originVisitsUrl);
-        entry.setType(type);
         entry.setUrl(url);
         return entry;
-    }
-    
-    private SoftwareHeritageOriginEntry buildSoftwareHeritageOriginEntry(
-            String id, String type, String url) {
-        return buildSoftwareHeritageOriginEntry(id, "irrelevant", type, url);
     }
     
 }

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/meta/sh_origins.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/input/meta/sh_origins.json
@@ -1,1 +1,1 @@
-{"origin": "git", "url": "https://github.com/openaire/iis"}
+{"origin": null, "url": "https://github.com/openaire/iis"}

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/sqlite_builder/oozie_app/lib/scripts/shinit.sql
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/sqlite_builder/oozie_app/lib/scripts/shinit.sql
@@ -1,2 +1,3 @@
-create table links as select id,source, lower(link) as link, link as originlink from (setschema 'id,source,link' select rowid as id, c1 as source, c2 as link from (rowidvt select jsonpath(c1,'source','url') from stdinput()));
+create table links as select id, lower(link) as link, link as originlink from (setschema 'id,link' select rowid as id, c1 as link from (rowidvt select jsonpath(c1,'url') from stdinput()));
 CREATE INDEX links_ind on links(link,originlink);
+

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/data/sh_origins.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/data/sh_origins.json
@@ -1,1 +1,1 @@
-{"origin": "git", "url": "https://github.com/openaire/IIS"}
+{"origin": null, "url": "https://github.com/openaire/IIS"}


### PR DESCRIPTION
This PR removes:
* obsolete `source` field from madis script (Ioannis' commit)
* all unused fields from importer process: `id`, `originVisitsUrl` and `type`

`type` field was meant to be provided to madis script as `source` but 1) SH endpoint does not provide this field anymore and 2) it turned out `source` is not being used in mining so it can be dropped.

Those removed fields were imported from SH endpoint but after the algorithm evolved it turned out we can just rely on `url` field alone.