### PR TITLE
Closes #1131: Change the way software webcrawler parallelism level is capped

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJob.java
@@ -64,7 +64,8 @@ public class CachedWebCrawlerJob {
         jcommander.parse(args);
         
         ContentRetrieverContext contentRetrieverContext = new ContentRetrieverContext(params.contentRetrieverClassName, 
-                params.connectionTimeout, params.readTimeout, params.maxPageContentLength, params.numberOfEmittedFiles);
+                params.connectionTimeout, params.readTimeout, params.maxPageContentLength, params.numberOfEmittedFiles,
+                params.numberOfPartitionsForCrawling);
         
         try (JavaSparkContext sc = JavaSparkContextFactory.withConfAndKryo(new SparkConf())) {
             
@@ -228,7 +229,9 @@ public class CachedWebCrawlerJob {
         
         @Parameter(names = "-numberOfEmittedFiles", required = true)
         private int numberOfEmittedFiles;
-
         
+        @Parameter(names = "-numberOfPartitionsForCrawling", required = true)
+        private int numberOfPartitionsForCrawling;
+
     }
 }

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/ContentRetrieverContext.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/ContentRetrieverContext.java
@@ -25,12 +25,15 @@ public class ContentRetrieverContext implements Serializable {
     private int maxPageContentLength;
     
     private int numberOfEmittedFiles;
-
+    
+    private int numberOfPartitionsForCrawling;
 
     public ContentRetrieverContext() {}
     
-    public ContentRetrieverContext(String contentRetrieverClassName,
-            int connectionTimeout, int readTimeout, int maxPageContentLength, int numberOfEmittedFiles) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException {
+    public ContentRetrieverContext(String contentRetrieverClassName, int connectionTimeout, int readTimeout,
+            int maxPageContentLength, int numberOfEmittedFiles, int numberOfPartitionsForCrawling)
+            throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+            NoSuchMethodException, SecurityException, ClassNotFoundException {
         @SuppressWarnings("unchecked")
         Class<ContentRetriever> clazz = (Class<ContentRetriever>) Class.forName(contentRetrieverClassName);
         this.contentRetriever = clazz.getConstructor().newInstance();
@@ -38,6 +41,7 @@ public class ContentRetrieverContext implements Serializable {
         this.readTimeout = readTimeout;
         this.maxPageContentLength = maxPageContentLength;
         this.numberOfEmittedFiles = numberOfEmittedFiles;
+        this.numberOfPartitionsForCrawling = numberOfPartitionsForCrawling;
     }
 
 
@@ -45,16 +49,13 @@ public class ContentRetrieverContext implements Serializable {
         return contentRetriever;
     }
 
-
     public int getConnectionTimeout() {
         return connectionTimeout;
     }
 
-
     public int getReadTimeout() {
         return readTimeout;
     }
-
 
     public int getMaxPageContentLength() {
         return maxPageContentLength;
@@ -62,6 +63,10 @@ public class ContentRetrieverContext implements Serializable {
 
     public int getNumberOfEmittedFiles() {
         return numberOfEmittedFiles;
+    }
+    
+    public int getNumberOfPartitionsForCrawling() {
+        return numberOfPartitionsForCrawling;
     }
 
     public void setContentRetriever(ContentRetriever contentRetriever) {
@@ -72,11 +77,9 @@ public class ContentRetrieverContext implements Serializable {
         this.connectionTimeout = connectionTimeout;
     }
 
-
     public void setReadTimeout(int readTimeout) {
         this.readTimeout = readTimeout;
     }
-
 
     public void setMaxPageContentLength(int maxPageContentLength) {
         this.maxPageContentLength = maxPageContentLength;
@@ -84,6 +87,10 @@ public class ContentRetrieverContext implements Serializable {
 
     public void setNumberOfEmittedFiles(int numberOfEmittedFiles) {
         this.numberOfEmittedFiles = numberOfEmittedFiles;
+    }
+    
+    public void setNumberOfPartitionsForCrawling(int numberOfPartitionsForCrawling) {
+        this.numberOfPartitionsForCrawling = numberOfPartitionsForCrawling;
     }
     
 }

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/ContentRetrieverContext.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/ContentRetrieverContext.java
@@ -1,7 +1,6 @@
 package eu.dnetlib.iis.wf.referenceextraction.softwareurl;
 
 import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * Content retriveal context.
@@ -32,8 +31,7 @@ public class ContentRetrieverContext implements Serializable {
     
     public ContentRetrieverContext(String contentRetrieverClassName, int connectionTimeout, int readTimeout,
             int maxPageContentLength, int numberOfEmittedFiles, int numberOfPartitionsForCrawling)
-            throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
-            NoSuchMethodException, SecurityException, ClassNotFoundException {
+            throws Exception {
         @SuppressWarnings("unchecked")
         Class<ContentRetriever> clazz = (Class<ContentRetriever>) Class.forName(contentRetrieverClassName);
         this.contentRetriever = clazz.getConstructor().newInstance();

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/WebCrawlerUtils.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/WebCrawlerUtils.java
@@ -25,6 +25,7 @@ public class WebCrawlerUtils {
         JavaRDD<CharSequence> uniqueSoftwareUrl = documentToSoftwareUrl.map(e -> e.getSoftwareUrl()).distinct();
         
         JavaPairRDD<CharSequence, ContentRetrieverResponse> uniqueFilteredSoftwareUrlToSource = uniqueSoftwareUrl
+                .repartition(ctx.getNumberOfPartitionsForCrawling())
                 .mapToPair(e -> new Tuple2<CharSequence, ContentRetrieverResponse>(e, ctx.getContentRetriever().retrieveUrlContent(e, 
                         ctx.getConnectionTimeout(), ctx.getReadTimeout(), ctx.getMaxPageContentLength())));
 

--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/oozie_app/workflow.xml
@@ -55,9 +55,9 @@
             <description>number of files created by webcrawler module</description>
         </property>
         <property>
-            <name>webcrawlMaxExecutors</name>
+            <name>webcrawlNumberOfPartitionsForCrawling</name>
             <value>4</value>
-            <description>maximum number of executors conducting webcrawl operations</description>
+            <description>number of partitions to be used by executors conducting webcrawl operations</description>
         </property>
         <property>
             <name>sparkDriverMemory</name>
@@ -206,7 +206,6 @@
                 --executor-memory=${sparkExecutorMemory}
                 --executor-cores=1
                 --driver-memory=${sparkDriverMemory}
-                --conf spark.dynamicAllocation.maxExecutors=${webcrawlMaxExecutors}
                 --conf spark.extraListeners=${spark2ExtraListeners}
                 --conf spark.sql.queryExecutionListeners=${spark2SqlQueryExecutionListeners}
                 --conf spark.yarn.historyServer.address=${spark2YarnHistoryServerAddress}
@@ -224,6 +223,7 @@
             <arg>-readTimeout=${webcrawlReadTimeout}</arg>
             <arg>-maxPageContentLength=${webcrawlMaxPageContentLength}</arg>
             <arg>-numberOfEmittedFiles=${webcrawlNumberOfEmittedFiles}</arg>
+            <arg>-numberOfPartitionsForCrawling=${webcrawlNumberOfPartitionsForCrawling}</arg>
             
             <arg>-cacheRootDir=${cacheRootDir}</arg>
         </spark>

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
@@ -286,6 +286,7 @@ public class CachedWebCrawlerJobTest {
                 .addArg("-readTimeout", "0")
                 .addArg("-maxPageContentLength", "0")
                 .addArg("-numberOfEmittedFiles", "1")
+                .addArg("-numberOfPartitionsForCrawling", "1")
                 .addArg("-cacheRootDir", cacheRootDir.toString())
                 .addArg("-outputPath", outputPath)
                 .addArg("-outputFaultPath", outputFaultPath)


### PR DESCRIPTION
Introducing `webcrawlNumberOfPartitionsForCrawling` parameter, set to 4 by default, describing number of partitions to be created for web pages retrieval phase.

This PR relies on a solution already introduced in patents retrieval caching (#1096).