### PR TITLE
Closes #1106: Deduplicate contents by checksum

### DIFF
--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/import.txt
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/import.txt
@@ -1,4 +1,5 @@
 ## This is a classpath-based import file (this header is required)
 import_content_url_core classpath eu/dnetlib/iis/wf/importer/content_url/core/oozie_app
+import_content_url_dedup classpath eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app
 transformers_idreplacer classpath eu/dnetlib/iis/wf/transformers/idreplacer/oozie_app
 transformers_common_existencefilter classpath eu/dnetlib/iis/wf/transformers/common/existencefilter/oozie_app

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/workflow.xml
@@ -267,10 +267,30 @@
                 </property>
 			</configuration>
         </sub-workflow>
-		<ok to="content-url-dispatcher" />
+		<ok to="content-url-dedup" />
 		<error to="fail" />
 	</action>
 	
+    <action name="content-url-dedup">
+        <sub-workflow>
+            <app-path>${wf:appPath()}/import_content_url_dedup</app-path>
+            <propagate-configuration/>
+            <configuration>
+                <property>
+                    <name>input</name>
+                    <value>${wf:actionData('input_id-path-setter')['result']}</value>
+                </property>
+                <property>
+                    <name>output</name>
+                    <value>${workingDir}/document_content_url_deduped/output</value>
+                </property>
+            </configuration>
+        </sub-workflow>
+        <ok to="content-url-dispatcher" />
+        <error to="fail" />
+    </action>
+    
+    
 	<action name="content-url-dispatcher">
 		<map-reduce>
 			<prepare>
@@ -391,7 +411,7 @@
 				</property>
 				<property>
 					<name>mapreduce.input.fileinputformat.inputdir</name>
-					<value>${wf:actionData('input_id-path-setter')['result']}</value>
+					<value>${workingDir}/document_content_url_deduped/output</value>
 				</property>
 				<property>
 					<name>mapreduce.output.fileoutputformat.outputdir</name>

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app/lib/scripts/dedup.pig
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app/lib/scripts/dedup.pig
@@ -1,0 +1,14 @@
+define AVRO_LOAD_DATA AvroStorage('$schema_data');
+
+define AVRO_STORE_DATA AvroStorage('$schema_data', '-doublecolons');
+
+data = load '$input' using AVRO_LOAD_DATA;
+
+grouped = GROUP data BY (id, contentChecksum);
+
+deduped = FOREACH grouped {
+      top_rec = LIMIT data 1;
+      GENERATE FLATTEN(top_rec);
+};
+
+store deduped into '$output' using AVRO_STORE_DATA;

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app/workflow.xml
@@ -1,0 +1,62 @@
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="content_url_dedup">
+    <parameters>
+        <property>
+            <name>input</name>
+            <description>eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl avro records to be deduplicated by id and content checksum</description>
+        </property>
+        <property>
+            <name>output</name>
+            <description>deduplicated eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl avro records</description>
+        </property>
+    </parameters>
+    
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapreduce.job.queuename</name>
+                <value>${queueName}</value>
+            </property>
+            <property>
+                <name>oozie.launcher.mapred.job.queue.name</name>
+                <value>${oozieLauncherQueueName}</value>
+            </property>
+        </configuration>
+    </global>
+    
+    
+    <start to="generate-schema"/>
+    
+    <action name="generate-schema">
+	    <java>
+	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
+	        <arg>eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl</arg>
+	        <capture-output />
+	    </java>
+	    <ok to="dedup" />
+	    <error to="fail" />
+	</action>
+	
+    <action name="dedup">
+        <pig>
+            <prepare>
+                <delete path="${nameNode}${output}" />
+            </prepare>
+            <script>lib/scripts/dedup.pig</script>
+            <param>input=${input}</param>
+            <param>output=${output}</param>
+            <param>schema_data=${wf:actionData('generate-schema')['eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl']}</param>
+        </pig>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+
+    <kill name="fail">
+        <message>Unfortunately, the workflow failed -- error message:
+            [${wf:errorMessage(wf:lastErrorNode())}]</message>
+    </kill>
+
+    <end name="end"/>
+
+</workflow-app>

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/content/WorkflowTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/content/WorkflowTest.java
@@ -29,4 +29,11 @@ public class WorkflowTest extends AbstractOozieWorkflowTestCase {
         wfConf.setTimeoutInSeconds(720);
         testWorkflow("eu/dnetlib/iis/wf/importer/content_url/core/blacklisting", wfConf);
     }
