### PR TITLE
Closing #1066 and #1079: DNet dependency cleanup

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/pom.xml
+++ b/iis-wf/iis-wf-export-actionmanager/pom.xml
@@ -40,11 +40,6 @@
         </dependency>
 
         <dependency>
-            <groupId>eu.dnetlib</groupId>
-            <artifactId>dnet-openaireplus-mapping-utils</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
@@ -58,29 +53,6 @@
             <artifactId>protobuf-java</artifactId>
         </dependency>
 
-        <!-- required for SOAP communication with MDStore -->
-        <dependency>
-            <groupId>eu.dnetlib</groupId>
-            <artifactId>cnr-service-utils</artifactId>
-        </dependency>
-
-        <!-- required to access MDStore API -->
-        <dependency>
-            <groupId>eu.dnetlib</groupId>
-            <artifactId>cnr-rmi-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>eu.dnetlib</groupId>
-            <artifactId>cnr-resultset-client</artifactId>
-        </dependency>
-
-        <!-- proper spring context version required by cnr-resultset-client -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
@@ -90,13 +62,6 @@
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-        </dependency>
-
-        <!-- required by dnet-actionmanager-common on CNR cluster only
-            for XSLT tansformations when exporting entities -->
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
         </dependency>
 
         <dependency>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/SoftwareExporterJob.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -26,7 +27,6 @@ import com.beust.jcommander.Parameters;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import eu.dnetlib.data.transform.xml.AbstractDNetXsltFunctions;
 import eu.dnetlib.dhp.schema.action.AtomicAction;
 import eu.dnetlib.dhp.schema.oaf.DataInfo;
 import eu.dnetlib.dhp.schema.oaf.Field;
