### PR TITLE
Closes #1151: Introduce a common functionality for retrieving resources - FIX#2

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/SoftwareUrlRefExtractionWfTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/SoftwareUrlRefExtractionWfTest.java
@@ -1,5 +1,6 @@
 package eu.dnetlib.iis.wf.referenceextraction.softwareurl;
 
+import eu.dnetlib.iis.common.OozieWorkflowTestConfiguration;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -15,17 +16,23 @@ import eu.dnetlib.iis.common.IntegrationTest;
 public class SoftwareUrlRefExtractionWfTest extends AbstractOozieWorkflowTestCase {
 
     @Test
-    public void testMainWorkflow() throws Exception {
-        testWorkflow("eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/sampletest");
+    public void testMainWorkflow() {
+        OozieWorkflowTestConfiguration configuration = new OozieWorkflowTestConfiguration();
+        configuration.setTimeoutInSeconds(1800);
+        testWorkflow("eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/sampletest", configuration);
     }
 
     @Test
-    public void testMainWorkflowWithoutReferences() throws Exception {
+    public void testMainWorkflowWithoutReferences() {
+        OozieWorkflowTestConfiguration configuration = new OozieWorkflowTestConfiguration();
+        configuration.setTimeoutInSeconds(1800);
         testWorkflow("eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/sampletest_without_references");
     }
 
     @Test
-    public void testMainWorkflowEmptyInput() throws Exception {
+    public void testMainWorkflowEmptyInput() {
+        OozieWorkflowTestConfiguration configuration = new OozieWorkflowTestConfiguration();
+        configuration.setTimeoutInSeconds(1800);
         testWorkflow("eu/dnetlib/iis/wf/referenceextraction/softwareurl/main/sampletest_empty_input");
     }
 }


### PR DESCRIPTION
This PR fixes a failing integration test suite `eu.dnetlib.iis.wf.referenceextraction.softwareurl.SoftwareUrlRefExtractionWfTest`. It seems that as a result of merging #1152 integration tests timeout value needs to be increased. I've increased it to 30min/1800s.

Also a minor fix - removal of `throws` clause because no exceptions are thrown in test methods.