### PR TITLE
Closes #1086: Accept non-standard date of acceptance format in DocumentMetadataConverter

### DIFF
--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -39,22 +39,26 @@ public abstract class MetadataConverterUtils {
     }
     
     /**
-     * Extracts year out of the date defined in yyyy-MM-dd with possible single digit month and day part.
+     * Extracts year out of the date defined in 'yyyy' or 'yyyy-MM-dd' format with possible single digit month and day part.
      */
     public static Year extractYearOrNull(String date, Logger log) {
         if (StringUtils.isNotBlank(date)) {
-            if (date.indexOf('-') == 4) {
-                try {
-                    return Year.parse(date.substring(0, date.indexOf('-')), DateTimeFormatter.ofPattern("yyyy"));
-                } catch (DateTimeParseException e) {
-                    log.warn("unsupported, non integer, format of year value: " + date);
-                    return null;
-                }
-            } else {
-                log.warn("unsupported format of year value: " + date);
-            }
+            return parseYearOrGetNull(date.indexOf('-') == 4 ? date.substring(0, date.indexOf('-')) : date, log);
+        } else {
+            return null;    
         }
-        return null;
+    }
+    
+    /**
+     * Parses year privided in 'yyyy' format. Returns null whenever year defined in an invalid format.
+     */
+    private static Year parseYearOrGetNull(String year, Logger log) {
+        try {
+            return Year.parse(year, DateTimeFormatter.ofPattern("yyyy"));
+        } catch (DateTimeParseException e) {
+            log.warn("unsupported, non 'yyyy', format of year value: " + year);
+            return null;
+        }
     }
     
 }

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -35,11 +35,13 @@ public class MetadataConverterUtilsTest {
         assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020-12-31", log));
         assertEquals(Year.of(2010), MetadataConverterUtils.extractYearOrNull("2010-1-1", log));
         assertEquals(Year.of(1900), MetadataConverterUtils.extractYearOrNull("1900-2", log));
+        assertEquals(Year.of(2020), MetadataConverterUtils.extractYearOrNull("2020", log));
     }
     
     @Test
     public void testExtractYearOrNullWithInvalidInput() {
         assertNull(MetadataConverterUtils.extractYearOrNull("invalid", log));
+        assertNull(MetadataConverterUtils.extractYearOrNull("20200304", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("20-20-01", log));
         assertNull(MetadataConverterUtils.extractYearOrNull("", log));
         assertNull(MetadataConverterUtils.extractYearOrNull(null, log));


### PR DESCRIPTION
Accepting `yyyy` date format.