### PR TITLE
Closes #1151: Introduce a common functionality for retrieving resources - FIX

### DIFF
--- a/iis-common/src/main/java/eu/dnetlib/iis/common/java/jsonworkflownodes/ClassPathResourceToHdfsCopier.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/java/jsonworkflownodes/ClassPathResourceToHdfsCopier.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import eu.dnetlib.iis.common.ClassPathResourceProvider;
 import org.apache.hadoop.conf.Configuration;
@@ -28,6 +29,8 @@ public class ClassPathResourceToHdfsCopier implements Process {
     
     private static final String PARAM_OUTPUT_HDFS_FILE_LOCATION = "outputHdfsFileLocation";
 
+    private Function<String, InputStream> classPathResourceProvider = ClassPathResourceProvider::getResourceInputStream;
+
     @Override
     public void run(PortBindings portBindings, Configuration conf, Map<String, String> parameters) throws Exception {
         Preconditions.checkNotNull(parameters.get(PARAM_INPUT_CLASSPATH_RESOURCE), PARAM_INPUT_CLASSPATH_RESOURCE + " parameter was not specified!");
@@ -35,7 +38,7 @@ public class ClassPathResourceToHdfsCopier implements Process {
 
         FileSystem fs = FileSystem.get(conf);
 
-        try (InputStream in = ClassPathResourceProvider.getResourceInputStream(PARAM_INPUT_CLASSPATH_RESOURCE);
+        try (InputStream in = classPathResourceProvider.apply(parameters.get(PARAM_INPUT_CLASSPATH_RESOURCE));
              OutputStream os = fs.create(new Path(parameters.get(PARAM_OUTPUT_HDFS_FILE_LOCATION)))) {
             IOUtils.copyBytes(in, os, 4096, false);
         }
@@ -43,12 +46,12 @@ public class ClassPathResourceToHdfsCopier implements Process {
 
     @Override
     public Map<String, PortType> getInputPorts() {
-        return new HashMap<String, PortType>();
+        return new HashMap<>();
     }
 
     @Override
     public Map<String, PortType> getOutputPorts() {
-        return new HashMap<String, PortType>();
+        return new HashMap<>();
     }
 
 }

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/java/jsonworkflownodes/ClassPathResourceToHdfsCopierTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/java/jsonworkflownodes/ClassPathResourceToHdfsCopierTest.java
@@ -1,0 +1,66 @@
+package eu.dnetlib.iis.common.java.jsonworkflownodes;
+
+import eu.dnetlib.iis.common.java.PortBindings;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClassPathResourceToHdfsCopierTest {
+
+    @Mock
+    private Function<String, InputStream> classPathResourceProvider;
+
+    private Configuration conf = new Configuration();
+
+    @InjectMocks
+    private ClassPathResourceToHdfsCopier classPathResourceToHdfsCopier = new ClassPathResourceToHdfsCopier();
+
+    @Test(expected = NullPointerException.class)
+    public void givenParametersWithoutInputClassPathResource_whenRunIsCalled_thenCheckFails() throws Exception {
+        classPathResourceToHdfsCopier.run(mock(PortBindings.class), conf, new HashMap<>());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void givenParametersWithoutOutputHdfsFileLocation_whenRunIsCalled_thenCheckFails() throws Exception {
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("inputClasspathResource", "/path/to/resource");
+
+        classPathResourceToHdfsCopier.run(mock(PortBindings.class), conf, parameters);
+    }
+
+    @Test
+    public void givenParametersWithValues_whenRunIsCalled_thenResourceIsCopiedToLocation() throws Exception {
+        Path tempDirectory = Files.createTempDirectory(this.getClass().getSimpleName());
+        Path file = tempDirectory.resolve("file.tmp");
+
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("inputClasspathResource", "/path/to/resource");
+        parameters.put("outputHdfsFileLocation", file.toString());
+
+        when(classPathResourceProvider.apply("/path/to/resource")).thenReturn(
+                new ByteArrayInputStream("resource content".getBytes(StandardCharsets.UTF_8)));
+
+        classPathResourceToHdfsCopier.run(mock(PortBindings.class), conf, parameters);
+
+        assertTrue(Files.exists(file));
+        assertEquals("resource content", FileUtils.readFileToString(file.toFile(), StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in `eu.dnetlib.iis.common.java.jsonworkflownodes.ClassPathResourceToHdfsCopier` introduced with merge of PR #1152 when `parameters.get(PARAM_INPUT_CLASSPATH_RESOURCE)` was removed when creating resource input stream. Test was also added for the referenced class. 