### PR TITLE
Fix 'UnicodeDecodeError' in madis

### DIFF
--- a/iis-3rdparty-madis/src/main/resources/eu/dnetlib/iis/3rdparty/scripts/madis/mexec.py
+++ b/iis-3rdparty-madis/src/main/resources/eu/dnetlib/iis/3rdparty/scripts/madis/mexec.py
@@ -6,6 +6,7 @@ import sys
 import apsw
 import madis
 import json
+import io
 
 def exitwitherror(txt):
     sys.stderr.write(txt+'\n')
@@ -61,7 +62,7 @@ def main():
         sys.exit(1)
 
     try:
-        f = open(flowname,'r')
+        f = io.open(flowname, mode='r', encoding='utf-8')
     except Exception, e:
         exitwitherror("Error in opening SQL flow: " + str(e))
 


### PR DESCRIPTION
This error appears when parsing statements with unicode characters from an SQL-flow in 'mexec.py'.

Reflects the update in madis: https://github.com/madgik/madis/pull/12

This PR must be merged before the canadian-mining update: https://github.com/openaire/iis/pull/1093