### PR TITLE
Closes #1140: Add missing patent related report entries in primary integration test

### DIFF
--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -625,6 +625,12 @@
             <arg>-C{docSoftwareUrlWebcrawlReport,eu.dnetlib.iis.common.schemas.ReportEntry,eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_softwareurl_webcrawl.json}</arg>
             <arg>-IdocSoftwareUrlWebcrawlReport=${workingDir}/report/referenceextraction_software</arg>
 
+            <arg>-C{patentMetadataRetrieval,eu.dnetlib.iis.common.schemas.ReportEntry,eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_retrieval.json}</arg>
+            <arg>-IpatentMetadataRetrieval=${workingDir}/report/patent_metadata_retrieval</arg>
+            
+            <arg>-C{patentMetadataExtraction,eu.dnetlib.iis.common.schemas.ReportEntry,eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_extraction.json}</arg>
+            <arg>-IpatentMetadataExtraction=${workingDir}/report/patent_metadata_extraction</arg>
+
             <arg>-C{execTimeReport,eu.dnetlib.iis.common.schemas.ReportEntry,eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/primary-processing-execution-times.json}</arg>
             <arg>-IexecTimeReport=${workingDir}/report/primary-processing-execution-times</arg>
 

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_extraction.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_extraction.json
@@ -1,0 +1,2 @@
+{"key": "processing.referenceExtraction.patent.metadataextraction.processed.fault", "type": "COUNTER", "value": "0"}
+{"key": "processing.referenceExtraction.patent.metadataextraction.processed.total", "type": "COUNTER", "value": "1"}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_retrieval.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/doc_patent_metadata_retrieval.json
@@ -1,0 +1,3 @@
+{"key": "processing.referenceExtraction.patent.retrieval.fromCache.total", "type": "COUNTER", "value": "0"}
+{"key": "processing.referenceExtraction.patent.retrieval.processed.fault", "type": "COUNTER", "value": "0"}
+{"key": "processing.referenceExtraction.patent.retrieval.processed.total", "type": "COUNTER", "value": "1"}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/pushgateway.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/report/pushgateway.json
@@ -43,6 +43,7 @@
 {"key":"processing.referenceExtraction.dataset.duration","type":"DURATION","value":"$(LONG_RANGE: [1000, 1500000])"}
 {"key":"processing.referenceExtraction.dataset.opentrials.references","type":"COUNTER","value":"0"}
 {"key":"processing.referenceExtraction.dataset.deduped.references","type":"COUNTER","value":"1"}
+{"key":"processing.referenceExtraction.patent.retrieval.fromCache.total", "type": "COUNTER", "value": "0"}
 {"key":"processing.referenceExtraction.patent.retrieval.processed.total","type":"COUNTER","value":"1"}
 {"key":"processing.referenceExtraction.patent.retrieval.processed.fault","type":"COUNTER","value": "0"}
 {"key":"processing.referenceExtraction.patent.metadataextraction.processed.total","type":"COUNTER","value":"1"}


### PR DESCRIPTION
Simple fix: introducing missing missing report entry among expectations. IIS primary integration test finishes successfully after applying this fix.

Additional improvement: defining expectations against patent metadata extraction and retrieval jobs.