### PR TITLE
Closes #1075: Make InfoSpace metadata importer module immune to missing values in complex Field objects

### DIFF
--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
@@ -1,6 +1,5 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
-import java.time.Year;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -125,9 +124,9 @@ public class DatasetMetadataConverter implements OafEntityToAvroConverter<Result
     private void handleYear(Field<String> dateOfAcceptance, DataSetReference.Builder metaBuilder) {
         if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
                 && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
-            Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
+            Integer year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
-                metaBuilder.setPublicationYear(year.toString());
+                metaBuilder.setPublicationYear(String.valueOf(year));
             }
         }    
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
@@ -1,5 +1,6 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
+import java.time.Year;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -124,9 +125,9 @@ public class DatasetMetadataConverter implements OafEntityToAvroConverter<Result
     private void handleYear(Field<String> dateOfAcceptance, DataSetReference.Builder metaBuilder) {
         if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
                 && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
-            Integer year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
+            Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
-                metaBuilder.setPublicationYear(String.valueOf(year));
+                metaBuilder.setPublicationYear(year.toString());
             }
         }    
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
@@ -123,7 +123,8 @@ public class DatasetMetadataConverter implements OafEntityToAvroConverter<Result
     }
     
     private void handleYear(Field<String> dateOfAcceptance, DataSetReference.Builder metaBuilder) {
-        if (dateOfAcceptance!= null && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
+        if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
+                && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
             Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
                 metaBuilder.setPublicationYear(year.toString());

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
@@ -108,6 +108,7 @@ public class DocumentMetadataConverter implements OafEntityToAvroConverter<Resul
 
             titleList.stream().filter(x -> Objects.nonNull(x.getQualifier()))
                     .filter(x -> InfoSpaceConstants.SEMANTIC_CLASS_MAIN_TITLE.equals(x.getQualifier().getClassid()))
+                    .filter(x -> StringUtils.isNotBlank(x.getValue()))
                     .filter(x -> fieldApprover.approve(x.getDataInfo())).findFirst()
                     .ifPresent(x -> metaBuilder.setTitle(x.getValue()));
 
@@ -150,7 +151,8 @@ public class DocumentMetadataConverter implements OafEntityToAvroConverter<Resul
     }
     
     private void handleYear(Field<String> dateOfAcceptance, DocumentMetadata.Builder metaBuilder) {
-        if (dateOfAcceptance != null && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
+        if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
+                && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
             Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
                 metaBuilder.setYear(year.getValue());

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
@@ -1,6 +1,7 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
 import java.io.IOException;
+import java.time.Year;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -152,9 +153,9 @@ public class DocumentMetadataConverter implements OafEntityToAvroConverter<Resul
     private void handleYear(Field<String> dateOfAcceptance, DocumentMetadata.Builder metaBuilder) {
         if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
                 && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
-            Integer year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
+            Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
-                metaBuilder.setYear(year);
+                metaBuilder.setYear(year.getValue());
             }
         }    
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
@@ -1,7 +1,6 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
 import java.io.IOException;
-import java.time.Year;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -153,9 +152,9 @@ public class DocumentMetadataConverter implements OafEntityToAvroConverter<Resul
     private void handleYear(Field<String> dateOfAcceptance, DocumentMetadata.Builder metaBuilder) {
         if (dateOfAcceptance != null && StringUtils.isNotBlank(dateOfAcceptance.getValue())
                 && fieldApprover.approve(dateOfAcceptance.getDataInfo())) {
-            Year year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
+            Integer year = MetadataConverterUtils.extractYearOrNull(dateOfAcceptance.getValue(), log);
             if (year != null) {
-                metaBuilder.setYear(year.getValue());
+                metaBuilder.setYear(year);
             }
         }    
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -1,7 +1,5 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
-import java.time.Year;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,13 +36,17 @@ public abstract class MetadataConverterUtils {
     }
     
     /**
-     * Extracts year out of the date defined in yyyy-MM-dd format.
+     * Extracts year out of the date defined in yyyy-MM-dd with possible single digit month and day part.
      */
-    public static Year extractYearOrNull(String date, Logger log) {
-        try {
-            return Year.parse(date, DateTimeFormatter.ISO_LOCAL_DATE);
-        } catch (Exception e) {
-            log.warn("unsupported, non integer, format of year value: " + date);
+    public static Integer extractYearOrNull(String date, Logger log) {
+        if (StringUtils.isNotBlank(date) && date.indexOf('-') == 4) {
+            try {
+                return Integer.valueOf(date.substring(0, date.indexOf('-')));    
+            } catch (NumberFormatException e) {
+                log.warn("unsupported, non integer, format of year value: " + date);
+                return null;
+            }
+        } else {
             return null;
         }
     }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -2,9 +2,9 @@ package eu.dnetlib.iis.wf.importer.infospace.converter;
 
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
@@ -26,12 +26,14 @@ public abstract class MetadataConverterUtils {
     /**
      * Extracts values from {@link StructuredProperty} list. Checks DataInfo
      * element whether this piece of information should be approved.
+     * Does not accept null fieldApprover or source collection. Skips null values stored in this collection.
      * 
      */
     public static List<String> extractValues(Collection<StructuredProperty> source, FieldApprover fieldApprover) {
         return source.stream()
                 .filter(x -> fieldApprover.approve(x.getDataInfo()))
                 .map(StructuredProperty::getValue)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
     
@@ -41,7 +43,7 @@ public abstract class MetadataConverterUtils {
     public static Year extractYearOrNull(String date, Logger log) {
         try {
             return Year.parse(date, DateTimeFormatter.ISO_LOCAL_DATE);
-        } catch (DateTimeParseException e) {
+        } catch (Exception e) {
             log.warn("unsupported, non integer, format of year value: " + date);
             return null;
         }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -1,5 +1,8 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,17 +41,20 @@ public abstract class MetadataConverterUtils {
     /**
      * Extracts year out of the date defined in yyyy-MM-dd with possible single digit month and day part.
      */
-    public static Integer extractYearOrNull(String date, Logger log) {
-        if (StringUtils.isNotBlank(date) && date.indexOf('-') == 4) {
-            try {
-                return Integer.valueOf(date.substring(0, date.indexOf('-')));    
-            } catch (NumberFormatException e) {
-                log.warn("unsupported, non integer, format of year value: " + date);
-                return null;
+    public static Year extractYearOrNull(String date, Logger log) {
+        if (StringUtils.isNotBlank(date)) {
+            if (date.indexOf('-') == 4) {
+                try {
+                    return Year.parse(date.substring(0, date.indexOf('-')), DateTimeFormatter.ofPattern("yyyy"));
+                } catch (DateTimeParseException e) {
+                    log.warn("unsupported, non integer, format of year value: " + date);
+                    return null;
+                }
+            } else {
+                log.warn("unsupported format of year value: " + date);
             }
-        } else {
-            return null;
         }
+        return null;
     }
     
 }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -4,9 +4,9 @@ import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
@@ -26,14 +26,14 @@ public abstract class MetadataConverterUtils {
     /**
      * Extracts values from {@link StructuredProperty} list. Checks DataInfo
      * element whether this piece of information should be approved.
-     * Does not accept null fieldApprover or source collection. Skips null values stored in this collection.
+     * Does not accept null fieldApprover or source collection. Skips null and empty values stored in this collection.
      * 
      */
     public static List<String> extractValues(Collection<StructuredProperty> source, FieldApprover fieldApprover) {
         return source.stream()
                 .filter(x -> fieldApprover.approve(x.getDataInfo()))
                 .map(StructuredProperty::getValue)
-                .filter(Objects::nonNull)
+                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toList());
     }
     

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/OrganizationConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/OrganizationConverter.java
@@ -43,13 +43,13 @@ public class OrganizationConverter implements OafEntityToAvroConverter<eu.dnetli
         
         orgBuilder.setName(srcOrganization.getLegalname().getValue());
         
-        orgBuilder.setShortName(srcOrganization.getLegalshortname().getValue());
+        orgBuilder.setShortName(srcOrganization.getLegalshortname() != null ? srcOrganization.getLegalshortname().getValue() : null);    
      
-        orgBuilder.setCountryName(srcOrganization.getCountry().getClassname());
-        
-        orgBuilder.setCountryCode(srcOrganization.getCountry().getClassid());
-        
-        orgBuilder.setWebsiteUrl(srcOrganization.getWebsiteurl().getValue());
+        orgBuilder.setCountryName(srcOrganization.getCountry() != null ? srcOrganization.getCountry().getClassname() : null);
+
+        orgBuilder.setCountryCode(srcOrganization.getCountry() != null ? srcOrganization.getCountry().getClassid() : null);
+     
+        orgBuilder.setWebsiteUrl(srcOrganization.getWebsiteurl() != null ? srcOrganization.getWebsiteurl().getValue(): null);    
         
         return orgBuilder.build();
         

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverterTest.java
@@ -147,6 +147,22 @@ public class DatasetMetadataConverterTest {
     }
     
     @Test
+    public void convert_null_date_of_acceptance() {
+     // given
+        Result sourceDataset = documentEntity(EXT_IDENTIFIERS);
+        sourceDataset.getDateofacceptance().setValue(null);
+        
+        // execute
+        DataSetReference metadata = converter.convert(sourceDataset);
+
+        // assert
+        assertNotNull(metadata);
+        assertEquals(ID, metadata.getId());
+        
+        assertNull(metadata.getPublicationYear());
+    }
+    
+    @Test
     public void convert_not_approved() {
         // given
         Result sourceDataset = documentEntity(EXT_IDENTIFIERS);

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverterTest.java
@@ -1,6 +1,8 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -91,6 +93,21 @@ public class DocumentMetadataConverterTest {
         // assert
         assertEquals(TITLE, metadata.getTitle());
     }
+    
+    @Test
+    public void convert_using_null_main_title_and_not_null_other_title() throws IOException {
+     // given
+        Publication publication = minimalEntityBuilder(ID, InfoSpaceConstants.SEMANTIC_CLASS_INSTANCE_TYPE_ARTICLE);
+
+        addTitle(publication, OTHER_TITLE);
+        addTitle(publication, null, InfoSpaceConstants.SEMANTIC_CLASS_MAIN_TITLE);
+
+        // execute
+        DocumentMetadata metadata = converter.convert(publication);
+
+        // assert
+        assertEquals(OTHER_TITLE, metadata.getTitle());
+    }
 
     @Test
     public void convert_using_first_title() throws IOException {
@@ -105,6 +122,22 @@ public class DocumentMetadataConverterTest {
 
         // assert
         assertEquals(OTHER_TITLE, metadata.getTitle());
+    }
+    
+    @Test
+    public void convert_null_date_of_acceptance() throws IOException {
+        // given
+        Publication oafEntity = documentEntity();
+        oafEntity.getDateofacceptance().setValue(null);
+        
+        // execute
+        DocumentMetadata metadata = converter.convert(oafEntity);
+
+        // assert
+        assertNotNull(metadata);
+        assertEquals(ID, metadata.getId());
+        
+        assertNull(metadata.getYear());
     }
 
     @Test

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import java.time.Year;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.junit.Test;
@@ -30,12 +31,12 @@ public class MetadataConverterUtilsTest {
     private Logger log = mock(Logger.class);
     
     @Test
-    public void testExtractYearOrNullWithValidInput() throws Exception {
+    public void testExtractYearOrNullWithValidInput() {
         assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
     }
     
     @Test
-    public void testExtractYearOrNullWithInvalidInput() throws Exception {
+    public void testExtractYearOrNullWithInvalidInput() {
         assertNull(MetadataConverterUtils.extractYearOrNull("invalid", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("20-20-01", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("2020-01", log));
@@ -45,7 +46,7 @@ public class MetadataConverterUtilsTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void testExtractValuesForNullApprover() throws Exception {
+    public void testExtractValuesForNullApprover() {
         // given
         Collection<StructuredProperty> source = Lists.newArrayList();
         String validValue = "someValue";
@@ -56,12 +57,12 @@ public class MetadataConverterUtilsTest {
     }
     
     @Test(expected = NullPointerException.class)
-    public void testExtractValuesForNullSource() throws Exception {
+    public void testExtractValuesForNullSource() {
         MetadataConverterUtils.extractValues(null, mock(FieldApprover.class));
     }
     
     @Test
-    public void testExtractValuesForEmptySource() throws Exception {
+    public void testExtractValuesForEmptySource() {
         //execute
         List<String> results = MetadataConverterUtils.extractValues(Lists.newArrayList(), mock(FieldApprover.class));
         
@@ -71,20 +72,15 @@ public class MetadataConverterUtilsTest {
     }
     
     @Test
-    public void testExtractValues() throws Exception {
+    public void testExtractValues() {
         // given
-        @SuppressWarnings("serial")
-        FieldApprover notNullDataInfoFieldApprover = new FieldApprover() {
-            @Override
-            public boolean approve(DataInfo dataInfo) {
-                return dataInfo != null;
-            }
-        };
+        FieldApprover notNullDataInfoFieldApprover = Objects::nonNull;
         DataInfo dataInfo = new DataInfo();
         Collection<StructuredProperty> source = Lists.newArrayList();
         String validValue = "someValue";
         source.add(generateStructuredProperty(validValue, dataInfo));
         source.add(generateStructuredProperty(null, dataInfo));
+        source.add(generateStructuredProperty("", dataInfo));
         source.add(generateStructuredProperty("toBeRejectedBecauseOfNullDataInfo", null));
         
         // execute

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.time.Year;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -31,9 +32,9 @@ public class MetadataConverterUtilsTest {
     
     @Test
     public void testExtractYearOrNullWithValidInput() {
-        assertEquals(Integer.valueOf(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
-        assertEquals(Integer.valueOf(2010), MetadataConverterUtils.extractYearOrNull("2010-1-1", log));
-        assertEquals(Integer.valueOf(1900), MetadataConverterUtils.extractYearOrNull("1900-2", log));
+        assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
+        assertEquals(Year.of(2010), MetadataConverterUtils.extractYearOrNull("2010-1-1", log));
+        assertEquals(Year.of(1900), MetadataConverterUtils.extractYearOrNull("1900-2", log));
     }
     
     @Test

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -1,0 +1,106 @@
+package eu.dnetlib.iis.wf.importer.infospace.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.time.Year;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+import eu.dnetlib.dhp.schema.oaf.DataInfo;
+import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
+import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
+
+/**
+ * {@link MetadataConverterUtils} test class. 
+ * 
+ * @author mhorst
+ *
+ */
+public class MetadataConverterUtilsTest {
+
+    private Logger log = mock(Logger.class);
+    
+    @Test
+    public void testExtractYearOrNullWithValidInput() throws Exception {
+        assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
+    }
+    
+    @Test
+    public void testExtractYearOrNullWithInvalidInput() throws Exception {
+        assertNull(MetadataConverterUtils.extractYearOrNull("invalid", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull("20-20-01", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull("2020-01", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull("2020-01-1", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull("", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull(null, log));
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testExtractValuesForNullApprover() throws Exception {
+        // given
+        Collection<StructuredProperty> source = Lists.newArrayList();
+        String validValue = "someValue";
+        source.add(generateStructuredProperty(validValue, null));
+        
+        // execute
+        MetadataConverterUtils.extractValues(source, null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testExtractValuesForNullSource() throws Exception {
+        MetadataConverterUtils.extractValues(null, mock(FieldApprover.class));
+    }
+    
+    @Test
+    public void testExtractValuesForEmptySource() throws Exception {
+        //execute
+        List<String> results = MetadataConverterUtils.extractValues(Lists.newArrayList(), mock(FieldApprover.class));
+        
+        //assert
+        assertNotNull(results);
+        assertTrue(results.isEmpty());
+    }
+    
+    @Test
+    public void testExtractValues() throws Exception {
+        // given
+        @SuppressWarnings("serial")
+        FieldApprover notNullDataInfoFieldApprover = new FieldApprover() {
+            @Override
+            public boolean approve(DataInfo dataInfo) {
+                return dataInfo != null;
+            }
+        };
+        DataInfo dataInfo = new DataInfo();
+        Collection<StructuredProperty> source = Lists.newArrayList();
+        String validValue = "someValue";
+        source.add(generateStructuredProperty(validValue, dataInfo));
+        source.add(generateStructuredProperty(null, dataInfo));
+        source.add(generateStructuredProperty("toBeRejectedBecauseOfNullDataInfo", null));
+        
+        // execute
+        List<String> results = MetadataConverterUtils.extractValues(source, notNullDataInfoFieldApprover);
+        
+        // assert
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertEquals(validValue, results.get(0));
+    }
+
+    private static StructuredProperty generateStructuredProperty(String value, DataInfo dataInfo) {
+        StructuredProperty structProp = new StructuredProperty();
+        structProp.setValue(value);
+        structProp.setDataInfo(dataInfo);
+        return structProp;
+    }
+    
+}

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.time.Year;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -32,15 +31,15 @@ public class MetadataConverterUtilsTest {
     
     @Test
     public void testExtractYearOrNullWithValidInput() {
-        assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
+        assertEquals(Integer.valueOf(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
+        assertEquals(Integer.valueOf(2010), MetadataConverterUtils.extractYearOrNull("2010-1-1", log));
+        assertEquals(Integer.valueOf(1900), MetadataConverterUtils.extractYearOrNull("1900-2", log));
     }
     
     @Test
     public void testExtractYearOrNullWithInvalidInput() {
         assertNull(MetadataConverterUtils.extractYearOrNull("invalid", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("20-20-01", log));
-        assertNull(MetadataConverterUtils.extractYearOrNull("2020-01", log));
-        assertNull(MetadataConverterUtils.extractYearOrNull("2020-01-1", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("", log));
         assertNull(MetadataConverterUtils.extractYearOrNull(null, log));
     }

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/OrganizationConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/OrganizationConverterTest.java
@@ -93,6 +93,37 @@ public class OrganizationConverterTest {
         
     }
 
+    @Test
+    public void buildObject_legal_short_name_null() throws Exception {
+        
+        //given
+        Qualifier country = new Qualifier();
+        country.setClassid("PL");
+        country.setClassname("Poland");
+
+        eu.dnetlib.dhp.schema.oaf.Organization organization = createOafObject(country,
+                createStringField("Interdyscyplinary Centre"), null,
+                createStringField("www.icm.edu.pl"));
+        
+        // execute 
+        
+        Organization org = converter.convert(organization);
+        
+        
+        // assert
+        
+        assertNotNull(org);
+        
+        assertEquals("Interdyscyplinary Centre", org.getName());
+        assertNull(org.getShortName());
+        assertEquals("Poland", org.getCountryName());
+        assertEquals("PL", org.getCountryCode());
+        assertEquals("www.icm.edu.pl", org.getWebsiteUrl());
+        
+        verifyZeroInteractions(log);
+        
+    }
+    
     
     //------------------------ PRIVATE --------------------------
     


### PR DESCRIPTION
This PR introduces additional checks when importing InfoSpace metadata from the graph. 