+    
+    @Test
+    public void testContentUrlDedup() {
+        OozieWorkflowTestConfiguration wfConf = new OozieWorkflowTestConfiguration();
+        wfConf.setTimeoutInSeconds(720);
+        testWorkflow("eu/dnetlib/iis/wf/importer/content_url/dedup/sampletest", wfConf);
+    }
 }

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/data/input.json
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/data/input.json
@@ -1,0 +1,9 @@
+{"id": "id1", "url": "url1b", "mimeType": "text", "contentChecksum": "1111", "contentSizeKB": 10}
+{"id": "id1", "url": "url1c", "mimeType": "other", "contentChecksum": "1111", "contentSizeKB": 10}
+{"id": "id1", "url": "url1a", "mimeType": "application/pdf", "contentChecksum": "1111", "contentSizeKB": 1}
+{"id": "id1", "url": "url1d", "mimeType": null, "contentChecksum": "1b1b", "contentSizeKB": 10}
+{"id": "id2", "url": "url2", "mimeType": "application/pdf", "contentChecksum": "2222", "contentSizeKB": 20}
+{"id": "id3", "url": "url3", "mimeType": "application/pdf", "contentChecksum": "3333", "contentSizeKB": 30}
+{"id": "id3", "url": "url3", "mimeType": "application/pdf", "contentChecksum": "3b3b", "contentSizeKB": 30}
+{"id": "id3", "url": "url3", "mimeType": null, "contentChecksum": null, "contentSizeKB": 30}
+{"id": "id4", "url": "url4", "mimeType": "application/pdf", "contentChecksum": "1111", "contentSizeKB": 30}

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/data/output.json
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/data/output.json
@@ -1,0 +1,7 @@
+{"id": "id1", "url": "url1a", "mimeType": "application/pdf", "contentChecksum": "1111", "contentSizeKB": 1}
+{"id": "id1", "url": "url1d", "mimeType": null, "contentChecksum": "1b1b", "contentSizeKB": 10}
+{"id": "id2", "url": "url2", "mimeType": "application/pdf", "contentChecksum": "2222", "contentSizeKB": 20}
+{"id": "id3", "url": "url3", "mimeType": "application/pdf", "contentChecksum": "3333", "contentSizeKB": 30}
+{"id": "id3", "url": "url3", "mimeType": "application/pdf", "contentChecksum": "3b3b", "contentSizeKB": 30}
+{"id": "id3", "url": "url3", "mimeType": null, "contentChecksum": null, "contentSizeKB": 30}
+{"id": "id4", "url": "url4", "mimeType": "application/pdf", "contentChecksum": "1111", "contentSizeKB": 30}

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/sampletest/oozie_app/import.txt
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/sampletest/oozie_app/import.txt
@@ -1,0 +1,2 @@
+## This is a classpath-based import file (this header is required)
+import_content_url_dedup classpath eu/dnetlib/iis/wf/importer/content_url/dedup/oozie_app

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/sampletest/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/content_url/dedup/sampletest/oozie_app/workflow.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="test-importer_content_url_dedup_sampletest">
+
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapreduce.job.queuename</name>
+                <value>${queueName}</value>
+            </property>
+            <property>
+                <name>oozie.launcher.mapred.job.queue.name</name>
+                <value>${oozieLauncherQueueName}</value>
+            </property>
+        </configuration>
+    </global>
+    
+	<start to="producer"/>
+    
+    <action name="producer">
+        <java>
+            <prepare>
+                <delete path="${nameNode}${workingDir}/producer" />
+                <mkdir path="${nameNode}${workingDir}/producer" />
+            </prepare>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.common.java.jsonworkflownodes.Producer</arg>
+            <arg>-C{document_content_url,
+                eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl,
+                eu/dnetlib/iis/wf/importer/content_url/dedup/data/input.json}</arg>
+            <arg>-Odocument_content_url=${workingDir}/producer/document_content_url</arg>
+        </java>
+        <ok to="import_content_url_dedup"/>
+        <error to="fail"/>
+    </action>
+    
+    <action name="import_content_url_dedup">
+        <sub-workflow>
+            <app-path>${wf:appPath()}/import_content_url_dedup</app-path>
+            <propagate-configuration />
+            <configuration>
+                <property>
+                    <name>input</name>
+                    <value>${workingDir}/producer/document_content_url</value>
+                </property>
+                <property>
+                    <name>output</name>
+                    <value>${workingDir}/out</value>
+                </property>
+            </configuration>
+        </sub-workflow>
+        <ok to="consumer" />
+        <error to="fail" />
+    </action>
+
+	<action name="consumer">
+        <java>
+            <!-- This is simple wrapper for the Java code -->
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <!-- The business Java code that gets to be executed -->
+            <arg>eu.dnetlib.iis.common.java.jsonworkflownodes.TestingConsumer</arg>
+            <!-- All input and output ports have to be bound to paths in HDFS -->
+            <arg>-C{deduped,
+                eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl,
+                eu/dnetlib/iis/wf/importer/content_url/dedup/data/output.json}</arg>
+            <arg>-Ideduped=${workingDir}/out</arg>
+        </java>
+        <ok to="end" />
+        <error to="fail" />
+    </action>
+
+    <kill name="fail">
+        <message>Unfortunately, the process failed -- error message: [${wf:errorMessage(wf:lastErrorNode())}]</message>
+    </kill>
+
+    <end name="end"/>
+</workflow-app>


### PR DESCRIPTION
Deduplication is done by grouping records by id and content checksum and is performed by the dedicated PIG script defined as one of the `content_url/chain` phases (after identifiers mapping and filtering, before dispatching by mime-type). 

An alternative solution was to either make it a part of already defined phases or reimplement whole `content_url/chain` submodules in spark. None of already existing modules was a good candidate to incorporate deduplication into (due to a pretty well defined expectations against those modules) while reimplementing whole workflow as a spark job would take a massive amount of time without any significant performance-gain. Whole `content_url/chain` chain takes 26 mins to process the data and the most time consuming subpart is ObjectStore metadata import (19 mins) while the transformations which could be a subject for refactoring take 7 minutes.