### PR TITLE
Closes #1132: Fix http connection pool handling

### DIFF
--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporterTest.java
@@ -38,10 +38,10 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +78,7 @@ public class SoftwareHeritageOriginsImporterTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
     
     @Mock
-    private HttpClient httpClient;
+    private CloseableHttpClient httpClient;
     
     @Mock
     private DataFileWriter<SoftwareHeritageOrigin> originWriter;
@@ -144,7 +144,7 @@ public class SoftwareHeritageOriginsImporterTest {
     @Test
     public void testPrepareNextRequestUrlNotNull() throws Exception {
         // given
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         Header header = new BasicHeader("Link", "</api/next>; rel=\"next\"");
         when(httpResponse.getAllHeaders()).thenReturn(new Header[] {header});
         
@@ -160,7 +160,7 @@ public class SoftwareHeritageOriginsImporterTest {
     @Test
     public void testPrepareNextRequestUrlIsNull() throws Exception {
         // given
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         when(httpResponse.getAllHeaders()).thenReturn(null);
         
         // execute
@@ -275,7 +275,7 @@ public class SoftwareHeritageOriginsImporterTest {
     public void testRunWithoutNextHeader() throws Exception {
         // given
         SoftwareHeritageOriginsImporter importer = initializeImporterParams("api/origins", "somehost.com", "https", "8080", "1");
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse);
         StatusLine statusLine = mock(StatusLine.class);
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
@@ -308,8 +308,8 @@ public class SoftwareHeritageOriginsImporterTest {
         // given
         SoftwareHeritageOriginsImporter importer = initializeImporterParams("api/origins", "somehost.com", "https", "8080", "1");
         
-        HttpResponse httpResponse = mock(HttpResponse.class);
-        HttpResponse httpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        CloseableHttpResponse httpResponse2 = mock(CloseableHttpResponse.class);
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse, httpResponse2);
 
         StatusLine statusLine = mock(StatusLine.class);
@@ -369,8 +369,8 @@ public class SoftwareHeritageOriginsImporterTest {
         SoftwareHeritageOriginsImporter importer = initializeImporterParams("api/origins", "somehost.com", "https", "8080", "1");
         this.parameters.put(IMPORT_SOFTWARE_HERITAGE_ENDPOINT_RATELIMIT_DELAY, "1");
         
-        HttpResponse httpResponse = mock(HttpResponse.class);
-        HttpResponse httpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        CloseableHttpResponse httpResponse2 = mock(CloseableHttpResponse.class);
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse, httpResponse2);
 
         Gson gson = new Gson();
@@ -426,8 +426,8 @@ public class SoftwareHeritageOriginsImporterTest {
         SoftwareHeritageOriginsImporter importer = initializeImporterParams("api/origins", "somehost.com", "https", "8080", "1");
         this.parameters.put(IMPORT_SOFTWARE_HERITAGE_ENDPOINT_RATELIMIT_DELAY, "1");
         
-        HttpResponse httpResponse = mock(HttpResponse.class);
-        HttpResponse httpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        CloseableHttpResponse httpResponse2 = mock(CloseableHttpResponse.class);
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse, httpResponse2);
 
         Gson gson = new Gson();
@@ -482,7 +482,7 @@ public class SoftwareHeritageOriginsImporterTest {
         SoftwareHeritageOriginsImporter importer = initializeImporterParams("api/origins", "somehost.com", "https", "8080", "1");
         this.parameters.put(IMPORT_SOFTWARE_HERITAGE_ENDPOINT_RETRY_COUNT, "0");
         
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         when(httpClient.execute(any(HttpHost.class),any(HttpGet.class))).thenReturn(httpResponse);
         
         StatusLine statusLine = mock(StatusLine.class);
@@ -616,7 +616,7 @@ public class SoftwareHeritageOriginsImporterTest {
             }
             
             @Override
-            protected HttpClient buildHttpClient(int connectionTimeout, int readTimeout) {
+            protected CloseableHttpClient buildHttpClient(int connectionTimeout, int readTimeout) {
                 return httpClient;
             }
             

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/OpenPatentWebServiceFacadeTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/OpenPatentWebServiceFacadeTest.java
@@ -21,12 +21,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -54,7 +55,7 @@ public class OpenPatentWebServiceFacadeTest {
     private final String opsUriRoot = "ops_uri"; 
     
     @Mock
-    private HttpClient httpClient;
+    private CloseableHttpClient httpClient;
 
     @Test
     public void testGetPatentMetadaUrl() throws Exception {
@@ -120,7 +121,7 @@ public class OpenPatentWebServiceFacadeTest {
     public void testReauthenticate() throws Exception {
         // given
         OpenPatentWebServiceFacade service = prepareValidService();
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         StatusLine statusLine = mock(StatusLine.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
         String accessToken = "someAccessToken";
@@ -147,7 +148,7 @@ public class OpenPatentWebServiceFacadeTest {
     public void testReauthenticateResultingNon200() throws Exception {
         // given
         OpenPatentWebServiceFacade service = prepareValidService();
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         StatusLine statusLine = mock(StatusLine.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
         
@@ -165,7 +166,7 @@ public class OpenPatentWebServiceFacadeTest {
     public void testGetSecurityToken() throws Exception {
         // given
         OpenPatentWebServiceFacade service = prepareValidService();
-        HttpResponse httpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         StatusLine statusLine = mock(StatusLine.class);
         HttpEntity httpEntity = mock(HttpEntity.class);
         String accessToken = "someAccessToken";
@@ -207,7 +208,7 @@ public class OpenPatentWebServiceFacadeTest {
         OpenPatentWebServiceFacade service = prepareValidService();
         
         // authentication mock
-        HttpResponse authnHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity = mock(HttpEntity.class);
         String accessToken = "someAccessToken";
@@ -222,7 +223,7 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity.getContent()).thenReturn(pageInputStream);
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity = mock(HttpEntity.class);
         when(getPatentHttpResponse.getStatusLine()).thenReturn(getPatentStatusLine);
@@ -255,7 +256,7 @@ public class OpenPatentWebServiceFacadeTest {
         Gson gson = new Gson();
         String pageContents = gson.toJson(new AuthenticationResponse(accessToken));
 
-        HttpResponse authnHttpResponse1 = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse1 = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity1 = mock(HttpEntity.class);
         
@@ -264,7 +265,7 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpResponse1.getEntity()).thenReturn(authnHttpEntity1);
         when(authnHttpEntity1.getContent()).thenReturn(new ByteArrayInputStream(pageContents.getBytes()));
         
-        HttpResponse authnHttpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse2 = mock(CloseableHttpResponse.class);
         HttpEntity authnHttpEntity2 = mock(HttpEntity.class);
         
         when(authnHttpResponse2.getStatusLine()).thenReturn(authnStatusLine);
@@ -272,12 +273,12 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity2.getContent()).thenReturn(new ByteArrayInputStream(pageContents.getBytes()));
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse1 = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse1 = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine1 = mock(StatusLine.class);
         when(getPatentHttpResponse1.getStatusLine()).thenReturn(getPatentStatusLine1);
         when(getPatentStatusLine1.getStatusCode()).thenReturn(400);
         
-        HttpResponse getPatentHttpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse2 = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine2 = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity2 = mock(HttpEntity.class);
         when(getPatentHttpResponse2.getStatusLine()).thenReturn(getPatentStatusLine2);
@@ -304,7 +305,7 @@ public class OpenPatentWebServiceFacadeTest {
         OpenPatentWebServiceFacade service = prepareValidService();
         
         // authentication mock
-        HttpResponse authnHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity = mock(HttpEntity.class);
         String accessToken = "someAccessToken";
@@ -319,7 +320,7 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity.getContent()).thenReturn(pageInputStream);
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine = mock(StatusLine.class);
         when(getPatentHttpResponse.getStatusLine()).thenReturn(getPatentStatusLine);
         when(getPatentStatusLine.getStatusCode()).thenReturn(404);
@@ -344,7 +345,7 @@ public class OpenPatentWebServiceFacadeTest {
         Gson gson = new Gson();
         String pageContents = gson.toJson(new AuthenticationResponse(accessToken));
 
-        HttpResponse authnHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity = mock(HttpEntity.class);
         
@@ -354,14 +355,14 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(pageContents.getBytes()));
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse1 = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse1 = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine1 = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity1 = mock(HttpEntity.class);
         when(getPatentHttpResponse1.getStatusLine()).thenReturn(getPatentStatusLine1);
         when(getPatentStatusLine1.getStatusCode()).thenReturn(403);
         when(getPatentHttpResponse1.getEntity()).thenReturn(getPatentHttpEntity1);
         
-        HttpResponse getPatentHttpResponse2 = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse2 = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine2 = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity2 = mock(HttpEntity.class);
         when(getPatentHttpResponse2.getStatusLine()).thenReturn(getPatentStatusLine2);
@@ -392,7 +393,7 @@ public class OpenPatentWebServiceFacadeTest {
         Gson gson = new Gson();
         String pageContents = gson.toJson(new AuthenticationResponse(accessToken));
 
-        HttpResponse authnHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity = mock(HttpEntity.class);
         
@@ -402,7 +403,7 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(pageContents.getBytes()));
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity = mock(HttpEntity.class);
         when(getPatentHttpResponse.getStatusLine()).thenReturn(getPatentStatusLine);
@@ -423,7 +424,7 @@ public class OpenPatentWebServiceFacadeTest {
         OpenPatentWebServiceFacade service = prepareValidService();
         
         // authentication mock
-        HttpResponse authnHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse authnHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine authnStatusLine = mock(StatusLine.class);
         HttpEntity authnHttpEntity = mock(HttpEntity.class);
         String accessToken = "someAccessToken";
@@ -438,7 +439,7 @@ public class OpenPatentWebServiceFacadeTest {
         when(authnHttpEntity.getContent()).thenReturn(pageInputStream);
         
         // metadata retrieval mock
-        HttpResponse getPatentHttpResponse = mock(HttpResponse.class);
+        CloseableHttpResponse getPatentHttpResponse = mock(CloseableHttpResponse.class);
         StatusLine getPatentStatusLine = mock(StatusLine.class);
         HttpEntity getPatentHttpEntity = mock(HttpEntity.class);
         when(getPatentHttpResponse.getStatusLine()).thenReturn(getPatentStatusLine);


### PR DESCRIPTION
Fixed communication with remote endpoints providing software details (SH) and patents metadata (EPO).

Don't be mislead by the pretty high number of line changes ;) Most of them are caused by the indentation change. 

This is a simple pull request replacing `HttpResponse` with `CloseableHttpResponse` and putting the latter inside `try` block in order to handle closing the connection.