### PR TITLE
Closes #1159: Citation matching stage occupies resources for a very long time 

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -203,6 +203,11 @@
                 Set to 'a^' by default to guarantee nothing will be matched.
             </description>
         </property>
+        <!-- citation matching related -->
+        <property>
+            <name>citationmatchingFuzzyNumberOfPartitions</name>
+            <description>number of partitions used for rdds with citations and documents read from input files</description>
+        </property>
         <!-- action set id properties -->
         <property>
             <name>export_action_set_id_document_similarities_standard</name>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -309,7 +309,6 @@
         </property>
         <property>
             <name>citationmatchingFuzzyNumberOfPartitions</name>
-            <value>1000</value>
             <description>number of partitions used for rdds with citations and documents read from input files</description>
         </property>
         <property>

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -402,6 +402,10 @@
                     <name>citationmatchingFuzzySparkExecutorOverhead</name>
                     <value>512</value>
                 </property>
+				<property>
+					<name>citationmatchingFuzzyNumberOfPartitions</name>
+					<value>1000</value>
+				</property>
                 <property>
                     <name>researchInitiativeReferenceExtractionSparkExecutorOverhead</name>
                     <value>512</value>


### PR DESCRIPTION
This PR removes hardcoded value for citation matching number of partitions and moves the parameter to IIS deployment  repository. As a result the value of this parameter will be set upon deployment of IIS. Therefore this PR is matched by PR in IIS deployment repo.

