### PR TITLE
Closes #1071 and #1103: Add repartition with number of files for datastore write 

### DIFF
--- a/iis-common/src/main/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtils.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtils.java
@@ -66,9 +66,9 @@ public class DocumentTextCacheStorageUtils {
             
             try {
                 // store in cache
-                avroSaver.saveJavaRDD(toBeStoredEntities.coalesce(numberOfEmittedFiles), DocumentText.SCHEMA$, 
+                avroSaver.saveJavaRDD(toBeStoredEntities.repartition(numberOfEmittedFiles), DocumentText.SCHEMA$,
                         getCacheLocation(cacheRootDir, newCacheId, CacheRecordType.text).toString());
-                avroSaver.saveJavaRDD(toBeStoredFaults.coalesce(numberOfEmittedFiles), Fault.SCHEMA$, 
+                avroSaver.saveJavaRDD(toBeStoredFaults.repartition(numberOfEmittedFiles), Fault.SCHEMA$,
                         getCacheLocation(cacheRootDir, newCacheId, CacheRecordType.fault).toString());
                 // writing new cache id
                 cacheManager.writeCacheId(hadoopConf, cacheRootDir, newCacheId);

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/java/io/DataStore.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/java/io/DataStore.java
@@ -17,7 +17,9 @@ import org.apache.avro.specific.SpecificDatumWriter;
  *
  */
 public final class DataStore {
-	
+
+	public static final String AVRO_FILE_EXT = "avro";
+
 	private final static String singleDataStoreFileName = "content.avro";
 	
 	private static final int FILE_NO_PADDING_LENGTH = 7;

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/java/io/HdfsUtils.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/java/io/HdfsUtils.java
@@ -4,6 +4,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -50,4 +51,20 @@ public final class HdfsUtils {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Counts files in a dir.
+     *
+     * @param hadoopConf Configuration of hadoop env
+     * @param pathname   Path to a dir with files
+     * @param pathFilter Filter for files to be counted
+     * @return File count of files matching the filter
+     */
+    public static int countFiles(Configuration hadoopConf, String pathname, PathFilter pathFilter) throws IOException {
+        Path path = new Path(pathname);
+        FileSystem fileSystem = FileSystem.get(hadoopConf);
+        if (fileSystem.exists(path) && fileSystem.isDirectory(path)) {
+            return fileSystem.listStatus(path, pathFilter).length;
+        }
+        throw new RuntimeException(String.format("Path does not exist or is not a directory: %s", pathname));
+    }
 }

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/utils/RDDUtils.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/utils/RDDUtils.java
@@ -14,7 +14,7 @@ public class RDDUtils {
     }
 
     /**
-     * Saves a given pair RDD as a sequence file.
+     * Saves a given text pair RDD as a sequence file, repartitioning RDD to the given number of output files.
      *
      * @param pairs               RDD of Text pairs to save.
      * @param numberOfOutputFiles Number of output files.
@@ -23,7 +23,7 @@ public class RDDUtils {
      */
     public static void saveTextPairRDD(JavaPairRDD<Text, Text> pairs, Integer numberOfOutputFiles, String outputPath, Configuration conf) {
         pairs
-                .coalesce(numberOfOutputFiles)
+                .repartition(numberOfOutputFiles)
                 .saveAsNewAPIHadoopFile(outputPath, Text.class, Text.class, SequenceFileOutputFormat.class, conf);
     }
 }

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtilsTest.java
@@ -141,11 +141,11 @@ public class DocumentTextCacheStorageUtilsTest {
     public void testStoreInCacheValidRecords() throws Exception {
         // given
         Path cacheRootDir = new Path("some/root/dir");
-        int numberOfEmittedFiles = 1;
+        int numberOfEmittedFiles = 2;
         String predefinedCacheId = "someCacheId";
         doReturn(predefinedCacheId).when(cacheManager).generateNewCacheId(hadoopConf, cacheRootDir);
-        doReturn(toBeStoredCoalescedEntities).when(toBeStoredEntities).coalesce(numberOfEmittedFiles);
-        doReturn(toBeStoredCoalescedFaults).when(toBeStoredFaults).coalesce(numberOfEmittedFiles);
+        doReturn(toBeStoredCoalescedEntities).when(toBeStoredEntities).repartition(numberOfEmittedFiles);
+        doReturn(toBeStoredCoalescedFaults).when(toBeStoredFaults).repartition(numberOfEmittedFiles);
         
         // execute
         DocumentTextCacheStorageUtils.storeInCache(avroSaver, toBeStoredEntities, toBeStoredFaults, 
@@ -168,7 +168,7 @@ public class DocumentTextCacheStorageUtilsTest {
     public void testStoreInCacheByCheckingProperLocksHandlingWhenWriteCacheThrowsException() throws Exception {
         // given
         Path cacheRootDir = new Path("some/root/dir");
-        int numberOfEmittedFiles = 1;
+        int numberOfEmittedFiles = 2;
         String predefinedCacheId = "someCacheId";
         doReturn(predefinedCacheId).when(cacheManager).generateNewCacheId(hadoopConf, cacheRootDir);
         doReturn(FileSystem.DEFAULT_FS).when(hadoopConf).get(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/cache/DocumentTextCacheStorageUtilsTest.java
@@ -65,10 +65,10 @@ public class DocumentTextCacheStorageUtilsTest {
     private JavaRDD<Fault> toBeStoredFaults;
     
     @Mock
-    private JavaRDD<DocumentText> toBeStoredCoalescedEntities;
+    private JavaRDD<DocumentText> toBeStoredRepartitionedEntities;
     
     @Mock
-    private JavaRDD<Fault> toBeStoredCoalescedFaults;
+    private JavaRDD<Fault> toBeStoredRepartitionedFaults;
 
     
     @Test
@@ -144,8 +144,8 @@ public class DocumentTextCacheStorageUtilsTest {
         int numberOfEmittedFiles = 2;
         String predefinedCacheId = "someCacheId";
         doReturn(predefinedCacheId).when(cacheManager).generateNewCacheId(hadoopConf, cacheRootDir);
-        doReturn(toBeStoredCoalescedEntities).when(toBeStoredEntities).repartition(numberOfEmittedFiles);
-        doReturn(toBeStoredCoalescedFaults).when(toBeStoredFaults).repartition(numberOfEmittedFiles);
+        doReturn(toBeStoredRepartitionedEntities).when(toBeStoredEntities).repartition(numberOfEmittedFiles);
+        doReturn(toBeStoredRepartitionedFaults).when(toBeStoredFaults).repartition(numberOfEmittedFiles);
         
         // execute
         DocumentTextCacheStorageUtils.storeInCache(avroSaver, toBeStoredEntities, toBeStoredFaults, 
@@ -155,9 +155,9 @@ public class DocumentTextCacheStorageUtilsTest {
         verify(lockManager, times(1)).obtain(cacheRootDir.toString());
         verify(lockManager, times(1)).release(cacheRootDir.toString());
 
-        verify(avroSaver, times(1)).saveJavaRDD(toBeStoredCoalescedEntities, DocumentText.SCHEMA$, 
+        verify(avroSaver, times(1)).saveJavaRDD(toBeStoredRepartitionedEntities, DocumentText.SCHEMA$,
                 DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, predefinedCacheId, CacheRecordType.text).toString());
-        verify(avroSaver, times(1)).saveJavaRDD(toBeStoredCoalescedFaults, Fault.SCHEMA$, 
+        verify(avroSaver, times(1)).saveJavaRDD(toBeStoredRepartitionedFaults, Fault.SCHEMA$,
                 DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, predefinedCacheId, CacheRecordType.fault).toString());
         
         verify(cacheManager, times(1)).writeCacheId(hadoopConf, cacheRootDir, predefinedCacheId);
@@ -172,8 +172,8 @@ public class DocumentTextCacheStorageUtilsTest {
         String predefinedCacheId = "someCacheId";
         doReturn(predefinedCacheId).when(cacheManager).generateNewCacheId(hadoopConf, cacheRootDir);
         doReturn(FileSystem.DEFAULT_FS).when(hadoopConf).get(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
-        doReturn(toBeStoredCoalescedEntities).when(toBeStoredEntities).coalesce(numberOfEmittedFiles);
-        doReturn(toBeStoredCoalescedFaults).when(toBeStoredFaults).coalesce(numberOfEmittedFiles);
+        doReturn(toBeStoredRepartitionedEntities).when(toBeStoredEntities).repartition(numberOfEmittedFiles);
+        doReturn(toBeStoredRepartitionedFaults).when(toBeStoredFaults).repartition(numberOfEmittedFiles);
         doThrow(IOException.class).when(cacheManager).writeCacheId(hadoopConf, cacheRootDir, predefinedCacheId);
         
         try {

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/utils/RDDUtilsTest.java
@@ -1,5 +1,6 @@
 package eu.dnetlib.iis.common.utils;
 
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import eu.dnetlib.iis.common.spark.JavaSparkContextFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -69,9 +70,8 @@ public class RDDUtilsTest {
 
         //then
         Pattern pattern = Pattern.compile("^part-r-.\\d+$");
-        long fileCount = Files.list(outputDir)
-                .filter(x -> pattern.matcher(x.getFileName().toString()).matches())
-                .count();
+        long fileCount = HdfsUtils.countFiles(new Configuration(), outputDir.toString(), x ->
+                pattern.matcher(x.getName()).matches());
         assertEquals(NUMBER_OF_OUTPUT_FILES, fileCount);
 
         List<Text> out = ListTestUtils.readValues(outputDir.toString(), Function.identity());

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJob.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJob.java
@@ -71,7 +71,7 @@ public class AffMatchingDedupJob {
             
             List<ReportEntry> reportEntries = reportGenerator.generateReport(results);
             
-            sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries), ReportEntry.SCHEMA$, outputReportPath);
+            sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries, 1), ReportEntry.SCHEMA$, outputReportPath);
         }
     }
 

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJob.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJob.java
@@ -106,7 +106,7 @@ public class ProjectBasedMatchingJob {
             
             List<ReportEntry> reportEntries = reportGenerator.generateReport(distinctMatchedOrganizations);
             
-            sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries), ReportEntry.SCHEMA$, outputReportPath);
+            sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries, 1), ReportEntry.SCHEMA$, outputReportPath);
         }
     }
 

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriter.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriter.java
@@ -61,13 +61,13 @@ public class IisAffMatchResultWriter implements AffMatchResultWriter {
         
         distinctMatchedOrganizations.cache();
         
-        sparkAvroSaver.saveJavaRDD(distinctMatchedOrganizations.coalesce(numberOfEmittedFiles), MatchedOrganization.SCHEMA$, outputPath);
+        sparkAvroSaver.saveJavaRDD(distinctMatchedOrganizations.repartition(numberOfEmittedFiles), MatchedOrganization.SCHEMA$, outputPath);
         
         
         
         List<ReportEntry> reportEntries = reportGenerator.generateReport(distinctMatchedOrganizations);
         
-        sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries), ReportEntry.SCHEMA$, outputReportPath);
+        sparkAvroSaver.saveJavaRDD(sc.parallelize(reportEntries, 1), ReportEntry.SCHEMA$, outputReportPath);
         
 
         

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJobTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJobTest.java
@@ -2,14 +2,15 @@ package eu.dnetlib.iis.wf.affmatching;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Files;
 
 import eu.dnetlib.iis.common.schemas.ReportEntry;
 import eu.dnetlib.iis.common.utils.AvroAssertTestUtil;
@@ -20,6 +21,8 @@ import eu.dnetlib.iis.wf.affmatching.model.MatchedOrganizationWithProvenance;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
+
+import static org.junit.Assert.*;
 
 /**
 * @author mhorst
@@ -42,9 +45,9 @@ public class AffMatchingDedupJobTest {
     
     
     @Before
-    public void before() {
+    public void before() throws IOException {
         
-        workingDir = Files.createTempDir();
+        workingDir = Files.createTempDirectory(AffMatchingDedupJobTest.class.getSimpleName()).toFile();
         
         inputADirPath = workingDir + "/affiliation_dedup/input/a";
         inputBDirPath = workingDir + "/affiliation_dedup/input/b";
@@ -124,6 +127,8 @@ public class AffMatchingDedupJobTest {
         
         // assert
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDirPath, jsonOutputPath, MatchedOrganizationWithProvenance.class);
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonOutputReportPath, ReportEntry.class);
 
     }

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJobTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJobTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -128,7 +129,7 @@ public class AffMatchingDedupJobTest {
         // assert
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDirPath, jsonOutputPath, MatchedOrganizationWithProvenance.class);
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonOutputReportPath, ReportEntry.class);
 
     }

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJobTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJobTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -153,7 +154,7 @@ public class ProjectBasedMatchingJobTest {
         // assert
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDirPath, jsonOutputPath, MatchedOrganization.class);
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonOutputReportPath, ReportEntry.class);
 
     }

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJobTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/ProjectBasedMatchingJobTest.java
@@ -2,14 +2,16 @@ package eu.dnetlib.iis.wf.affmatching;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Files;
 
 import eu.dnetlib.iis.common.schemas.ReportEntry;
 import eu.dnetlib.iis.common.utils.AvroAssertTestUtil;
@@ -22,6 +24,8 @@ import eu.dnetlib.iis.wf.affmatching.model.MatchedOrganization;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
+
+import static org.junit.Assert.assertEquals;
 
 /**
 * @author mhorst
@@ -52,9 +56,9 @@ public class ProjectBasedMatchingJobTest {
     
     
     @Before
-    public void before() {
+    public void before() throws IOException {
         
-        workingDir = Files.createTempDir();
+        workingDir = Files.createTempDirectory(ProjectBasedMatchingJobTest.class.getSimpleName()).toFile();
 
         inputInferredDocProjDirPath = workingDir + "/projectbased_matching/input/doc_proj_inferred";
         inputDocProjDirPath = workingDir + "/projectbased_matching/input/doc_proj";
@@ -148,6 +152,8 @@ public class ProjectBasedMatchingJobTest {
         
         // assert
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDirPath, jsonOutputPath, MatchedOrganization.class);
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonOutputReportPath, ReportEntry.class);
 
     }

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
@@ -75,7 +75,7 @@ public class IisAffMatchResultWriterTest {
     private JavaRDD<MatchedOrganization> distinctMatchedOrganizationsValues;
     
     @Mock
-    private JavaRDD<MatchedOrganization> distinctMatchedOrganizationsValuesCoalesce;
+    private JavaRDD<MatchedOrganization> distinctMatchedOrganizationsValuesRepartition;
  
     @Mock
     private List<ReportEntry> reportEntries;
@@ -153,7 +153,7 @@ public class IisAffMatchResultWriterTest {
         doReturn(matchedOrganizationsDocOrgIdKey).when(matchedOrganizations).keyBy(any());
         when(matchedOrganizationsDocOrgIdKey.reduceByKey(any())).thenReturn(distinctMatchedOrganizations);
         when(distinctMatchedOrganizations.values()).thenReturn(distinctMatchedOrganizationsValues);
-        when(distinctMatchedOrganizationsValues.repartition(2)).thenReturn(distinctMatchedOrganizationsValuesCoalesce);
+        when(distinctMatchedOrganizationsValues.repartition(2)).thenReturn(distinctMatchedOrganizationsValuesRepartition);
         when(reportGenerator.generateReport(distinctMatchedOrganizationsValues)).thenReturn(reportEntries);
         when(sc.parallelize(reportEntries, 1)).thenReturn(rddReportEntries);
         
@@ -165,7 +165,7 @@ public class IisAffMatchResultWriterTest {
         
         // assert
         
-        verify(sparkAvroSaver).saveJavaRDD(distinctMatchedOrganizationsValuesCoalesce, MatchedOrganization.SCHEMA$, outputPath);
+        verify(sparkAvroSaver).saveJavaRDD(distinctMatchedOrganizationsValuesRepartition, MatchedOrganization.SCHEMA$, outputPath);
         verify(sparkAvroSaver).saveJavaRDD(rddReportEntries, ReportEntry.SCHEMA$, outputReportPath);
         
         verify(affMatchResults).map(convertFunction.capture());

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
@@ -153,14 +153,14 @@ public class IisAffMatchResultWriterTest {
         doReturn(matchedOrganizationsDocOrgIdKey).when(matchedOrganizations).keyBy(any());
         when(matchedOrganizationsDocOrgIdKey.reduceByKey(any())).thenReturn(distinctMatchedOrganizations);
         when(distinctMatchedOrganizations.values()).thenReturn(distinctMatchedOrganizationsValues);
-        when(distinctMatchedOrganizationsValues.coalesce(1)).thenReturn(distinctMatchedOrganizationsValuesCoalesce);
+        when(distinctMatchedOrganizationsValues.repartition(2)).thenReturn(distinctMatchedOrganizationsValuesCoalesce);
         when(reportGenerator.generateReport(distinctMatchedOrganizationsValues)).thenReturn(reportEntries);
-        when(sc.parallelize(reportEntries)).thenReturn(rddReportEntries);
+        when(sc.parallelize(reportEntries, 1)).thenReturn(rddReportEntries);
         
         
         // execute
         
-        writer.write(sc, affMatchResults, outputPath, outputReportPath, 1);
+        writer.write(sc, affMatchResults, outputPath, outputReportPath, 2);
         
         
         // assert

--- a/iis-wf/iis-wf-citationmatching-direct/src/main/java/eu/dnetlib/iis/wf/citationmatching/direct/service/CitationMatchingDirectCounterReporter.java
+++ b/iis-wf/iis-wf-citationmatching-direct/src/main/java/eu/dnetlib/iis/wf/citationmatching/direct/service/CitationMatchingDirectCounterReporter.java
@@ -38,7 +38,8 @@ public class CitationMatchingDirectCounterReporter {
         ReportEntry matchedCitationsCounter = generateMatchedCitationsCounter(citations);
         ReportEntry docsWithMatchedCitationsCounter = generateDocsWithCitationsCounter(citations);
         
-        JavaRDD<ReportEntry> report = sparkContext.parallelize(Lists.newArrayList(matchedCitationsCounter, docsWithMatchedCitationsCounter));
+        JavaRDD<ReportEntry> report = sparkContext
+                .parallelize(Lists.newArrayList(matchedCitationsCounter, docsWithMatchedCitationsCounter), 1);
         
         avroSaver.saveJavaRDD(report, ReportEntry.SCHEMA$, outputReportPath);
     }

--- a/iis-wf/iis-wf-citationmatching-direct/src/test/java/eu/dnetlib/iis/wf/citationmatching/direct/service/CitationMatchingDirectCounterReporterTest.java
+++ b/iis-wf/iis-wf-citationmatching-direct/src/test/java/eu/dnetlib/iis/wf/citationmatching/direct/service/CitationMatchingDirectCounterReporterTest.java
@@ -2,6 +2,7 @@ package eu.dnetlib.iis.wf.citationmatching.direct.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -77,7 +78,7 @@ public class CitationMatchingDirectCounterReporterTest {
         when(matchedCitationsDocumentIds.distinct()).thenReturn(matchedCitationsDistinctDocumentIds);
         when(matchedCitationsDistinctDocumentIds.count()).thenReturn(3L);
         
-        doReturn(reportCounters).when(sparkContext).parallelize(any());
+        doReturn(reportCounters).when(sparkContext).parallelize(any(), eq(1));
         
         
         // execute
@@ -90,7 +91,7 @@ public class CitationMatchingDirectCounterReporterTest {
         verify(matchedCitations).map(extractDocIdFunction.capture());
         assertExtractDocIdFunction(extractDocIdFunction.getValue());
         
-        verify(sparkContext).parallelize(reportEntriesCaptor.capture());
+        verify(sparkContext).parallelize(reportEntriesCaptor.capture(), eq(1));
         assertReportEntries(reportEntriesCaptor.getValue());
         
         verify(avroSaver).saveJavaRDD(reportCounters, ReportEntry.SCHEMA$, reportPath);

--- a/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/CitationMatchingCounterReporter.java
+++ b/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/CitationMatchingCounterReporter.java
@@ -46,7 +46,8 @@ public class CitationMatchingCounterReporter {
         ReportEntry docsWithMatchedCitationsCounter = generateDocsWithCitationsCounter(matchedCitations);
         
         
-        JavaRDD<ReportEntry> report = sparkContext.parallelize(Lists.newArrayList(matchedCitationsCounter, docsWithMatchedCitationsCounter));
+        JavaRDD<ReportEntry> report = sparkContext
+                .parallelize(Lists.newArrayList(matchedCitationsCounter, docsWithMatchedCitationsCounter), 1);
         
         avroSaver.saveJavaRDD(report, ReportEntry.SCHEMA$, reportPath);
         

--- a/iis-wf/iis-wf-citationmatching/src/test/java/eu/dnetlib/iis/wf/citationmatching/CitationMatchingCounterReporterTest.java
+++ b/iis-wf/iis-wf-citationmatching/src/test/java/eu/dnetlib/iis/wf/citationmatching/CitationMatchingCounterReporterTest.java
@@ -2,6 +2,7 @@ package eu.dnetlib.iis.wf.citationmatching;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,10 +15,7 @@ import org.apache.spark.api.java.function.Function;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import eu.dnetlib.iis.citationmatching.schemas.Citation;
@@ -98,10 +96,10 @@ public class CitationMatchingCounterReporterTest {
         doReturn(matchedCitationsDocumentIds).when(matchedCitations).map(any());
         when(matchedCitationsDocumentIds.distinct()).thenReturn(matchedCitationsDistinctDocumentIds);
         when(matchedCitationsDistinctDocumentIds.count()).thenReturn(3L);
-        
-        doReturn(reportCounters).when(sparkContext).parallelize(any());
-        
-        
+
+        doReturn(reportCounters).when(sparkContext).parallelize(any(), eq(1));
+
+
         // execute
         
         counterReporter.report(matchedCitations);
@@ -112,7 +110,7 @@ public class CitationMatchingCounterReporterTest {
         verify(matchedCitations).map(extractDocIdFunction.capture());
         assertExtractDocIdFunction(extractDocIdFunction.getValue());
         
-        verify(sparkContext).parallelize(reportEntriesCaptor.capture());
+        verify(sparkContext).parallelize(reportEntriesCaptor.capture(), eq(1));
         assertReportEntries(reportEntriesCaptor.getValue());
         
         verify(avroSaver).saveJavaRDD(reportCounters, ReportEntry.SCHEMA$, reportPath);

--- a/iis-wf/iis-wf-documentsclassification/src/main/java/eu/dnetlib/iis/wf/documentsclassification/DocumentClassificationJob.java
+++ b/iis-wf/iis-wf-documentsclassification/src/main/java/eu/dnetlib/iis/wf/documentsclassification/DocumentClassificationJob.java
@@ -80,7 +80,7 @@ public class DocumentClassificationJob {
 
             List<ReportEntry> reportEntries = reportGenerator.generateReport(documentClasses);
             
-            avroSaver.saveJavaRDD(sc.parallelize(reportEntries), ReportEntry.SCHEMA$, params.outputReportPath);
+            avroSaver.saveJavaRDD(sc.parallelize(reportEntries, 1), ReportEntry.SCHEMA$, params.outputReportPath);
         }
         
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExportCounterReporter.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExportCounterReporter.java
@@ -44,7 +44,7 @@ public class SoftwareExportCounterReporter {
         ReportEntry distinctPubsCounter = generateDistinctPublicationsCounter(uniqueRelations);
         
         JavaRDD<ReportEntry> report = sparkContext.parallelize(Lists.newArrayList(
-                totalEntitiesCounter, totalRelationsCounter, distinctPubsCounter));
+                totalEntitiesCounter, totalRelationsCounter, distinctPubsCounter), 1);
         
         avroSaver.saveJavaRDD(report, ReportEntry.SCHEMA$, outputReportPath);
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExportCounterReporterTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExportCounterReporterTest.java
@@ -5,6 +5,7 @@ import static eu.dnetlib.iis.wf.export.actionmanager.entity.SoftwareExportCounte
 import static eu.dnetlib.iis.wf.export.actionmanager.entity.SoftwareExportCounterReporter.SOFTWARE_REFERENCES_COUNTER;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ public class SoftwareExportCounterReporterTest {
         doReturn(documentIds).when(uniqueRelations).map(any());
         when(documentIds.distinct()).thenReturn(distinctDocumentIds);
         when(distinctDocumentIds.count()).thenReturn(3L);
-        doReturn(reportCounters).when(sparkContext).parallelize(any());
+        doReturn(reportCounters).when(sparkContext).parallelize(any(), eq(1));
 
         // execute
         counterReporter.report(sparkContext, uniqueEntities, uniqueRelations, outputReportPath);
@@ -98,7 +99,7 @@ public class SoftwareExportCounterReporterTest {
         verify(uniqueRelations).map(extractDocIdFunction.capture());
         assertExtractDocIdFunction(extractDocIdFunction.getValue());
         
-        verify(sparkContext).parallelize(reportEntriesCaptor.capture());
+        verify(sparkContext).parallelize(reportEntriesCaptor.capture(), eq(1));
         assertReportEntries(reportEntriesCaptor.getValue());
         
         verify(avroSaver).saveJavaRDD(reportCounters, ReportEntry.SCHEMA$, outputReportPath);

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
@@ -368,7 +368,7 @@ public class ImportInformationSpaceJob {
                 ReportEntryFactory.createCounterReportEntry(COUNTER_READ_ORGANIZATION, organizationCount),
                 ReportEntryFactory.createCounterReportEntry(COUNTER_READ_DOC_PROJ_REFERENCE, docProjCount),
                 ReportEntryFactory.createCounterReportEntry(COUNTER_READ_PROJ_ORG_REFERENCE, projOrgCount),
-                ReportEntryFactory.createCounterReportEntry(COUNTER_READ_DOC_DEDUP_DOC_REFERENCE, dedupDocCount)));
+                ReportEntryFactory.createCounterReportEntry(COUNTER_READ_DOC_DEDUP_DOC_REFERENCE, dedupDocCount)), 1);
     }
     
     /**

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJob.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJob.java
@@ -72,7 +72,7 @@ public class PatentReaderJob {
     private static JavaRDD<ReportEntry> generateReportEntries(JavaSparkContext sparkContext,
                                                               JavaRDD<ImportedPatent> entries) {
         ReportEntry fromCacheEntitiesCounter = ReportEntryFactory.createCounterReportEntry(COUNTER_READ_TOTAL, entries.count());
-        return sparkContext.parallelize(Lists.newArrayList(fromCacheEntitiesCounter));
+        return sparkContext.parallelize(Lists.newArrayList(fromCacheEntitiesCounter), 1);
     }
 
     private static void storeInOutput(JavaRDD<ImportedPatent> results, JavaRDD<ReportEntry> reports,

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
@@ -6,17 +6,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -33,6 +31,8 @@ import eu.dnetlib.iis.importer.schemas.DocumentToProject;
 import eu.dnetlib.iis.importer.schemas.Organization;
 import eu.dnetlib.iis.importer.schemas.Project;
 import eu.dnetlib.iis.importer.schemas.ProjectToOrganization;
+
+import static org.junit.Assert.*;
 
 /**
  * @author mhorst
@@ -162,7 +162,9 @@ public class ImportInformationSpaceJobTest {
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.resolve(OUTPUT_NAME_DOC_PROJ).toString(), expectedDocProjectPath, DocumentToProject.class);
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.resolve(OUTPUT_NAME_PROJ_ORG).toString(), expectedProjOrgPath, ProjectToOrganization.class);
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.resolve(OUTPUT_NAME_DEDUP).toString(), expectedDedupMappingPath, IdentifierMapping.class);
-        
+
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), expectedReportPath, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -164,7 +165,7 @@ public class ImportInformationSpaceJobTest {
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.resolve(OUTPUT_NAME_DEDUP).toString(), expectedDedupMappingPath, IdentifierMapping.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), expectedReportPath, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJobTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJobTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -57,7 +58,7 @@ public class PatentReaderJobTest {
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), patentsEpoMappedPath, ImportedPatent.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
     }
 

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJobTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/patent/PatentReaderJobTest.java
@@ -5,7 +5,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +18,8 @@ import eu.dnetlib.iis.referenceextraction.patent.schemas.ImportedPatent;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
+
+import static org.junit.Assert.assertEquals;
 
 public class PatentReaderJobTest {
     private SparkJobExecutor executor = new SparkJobExecutor();
@@ -51,6 +55,9 @@ public class PatentReaderJobTest {
 
         // then
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), patentsEpoMappedPath, ImportedPatent.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
     }
 

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJob.java
@@ -53,7 +53,8 @@ public class RootConceptIdReportJob {
                     .reduceByKey(Integer::sum);
 
             JavaRDD<ReportEntry> conceptReport = convertToReportEntries(reducedRootConceptIdWithCount
-                    .sortByKey(true), params.reportKeyTemplate);
+                    .sortByKey(true), params.reportKeyTemplate)
+                    .repartition(1);
             
             avroSaver.saveJavaRDD(conceptReport, ReportEntry.SCHEMA$, params.outputReportPath);
         }

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJob.java
@@ -92,8 +92,8 @@ public class PatentMetadataExtractorJob {
         long faultCount = faults.count();
         ReportEntry processedPatentsCounter = ReportEntryFactory.createCounterReportEntry(COUNTER_PROCESSED_TOTAL, patents.count() + faultCount);
         ReportEntry processedFaultsCounter = ReportEntryFactory.createCounterReportEntry(COUNTER_PROCESSED_FAULT, faultCount);
-        
-        return sparkContext.parallelize(Lists.newArrayList(processedPatentsCounter, processedFaultsCounter));
+
+        return sparkContext.parallelize(Lists.newArrayList(processedPatentsCounter, processedFaultsCounter), 1);
     }
     
     private static Tuple2<Patent, Fault> parse(DocumentText patent, ImportedPatent importedPatent, PatentMetadataParser parser) {

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJob.java
@@ -163,9 +163,9 @@ public class PatentMetadataRetrieverJob {
     
     private static void storeInOutput(JavaRDD<DocumentText> retrievedPatentMeta, 
             JavaRDD<Fault> faults, JavaRDD<ReportEntry> reports, OutputPaths outputPaths, int numberOfEmittedFiles) {
-        avroSaver.saveJavaRDD(retrievedPatentMeta.coalesce(numberOfEmittedFiles), DocumentText.SCHEMA$, outputPaths.getResult());
-        avroSaver.saveJavaRDD(faults.coalesce(numberOfEmittedFiles), Fault.SCHEMA$, outputPaths.getFault());
-        avroSaver.saveJavaRDD(reports.coalesce(numberOfEmittedFiles), ReportEntry.SCHEMA$, outputPaths.getReport());
+        avroSaver.saveJavaRDD(retrievedPatentMeta.repartition(numberOfEmittedFiles), DocumentText.SCHEMA$, outputPaths.getResult());
+        avroSaver.saveJavaRDD(faults.repartition(numberOfEmittedFiles), Fault.SCHEMA$, outputPaths.getFault());
+        avroSaver.saveJavaRDD(reports.repartition(1), ReportEntry.SCHEMA$, outputPaths.getReport());
     }
 
     private static ContentRetrieverResponse getMetadataFromFacade(ImportedPatent patent, PatentServiceFacade patentServiceFacade) {

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJob.java
@@ -65,8 +65,8 @@ public class ProjectFunderReportJob {
                     .reduceByKey(Integer::sum);
 
             JavaRDD<ReportEntry> funderReport = convertToReportEntries(reducedFunderWithCount.sortByKey(true), params.reportKeyTemplate);
-            
-            avroSaver.saveJavaRDD(funderReport.union(sc.parallelize(Lists.newArrayList(totalReportEntry))), 
+
+            avroSaver.saveJavaRDD(funderReport.union(sc.parallelize(Lists.newArrayList(totalReportEntry))).repartition(1),
                     ReportEntry.SCHEMA$, params.outputReportPath);
         }
         

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJob.java
@@ -203,9 +203,9 @@ public class CachedWebCrawlerJob {
     
     private static void storeInOutput(JavaRDD<DocumentToSoftwareUrlWithSource> entities, 
             JavaRDD<Fault> faults, JavaRDD<ReportEntry> reports, OutputPaths outputPaths, int numberOfEmittedFiles) {
-        avroSaver.saveJavaRDD(entities.coalesce(numberOfEmittedFiles), DocumentToSoftwareUrlWithSource.SCHEMA$, outputPaths.getResult());
-        avroSaver.saveJavaRDD(faults.coalesce(numberOfEmittedFiles), Fault.SCHEMA$, outputPaths.getFault());
-        avroSaver.saveJavaRDD(reports.coalesce(numberOfEmittedFiles), ReportEntry.SCHEMA$, outputPaths.getReport());
+        avroSaver.saveJavaRDD(entities.repartition(numberOfEmittedFiles), DocumentToSoftwareUrlWithSource.SCHEMA$, outputPaths.getResult());
+        avroSaver.saveJavaRDD(faults.repartition(numberOfEmittedFiles), Fault.SCHEMA$, outputPaths.getFault());
+        avroSaver.saveJavaRDD(reports.repartition(1), ReportEntry.SCHEMA$, outputPaths.getReport());
     }
     
     private static DocumentToSoftwareUrlWithSource attachSource(DocumentToSoftwareUrl record, CharSequence source) {

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJobTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -74,7 +75,7 @@ public class RootConceptIdReportJobTest {
         
         // assert
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDirPath, jsonOutputReportFile, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/concept/RootConceptIdReportJobTest.java
@@ -2,14 +2,16 @@ package eu.dnetlib.iis.wf.referenceextraction.concept;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Files;
 
 import eu.dnetlib.iis.common.schemas.ReportEntry;
 import eu.dnetlib.iis.common.utils.AvroAssertTestUtil;
@@ -19,6 +21,8 @@ import eu.dnetlib.iis.referenceextraction.researchinitiative.schemas.DocumentToC
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * 
@@ -37,8 +41,8 @@ public class RootConceptIdReportJobTest {
     
     
     @Before
-    public void before() {
-        workingDir = Files.createTempDir();
+    public void before() throws IOException {
+        workingDir = Files.createTempDirectory(RootConceptIdReportJobTest.class.getSimpleName()).toFile();
         inputDocumentToConceptDirPath = workingDir + "/root_concept_report/input_document_to_concept";
         outputReportDirPath = workingDir + "/root_concept_report/output_report";
     }
@@ -69,6 +73,8 @@ public class RootConceptIdReportJobTest {
         executor.execute(buildRootConceptIdReportJob(inputDocumentToConceptDirPath, outputReportDirPath));
         
         // assert
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDirPath, jsonOutputReportFile, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJobTest.java
@@ -11,7 +11,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -92,6 +94,8 @@ public class PatentMetadataExtractorJobTest {
         assertNotNull(generatedFaults);
         assertEquals(0, generatedFaults.size());
 
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 0);
     }
     
@@ -127,6 +131,8 @@ public class PatentMetadataExtractorJobTest {
         assertNotNull(generatedFaults);
         assertEquals(0, generatedFaults.size());
 
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 0);
     }
     
@@ -162,6 +168,8 @@ public class PatentMetadataExtractorJobTest {
         assertEquals(patentId, fault.getInputObjectId().toString());
         assertEquals(PatentMetadataParserException.class.getCanonicalName(), fault.getCode().toString());
 
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 1);
     }
     
@@ -190,6 +198,8 @@ public class PatentMetadataExtractorJobTest {
         assertNotNull(generatedFaults);
         assertEquals(0, generatedFaults.size());
 
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 0, 0);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataExtractorJobTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -95,7 +96,7 @@ public class PatentMetadataExtractorJobTest {
         assertEquals(0, generatedFaults.size());
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 0);
     }
     
@@ -132,7 +133,7 @@ public class PatentMetadataExtractorJobTest {
         assertEquals(0, generatedFaults.size());
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 0);
     }
     
@@ -169,7 +170,7 @@ public class PatentMetadataExtractorJobTest {
         assertEquals(PatentMetadataParserException.class.getCanonicalName(), fault.getCode().toString());
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 1, 1);
     }
     
@@ -199,7 +200,7 @@ public class PatentMetadataExtractorJobTest {
         assertEquals(0, generatedFaults.size());
 
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDir.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertReports(AvroTestUtils.readLocalAvroDataStore(outputReportDir.toString()), 0, 0);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
@@ -103,16 +104,16 @@ public class PatentMetadataRetrieverJobTest {
         Configuration conf = new Configuration();
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
 
         // need to validate faults programmatically due to dynamic timestamp generation
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
         
         // validating cache
@@ -122,13 +123,13 @@ public class PatentMetadataRetrieverJobTest {
         org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
 
         org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
     
@@ -167,28 +168,28 @@ public class PatentMetadataRetrieverJobTest {
         Configuration conf = new Configuration();
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Dir.toString(), output2Path, DocumentText.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Dir.toString(), report2Path, ReportEntry.class);
 
         // need to validate faults programatically due to dynamic timestamp generation
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputFault2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputFault2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Dir.toString()).size());
         
         // validating cache
@@ -198,13 +199,13 @@ public class PatentMetadataRetrieverJobTest {
         org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
 
         org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
 
@@ -237,28 +238,28 @@ public class PatentMetadataRetrieverJobTest {
         Configuration conf = new Configuration();
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
 
         assertEquals(2,
-                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Dir.toString(), outputPath, DocumentText.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Dir.toString(), report2Path, ReportEntry.class);
 
         // need to validate faults programatically due to dynamic timestamp generation
         assertEquals(2,
-                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
 
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Dir.toString()).size());
         
         // validating cache
@@ -268,13 +269,13 @@ public class PatentMetadataRetrieverJobTest {
         org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
 
         org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
@@ -99,20 +100,36 @@ public class PatentMetadataRetrieverJobTest {
         executor.execute(sparkJob);
 
         // then
+        Configuration conf = new Configuration();
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
-        // need to validate faults programatically due to dynamic timestamp generation
+
+        // need to validate faults programmatically due to dynamic timestamp generation
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
         
         // validating cache
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, new org.apache.hadoop.fs.Path(cacheRootDir.toString()));
         assertNotNull(cacheId);
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(DocumentTextCacheStorageUtils
-                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text)
-                .toString(), cachePath, DocumentText.class);
-        validateFaults(AvroTestUtils.readLocalAvroDataStore(DocumentTextCacheStorageUtils.getCacheLocation(
-                new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault).toString()));
+
+        org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
+
+        org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
     
     @Test
@@ -147,23 +164,48 @@ public class PatentMetadataRetrieverJobTest {
                 outputReport2Dir.toString(), PatentFacadeMockFactory.class.getCanonicalName()));
 
         // then
+        Configuration conf = new Configuration();
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Dir.toString(), output2Path, DocumentText.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Dir.toString(), report2Path, ReportEntry.class);
+
         // need to validate faults programatically due to dynamic timestamp generation
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputFault2Dir.toString(), path -> path.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Dir.toString()).size());
         
         // validating cache
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, new org.apache.hadoop.fs.Path(cacheRootDir.toString()));
         assertNotNull(cacheId);
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(DocumentTextCacheStorageUtils
-                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text)
-                .toString(), cachePath, DocumentText.class);
-        validateFaults(AvroTestUtils.readLocalAvroDataStore(DocumentTextCacheStorageUtils.getCacheLocation(
-                new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault).toString()));
+
+        org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
+
+        org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
 
     @Test
@@ -192,23 +234,48 @@ public class PatentMetadataRetrieverJobTest {
                 outputReport2Dir.toString(), ExceptionThrowingPatentFacadeFactory.class.getCanonicalName()));
 
         // then
+        Configuration conf = new Configuration();
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputDir.toString(), outputPath, DocumentText.class);
+
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, output2Dir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Dir.toString(), outputPath, DocumentText.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReportDir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDir.toString(), reportPath, ReportEntry.class);
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Dir.toString(), report2Path, ReportEntry.class);
+
         // need to validate faults programatically due to dynamic timestamp generation
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, outputFaultDir.toString(), path -> path.getName().endsWith(".avro")));
         validateFaults(AvroTestUtils.readLocalAvroDataStore(outputFaultDir.toString()));
+
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReport2Dir.toString(), path -> path.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Dir.toString()).size());
         
         // validating cache
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, new org.apache.hadoop.fs.Path(cacheRootDir.toString()));
         assertNotNull(cacheId);
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(DocumentTextCacheStorageUtils
-                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text)
-                .toString(), cachePath, DocumentText.class);
-        validateFaults(AvroTestUtils.readLocalAvroDataStore(DocumentTextCacheStorageUtils.getCacheLocation(
-                new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault).toString()));
+
+        org.apache.hadoop.fs.Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), cachePath, DocumentText.class);
+
+        org.apache.hadoop.fs.Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(new org.apache.hadoop.fs.Path(cacheRootDir.toString()), cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), path -> path.getName().endsWith(".avro")));
+        validateFaults(AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString()));
     }
     
     private void validateFaults(List<Fault> faults) {
@@ -225,7 +292,7 @@ public class PatentMetadataRetrieverJobTest {
                 .setAppName(getClass().getName())
                 .setMainClass(PatentMetadataRetrieverJob.class)
                 .addArg("-inputPath", inputPath)
-                .addArg("-numberOfEmittedFiles", String.valueOf(1))
+                .addArg("-numberOfEmittedFiles", String.valueOf(2))
                 .addArg("-lockManagerFactoryClassName", ZookeeperLockManagerFactory.class.getName())
                 .addArg("-cacheRootDir", cacheRootDir.toString())
                 .addArg("-outputPath", outputPath)

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJobTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -84,7 +85,7 @@ public class ProjectFunderReportJobTest {
         
         // assert
         assertEquals(1,
-                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDirPath, jsonOutputReportFile, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/ProjectFunderReportJobTest.java
@@ -2,14 +2,16 @@ package eu.dnetlib.iis.wf.referenceextraction.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.io.Files;
 
 import eu.dnetlib.iis.common.schemas.ReportEntry;
 import eu.dnetlib.iis.common.utils.AvroAssertTestUtil;
@@ -20,6 +22,8 @@ import eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * 
@@ -40,8 +44,8 @@ public class ProjectFunderReportJobTest {
     
     
     @Before
-    public void before() {
-        workingDir = Files.createTempDir();
+    public void before() throws IOException {
+        workingDir = Files.createTempDirectory(ProjectFunderReportJobTest.class.getSimpleName()).toFile();
         inputProjectDirPath = workingDir + "/spark_project_referenceextraction_report/input_project";
         inputDocumentToProjectDirPath = workingDir + "/spark_project_referenceextraction_report/input_document_to_project";
         outputReportDirPath = workingDir + "/spark_project_referenceextraction_report/output_report";
@@ -79,6 +83,8 @@ public class ProjectFunderReportJobTest {
         executor.execute(buildProjectFunderReportJob(inputProjectDirPath, inputDocumentToProjectDirPath, outputReportDirPath));
         
         // assert
+        assertEquals(1,
+                HdfsUtils.countFiles(new Configuration(), outputReportDirPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportDirPath, jsonOutputReportFile, ReportEntry.class);
     }
     

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
-import org.apache.commons.io.FileUtils;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -17,8 +19,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import com.google.common.io.Files;
 
 import eu.dnetlib.iis.audit.schemas.Fault;
 import eu.dnetlib.iis.common.IntegrationTest;
@@ -71,7 +71,7 @@ public class CachedWebCrawlerJobTest {
     
     @Before
     public void before() throws Exception {
-        workingDir = Files.createTempDir();
+        workingDir = Files.createTempDirectory(CachedWebCrawlerJobTest.class.getSimpleName()).toFile();
         inputPath = workingDir + "/spark_webcrawler/input";
         input2Path = workingDir + "/spark_webcrawler/input2";
         outputPath = workingDir + "/spark_webcrawler/output";
@@ -86,7 +86,7 @@ public class CachedWebCrawlerJobTest {
     
     @After
     public void after() throws IOException {
-        FileUtils.deleteDirectory(workingDir);
+//        FileUtils.deleteDirectory(workingDir);
         zookeeperServer.stop();
     }
     
@@ -116,24 +116,32 @@ public class CachedWebCrawlerJobTest {
         executor.execute(buildWebCrawlerJob(inputPath, outputPath, outputFaultPath, outputReportPath));
         
         // assert
+        Configuration conf = new Configuration();
+
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, cacheRootDir);
         assertNotNull(cacheId);
-        
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text).toString(), 
-                jsonCacheFile, DocumentText.class);
+
+        Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
         
         // evaluating faults
+        Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
-        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault).toString());
+        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
      
         // evaluating report
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
     }
     
@@ -160,31 +168,42 @@ public class CachedWebCrawlerJobTest {
         executor.execute(buildWebCrawlerJob(inputPath, outputPath, outputFaultPath, outputReportPath));
         
         // assert
+        Configuration conf = new Configuration();
+
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, cacheRootDir);
         assertNotNull(cacheId);
-        
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text).toString(), 
-                jsonCacheFile, DocumentText.class);
+
+        Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
+
         // evaluating faults
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
         List<Fault> resultFaults = AvroTestUtils.readLocalAvroDataStore(outputFaultPath);
         assertEquals(2, resultFaults.size());
         assertEquals(DocumentNotFoundException.class.getName(), resultFaults.get(0).getCode().toString());
         assertEquals("id-1", resultFaults.get(0).getInputObjectId().toString());
         assertEquals(DocumentNotFoundException.class.getName(), resultFaults.get(1).getCode().toString());
         assertEquals("id-2", resultFaults.get(1).getInputObjectId().toString());
-        
-        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault).toString());
+
+        Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(1, cachedFaults.size());
         assertEquals(DocumentNotFoundException.class.getName(), cachedFaults.get(0).getCode().toString());
         assertEquals("https://github.com/openaire/invalid", cachedFaults.get(0).getInputObjectId().toString());
         
         // evaluating report
+        assertEquals(1,
+                HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
     }
     
@@ -221,25 +240,39 @@ public class CachedWebCrawlerJobTest {
         executor.execute(buildWebCrawlerJob(input2Path, output2Path, outputFault2Path, outputReport2Path));
         
         // assert
+        Configuration conf = new Configuration();
+
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
+        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Path, jsonOutput2File, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, cacheRootDir);
         assertNotNull(cacheId);
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text).toString(), 
-                jsonCache2File, DocumentText.class);
+
+        Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCache2File, DocumentText.class);
+
         // evaluating faults
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Path).size());
-        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault).toString());
+        Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
         
         // evaluating report
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Path, jsonReport2File, ReportEntry.class);
     }
     
@@ -270,25 +303,40 @@ public class CachedWebCrawlerJobTest {
                 "eu.dnetlib.iis.wf.referenceextraction.softwareurl.ExceptionThrowingContentRetrieverFactory"));
         
         // assert
+        Configuration conf = new Configuration();
+
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
+        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Path, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
-        Configuration conf = new Configuration();
         String cacheId = cacheManager.getExistingCacheId(conf, cacheRootDir);
         assertNotNull(cacheId);
-        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text).toString(), 
-                jsonCacheFile, DocumentText.class);
+
+        Path textCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
+
         // evaluating faults
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(".avro")));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Path).size());
-        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(
-                DocumentTextCacheStorageUtils.getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault).toString());
+
+        Path faultCacheLocation = DocumentTextCacheStorageUtils
+                .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
+        assertEquals(2,
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+        List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
         
         // evaluating report
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(".avro")));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Path, jsonReport2File, ReportEntry.class);
     }
     
@@ -303,7 +351,7 @@ public class CachedWebCrawlerJobTest {
                 .addArg("-inputPath", inputPath)
                 .addArg("-contentRetrieverFactoryClassName", contentRetrieverFactoryClassName)
                 .addArg("-lockManagerFactoryClassName", ZookeeperLockManagerFactory.class.getName())
-                .addArg("-numberOfEmittedFiles", "1")
+                .addArg("-numberOfEmittedFiles", "2")
                 .addArg("-numberOfPartitionsForCrawling", "1")
                 .addArg("-cacheRootDir", cacheRootDir.toString())
                 .addArg("-outputPath", outputPath)

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
@@ -6,11 +6,12 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.common.java.io.DataStore;
 import eu.dnetlib.iis.common.java.io.HdfsUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -86,7 +87,7 @@ public class CachedWebCrawlerJobTest {
     
     @After
     public void after() throws IOException {
-//        FileUtils.deleteDirectory(workingDir);
+        FileUtils.deleteDirectory(workingDir);
         zookeeperServer.stop();
     }
     
@@ -118,7 +119,7 @@ public class CachedWebCrawlerJobTest {
         // assert
         Configuration conf = new Configuration();
 
-        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
@@ -128,20 +129,20 @@ public class CachedWebCrawlerJobTest {
         Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
         
         // evaluating faults
         Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
         List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
      
         // evaluating report
-        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
     }
     
@@ -170,7 +171,7 @@ public class CachedWebCrawlerJobTest {
         // assert
         Configuration conf = new Configuration();
 
-        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
@@ -180,11 +181,11 @@ public class CachedWebCrawlerJobTest {
         Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
 
         // evaluating faults
-        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         List<Fault> resultFaults = AvroTestUtils.readLocalAvroDataStore(outputFaultPath);
         assertEquals(2, resultFaults.size());
         assertEquals(DocumentNotFoundException.class.getName(), resultFaults.get(0).getCode().toString());
@@ -195,7 +196,7 @@ public class CachedWebCrawlerJobTest {
         Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(1, cachedFaults.size());
         assertEquals(DocumentNotFoundException.class.getName(), cachedFaults.get(0).getCode().toString());
@@ -203,7 +204,7 @@ public class CachedWebCrawlerJobTest {
         
         // evaluating report
         assertEquals(1,
-                HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
     }
     
@@ -242,9 +243,9 @@ public class CachedWebCrawlerJobTest {
         // assert
         Configuration conf = new Configuration();
 
-        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
-        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Path, jsonOutput2File, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
@@ -254,25 +255,25 @@ public class CachedWebCrawlerJobTest {
         Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCache2File, DocumentText.class);
 
         // evaluating faults
-        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
-        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Path).size());
         Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
         
         // evaluating report
-        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
-        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Path, jsonReport2File, ReportEntry.class);
     }
     
@@ -305,9 +306,9 @@ public class CachedWebCrawlerJobTest {
         // assert
         Configuration conf = new Configuration();
 
-        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputPath, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
-        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, output2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(output2Path, jsonOutputFile, DocumentToSoftwareUrlWithSource.class);
         
         // evaluating cache contents
@@ -317,26 +318,26 @@ public class CachedWebCrawlerJobTest {
         Path textCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.text);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, textCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(textCacheLocation.toString(), jsonCacheFile, DocumentText.class);
 
         // evaluating faults
-        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFaultPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFaultPath).size());
-        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(2, HdfsUtils.countFiles(conf, outputFault2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         assertEquals(0, AvroTestUtils.readLocalAvroDataStore(outputFault2Path).size());
 
         Path faultCacheLocation = DocumentTextCacheStorageUtils
                 .getCacheLocation(cacheRootDir, cacheId, CacheRecordType.fault);
         assertEquals(2,
-                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(".avro")));
+                HdfsUtils.countFiles(conf, faultCacheLocation.toString(), x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         List<Fault> cachedFaults = AvroTestUtils.readLocalAvroDataStore(faultCacheLocation.toString());
         assertEquals(0, cachedFaults.size());
         
         // evaluating report
-        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(".avro")));
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReportPath, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReportPath, jsonReportFile, ReportEntry.class);
-        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(".avro")));
+        assertEquals(1, HdfsUtils.countFiles(conf, outputReport2Path, x -> x.getName().endsWith(DataStore.AVRO_FILE_EXT)));
         AvroAssertTestUtil.assertEqualsWithJsonIgnoreOrder(outputReport2Path, jsonReport2File, ReportEntry.class);
     }
     


### PR DESCRIPTION
This PR closes #1071 and #1103. 

Changes overview:
- replacing `coalesce()` with `repartition()` when writing datastores with desired number of emitted files; for writing report datastores repartitioning to a single partition is added
- adding relevant test assertions for produced number of files
- adding a general HDFS file counting method: `HdfsUtils.countFiles`
- minor fixes and changes for related files
  -  changing from `com.google.common.io.Files` to `java.nio.file.Files` - this needs a bit of clarification because it is not directly related to the goal of this PR: at first I've used `java.nio.file.Files.list` for listing and counting files in tests, this did not go well with `com.google.common.io.Files` so I've removed the google version, then I've added `HdfsUtils.countFiles` and changes related to `java.nio.file.Files` could be reverted but I've decided to keep the changes because `com.google.common.io.Files` gives warnings when `createTempDir()` is used `'createTempDir()' is declared in unstable class 'com.google.common.io.Files' marked with @Beta`
  - for test with number of emitted files I've changed the number of emitted files from `1` to `2` to make it different then the number for reports 