@@ -224,12 +224,12 @@ public class SoftwareExporterJob {
 
     protected static String generateSoftwareEntityId(String url) {
         return InfoSpaceConstants.ROW_PREFIX_RESULT + InfoSpaceConstants.OPENAIRE_ENTITY_ID_PREFIX +
-                InfoSpaceConstants.ID_NAMESPACE_SEPARATOR + AbstractDNetXsltFunctions.md5(url);
+                InfoSpaceConstants.ID_NAMESPACE_SEPARATOR + DigestUtils.md5Hex(url);
     }
 
     private static String generateDatasourceId(String repositoryName) {
         return InfoSpaceConstants.ROW_PREFIX_DATASOURCE + InfoSpaceConstants.OPENAIRE_ENTITY_ID_PREFIX +
-                InfoSpaceConstants.ID_NAMESPACE_SEPARATOR + AbstractDNetXsltFunctions.md5(repositoryName);
+                InfoSpaceConstants.ID_NAMESPACE_SEPARATOR + DigestUtils.md5Hex(repositoryName);
     }
 
     private static AtomicAction<Software> buildEntityAction(Tuple2<DocumentToSoftwareUrlWithMeta, Set<CharSequence>> object) {

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.SequenceFile;
@@ -25,7 +26,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.Lists;
 
-import eu.dnetlib.data.transform.xml.AbstractDNetXsltFunctions;
 import eu.dnetlib.dhp.schema.action.AtomicAction;
 import eu.dnetlib.dhp.schema.oaf.Author;
 import eu.dnetlib.dhp.schema.oaf.Country;
@@ -481,7 +481,7 @@ public class PatentExporterJob {
     }
 
     private static String appendMd5(String prefix, String suffix) {
-        return prefix + AbstractDNetXsltFunctions.md5(suffix);
+        return prefix + DigestUtils.md5Hex(suffix);
     }
 
     @Parameters(separators = "=")

--- a/iis-wf/iis-wf-import/pom.xml
+++ b/iis-wf/iis-wf-import/pom.xml
@@ -89,17 +89,7 @@
 
         <dependency>
             <groupId>eu.dnetlib</groupId>
-            <artifactId>cnr-rmi-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>eu.dnetlib</groupId>
             <artifactId>cnr-resultset-client</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>eu.dnetlib</groupId>
-            <artifactId>dnet-openaireplus-mapping-utils</artifactId>
         </dependency>
 
         <!-- proper spring context version required by cnr-resultset-client -->

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetail.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetail.java
@@ -1,0 +1,75 @@
+package eu.dnetlib.iis.wf.importer.stream.project;
+
+import com.google.gson.Gson;
+
+import java.util.List;
+
+public class ProjectDetail {
+    private String projectId;
+    private String acronym;
+    private String code;
+    private String optional1;
+    private String optional2;
+    private String jsonextrainfo;
+    private List<String> fundingPath;
+
+    public static ProjectDetail fromJson(final String json) {
+        return new Gson().fromJson(json, ProjectDetail.class);
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getAcronym() {
+        return acronym;
+    }
+
+    public void setAcronym(String acronym) {
+        this.acronym = acronym;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getOptional1() {
+        return optional1;
+    }
+
+    public void setOptional1(String optional1) {
+        this.optional1 = optional1;
+    }
+
+    public String getOptional2() {
+        return optional2;
+    }
+
+    public void setOptional2(String optional2) {
+        this.optional2 = optional2;
+    }
+
+    public String getJsonextrainfo() {
+        return jsonextrainfo;
+    }
+
+    public void setJsonextrainfo(String jsonextrainfo) {
+        this.jsonextrainfo = jsonextrainfo;
+    }
+
+    public List<String> getFundingPath() {
+        return fundingPath;
+    }
+
+    public void setFundingPath(List<String> fundingPath) {
+        this.fundingPath = fundingPath;
+    }
+}

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetailConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetailConverter.java
@@ -2,15 +2,14 @@ package eu.dnetlib.iis.wf.importer.stream.project;
 
 import java.io.IOException;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import eu.dnetlib.data.transform.xml.AbstractDNetXsltFunctions;
 import eu.dnetlib.iis.common.InfoSpaceConstants;
 import eu.dnetlib.iis.importer.schemas.Project;
 import eu.dnetlib.iis.wf.importer.infospace.converter.FundingTreeParser;
 import eu.dnetlib.iis.wf.importer.infospace.converter.ProjectConverter;
-import eu.dnetlib.openaire.exporter.model.ProjectDetail;
 
 /**
  * Utility class for converting projects into different representation. 
@@ -63,8 +62,17 @@ public class ProjectDetailConverter {
             throw new RuntimeException("unexpected projectId format: " + sourceId + 
                     ", unable to split into two by " + InfoSpaceConstants.ID_NAMESPACE_SEPARATOR);
         }
-        return AbstractDNetXsltFunctions.oafId("project", 
-                tokenizedProjectId[0], tokenizedProjectId[1]); 
+        return projectOafId(tokenizedProjectId[0], tokenizedProjectId[1]);
     }
-    
+
+    private static String projectOafId(String prefix, String id) {
+        if (id.isEmpty() || prefix.isEmpty()) {
+            return "";
+        }
+        return projectOafSimpleId(prefix + "::" + DigestUtils.md5Hex(id));
+    }
+
+    private static String projectOafSimpleId(String id) {
+        return (InfoSpaceConstants.ROW_PREFIX_PROJECT + id).replaceAll("\\s|\\n", "");
+    }
 }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/StreamingProjectImporter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/stream/project/StreamingProjectImporter.java
@@ -25,7 +25,6 @@ import eu.dnetlib.iis.common.java.porttype.AvroPortType;
 import eu.dnetlib.iis.common.java.porttype.PortType;
 import eu.dnetlib.iis.importer.schemas.Project;
 import eu.dnetlib.iis.wf.importer.facade.ServiceFacadeUtils;
-import eu.dnetlib.openaire.exporter.model.ProjectDetail;
 
 /**
  * {@link Project} importer reading data from stream.

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetailConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/stream/project/ProjectDetailConverterTest.java
@@ -16,7 +16,6 @@ import eu.dnetlib.iis.common.TestsIOUtils;
 import eu.dnetlib.iis.common.java.io.JsonUtils;
 import eu.dnetlib.iis.importer.schemas.Project;
 import eu.dnetlib.iis.wf.importer.infospace.converter.ProjectConverter;
-import eu.dnetlib.openaire.exporter.model.ProjectDetail;
 
 /**
  * @author mhorst

--- a/pom.xml
+++ b/pom.xml
@@ -469,42 +469,7 @@
 
             <dependency>
                 <groupId>eu.dnetlib</groupId>
-                <artifactId>dnet-openaireplus-mapping-utils</artifactId>
-                <version>[6.0.0, 7.0.0)</version>
-                <exclusions>
-                    <!-- unneeded dependencies -->
-                    <exclusion>
-                        <groupId>org.apache.hadoop</groupId>
-                        <artifactId>hadoop-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.hadoop</groupId>
-                        <artifactId>hadoop-hdfs</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.zookeeper</groupId>
-                        <artifactId>zookeeper</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>jgrapht</groupId>
-                        <artifactId>jgrapht</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>eu.dnetlib</groupId>
                 <artifactId>dnet-objectstore-rmi</artifactId>
-                <version>[2.0.0, 3.0.0)</version>
-            </dependency>
-
-            <dependency>
-                <groupId>eu.dnetlib</groupId>
-                <artifactId>cnr-rmi-api</artifactId>
                 <version>[2.0.0, 3.0.0)</version>
             </dependency>
 
@@ -523,12 +488,6 @@
                         <artifactId>spring-webmvc</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>eu.dnetlib</groupId>
-                <artifactId>cnr-service-utils</artifactId>
-                <version>[1.0.0, 2.0.0)</version>
             </dependency>
 
             <!-- command line arguments parser -->
@@ -572,12 +531,6 @@
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
                 <version>1.4.9</version>
-            </dependency>
-
-            <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>xalan</artifactId>
-                <version>2.7.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR closes issues #1066 and #1079 . Changes overview
* removal of dependencies 
* `AbstractDNetXsltFunctions.md5()` replaced by Apache Commons `DigestUtils.md5Hex()`
* `AbstractDNetXsltFunctions.oafId()` moved to ISS with minor improvements
* `ProjectDetail` moved to IIS