### PR TITLE
Closes #1111: Increase default timeout for integration tests

### DIFF
--- a/iis-common/src/test/java/eu/dnetlib/iis/common/OozieWorkflowTestConfiguration.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/OozieWorkflowTestConfiguration.java
@@ -15,7 +15,7 @@ import com.google.common.collect.Lists;
  */
 public class OozieWorkflowTestConfiguration {
 	
-	public static final int defaultTimeoutInSeconds = 360;
+	public static final int defaultTimeoutInSeconds = 600;
 	public static final WorkflowJob.Status defaultExpectedFinishStatus = 
 			WorkflowJob.Status.SUCCEEDED;
 	


### PR DESCRIPTION
Increasing default timeout value from `360` to `600`. Updating individual tests will be quite tedious and probably the workflows are now much more complex than in the very beginning when we decided to go with 6 minutes.