### PR TITLE
Marekhorst 1067 update pdb database and add support for textsnippet field

### DIFF
--- a/iis-schemas/src/main/avro/eu/dnetlib/iis/referenceextraction/common/DocumentToConceptId.avdl
+++ b/iis-schemas/src/main/avro/eu/dnetlib/iis/referenceextraction/common/DocumentToConceptId.avdl
@@ -1,4 +1,4 @@
-@namespace("eu.dnetlib.iis.referenceextraction.community.schemas")
+@namespace("eu.dnetlib.iis.referenceextraction.common.schemas")
 protocol IIS{
 
     record DocumentToConceptId {

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/community/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/community/main_sqlite/oozie_app/workflow.xml
@@ -38,7 +38,7 @@
 	    <java>
 	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
 	        <arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
-	        <arg>eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId</arg>
+	        <arg>eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId</arg>
 	        <capture-output />
 	    </java>
 	    <ok to="main_sqlite" />
@@ -97,7 +97,7 @@
 
                 <property>
                     <name>output.schema.literal</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId']}</value>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId']}</value>
                 </property>
 
 				<!-- this one is requred due to the large amount of time taken 

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/lib/scripts/pdbquery.sql
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/lib/scripts/pdbquery.sql
@@ -3,8 +3,8 @@ hidden var 'pdbneg' from select jmergeregexp(jgroup(c1)) from (select * from neg
 hidden var 'chromeneg' from select jmergeregexp(jgroup(c1)) from (select * from chromeneg order by length(C1) desc) ;
 hidden var 'dnaneg' from  select jmergeregexp(jgroup(c1)) from (select * from dnaneg order by length(C1) desc) ;
 
-select jdict('documentId', pubid, 'conceptId', pdbid,'confidenceLevel',conf) from (
-select pubid,pdbid, case when conf=1 then 0.25 when conf=2 then 0.45 when conf = 3 then 0.55 when conf > 3 and conf<7 then 0.75 else 0.9 end as conf from
+select jdict('documentId', pubid, 'conceptId', pdbid,'confidenceLevel',conf,'textsnippet',context) from (
+select pubid,pdbid, case when conf=1 then 0.25 when conf=2 then 0.45 when conf = 3 then 0.55 when conf > 3 and conf<7 then 0.75 else 0.9 end as conf, context from
     (unindexed select *, regexpcountwords(var('pdbpos'),context) - regexpcountwords(var('pdbneg'),context) as conf from
         (select regexpr("(\b\d\w{3})",middle) as pdbid,pubid, j2s(prev1,prev2,prev3,prev4,prev5,prev6,prev7,prev8,prev9,prev10,middle,next1,next2,next3,next4,next5) as context from
             (setschema 'pubid,prev1,prev2,prev3,prev4,prev5,prev6,prev7,prev8,prev9,prev10,middle,next1,next2,next3,next4,next5' select c1 as pubid,textwindow(comprspaces(lower(filterstopwords(regexpr('[^\w-]',c2,' ')))) ,-10,5,'(?:-|^)\d\w{3}(?:-|$)') from (select * from (setschema 'c1,c2' select jsonpath(c1, '$.id', '$.text') from stdinput()) where c2 is not null))

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
@@ -36,7 +36,7 @@
 	    <java>
 	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
 	        <arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
-	        <arg>eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToConceptId</arg>
+	        <arg>eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId</arg>
 	        <capture-output />
 	    </java>
 	    <ok to="main" />
@@ -95,7 +95,7 @@
 
                 <property>
                     <name>output.schema.literal</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToConceptId']}</value>
+                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId']}</value>
                 </property>
 
 				<!-- this one is requred due to the large amount of time taken 

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest/oozie_app/workflow.xml
@@ -88,7 +88,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_community,
-				eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/wf/referenceextraction/community/data/document_to_community.json}</arg>
             <arg>-C{report,
                 eu.dnetlib.iis.common.schemas.ReportEntry,

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest_empty_concept_input/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest_empty_concept_input/oozie_app/workflow.xml
@@ -87,7 +87,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_community,
-				eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/common/data/empty.json}</arg>
             <arg>-C{report,
                 eu.dnetlib.iis.common.schemas.ReportEntry,

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest_empty_text_input/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/community/main/sampletest_empty_text_input/oozie_app/workflow.xml
@@ -87,7 +87,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_community,
-				eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/common/data/empty.json}</arg>
             <arg>-C{report,
                 eu.dnetlib.iis.common.schemas.ReportEntry,

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/data/document_to_pdb.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/data/document_to_pdb.json
@@ -1,3 +1,18 @@
-{"documentId": "id-1", "conceptId": "1hcr", "confidenceLevel": 0.25}
-{"documentId": "id-1", "conceptId": "1cad", "confidenceLevel": 0.25}
-{"documentId": "id-1", "conceptId": "1enh", "confidenceLevel": 0.25}
+{
+  "documentId": "id-1",
+  "conceptId": "1hcr",
+  "confidenceLevel": 0.25,
+  "textsnippet": "   sample text related proteins listed pdb-code names 1hcr 1cad 1enh proteins matched database"
+}
+{
+  "documentId": "id-1",
+  "conceptId": "1cad",
+  "confidenceLevel": 0.25,
+  "textsnippet": "   sample text related proteins listed pdb-code names 1cad 1enh proteins matched database entries"
+}
+{
+  "documentId": "id-1",
+  "conceptId": "1enh",
+  "confidenceLevel": 0.25,
+  "textsnippet": "   sample text related proteins listed pdb-code names 1enh proteins matched database entries "
+}

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest/oozie_app/workflow.xml
@@ -90,7 +90,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_pdb,
-				eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/wf/referenceextraction/pdb/data/document_to_pdb.json}</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-Idocument_to_pdb=${workingDir}/referenceextraction_pdb/document_to_pdb</arg>

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest_empty_input/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest_empty_input/oozie_app/workflow.xml
@@ -90,7 +90,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_pdb,
-				eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/wf/referenceextraction/pdb/data/empty.json}</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-Idocument_to_pdb=${workingDir}/referenceextraction_pdb/document_to_pdb</arg>

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest_without_references/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/sampletest_without_references/oozie_app/workflow.xml
@@ -90,7 +90,7 @@
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-C{document_to_pdb,
-				eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/wf/referenceextraction/pdb/data/empty.json}</arg>
 			<!-- All input and output ports have to be bound to paths in HDFS -->
 			<arg>-Idocument_to_pdb=${workingDir}/referenceextraction_pdb/document_to_pdb</arg>

--- a/iis-wf/iis-wf-transformers/src/test/resources/eu/dnetlib/iis/wf/transformers/export/communities/test/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-transformers/src/test/resources/eu/dnetlib/iis/wf/transformers/export/communities/test/oozie_app/workflow.xml
@@ -28,7 +28,7 @@
 			<main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
 			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.Producer</arg>
             <arg>-C{document_to_concept_id,
-				eu.dnetlib.iis.referenceextraction.community.schemas.DocumentToConceptId,
+				eu.dnetlib.iis.referenceextraction.common.schemas.DocumentToConceptId,
 				eu/dnetlib/iis/wf/transformers/export/communities/test/data/document_to_community_id.json}</arg>
             <arg>-Odocument_to_concept_id=${workingDir}/producer/output</arg>
         </java>


### PR DESCRIPTION
This merges Yannis' change being part of #1054 pull request merged with `openaire:marekhorst_1067_update_PDB_database_and_add_support_for_textsnippet_field` branch as it required to be supplemented with the set of changes on IIS side.

Those changes were required due to introducing `textsnippet` field returned by the mining script. Since we already had `DocumentToConceptId` schema version extended with `textsnippet` field defined for community mining I have decided to move it to `common` package and reuse the same schema in PDB case.

