### PR TITLE
Closes #1104: Increase mapreduce.task.timeout for all referenceextraction modules to 12h

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/community/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/community/main_sqlite/oozie_app/workflow.xml
@@ -104,7 +104,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>14400000</value>
+					<value>43200000</value>
 				</property>
                 <property>
                     <name>oozie.action.external.stats.write</name>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/covid19/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/covid19/main/oozie_app/workflow.xml
@@ -167,7 +167,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>7200000</value>
+					<value>43200000</value>
 				</property>
                 <property>
                     <name>oozie.action.external.stats.write</name>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/datacite/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/datacite/main_sqlite/oozie_app/workflow.xml
@@ -115,7 +115,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>14400000</value>
+					<value>43200000</value>
 				</property>
 				
                 <property>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/opentrials/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/dataset/opentrials/main_sqlite/oozie_app/workflow.xml
@@ -115,7 +115,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>14400000</value>
+					<value>43200000</value>
 				</property>
 				
                 <property>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/patent/main_sqlite/oozie_app/workflow.xml
@@ -93,7 +93,7 @@
                 <!-- this one is required due to the large amount of time taken by process storing plaintexts into the database -->
                 <property>
                     <name>mapreduce.task.timeout</name>
-                    <value>14400000</value>
+                    <value>43200000</value>
                 </property>
             </configuration>
             <file>${input_patent_db}#patent.db</file>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/pdb/main/oozie_app/workflow.xml
@@ -102,7 +102,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>7200000</value>
+					<value>43200000</value>
 				</property>
             </configuration>
             

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/main_sqlite/oozie_app/workflow.xml
@@ -106,7 +106,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>28800000</value>
+					<value>43200000</value>
 				</property>
                 <property>
                     <name>oozie.action.external.stats.write</name>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/tara_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/tara_sqlite/oozie_app/workflow.xml
@@ -104,7 +104,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>28800000</value>
+					<value>43200000</value>
 				</property>
                 <property>
                     <name>oozie.action.external.stats.write</name>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main_sqlite/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/researchinitiative/main_sqlite/oozie_app/workflow.xml
@@ -106,7 +106,7 @@
 					by process storing plaintexts into the database -->
 				<property>
 					<name>mapreduce.task.timeout</name>
-					<value>14400000</value>
+					<value>43200000</value>
 				</property>
             </configuration>
             <file>${input_researchinitiative_db}#researchinitiative.db</file>

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
@@ -181,7 +181,7 @@
                 <!-- this one is requred due to the large amount of time taken by process storing plaintexts into the database -->
                 <property>
                     <name>mapreduce.task.timeout</name>
-                    <value>7200000</value>
+                    <value>43200000</value>
                 </property>
             </configuration>
 
@@ -283,7 +283,7 @@
                 <!-- this one is requred due to the large amount of time taken by process storing plaintexts into the database -->
                 <property>
                     <name>mapreduce.task.timeout</name>
-                    <value>7200000</value>
+                    <value>43200000</value>
                 </property>
             </configuration>
             <file>${input_softwareheritage_origins_db}#origins.db</file>


### PR DESCRIPTION
The urgent need was for research-initatives but I have decided to align also all the other reference extraction modules.