### PR TITLE
#1173: java.net.ConnectException in integration tests

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJobTest.java
@@ -18,7 +18,8 @@ import eu.dnetlib.iis.referenceextraction.patent.schemas.ImportedPatent;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.ZKFailoverController;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -57,10 +58,15 @@ public class PatentMetadataRetrieverJobTest {
     private Path outputReport2Dir;
     private Path cacheRootDir;
     
-    private TestingServer zookeeperServer;
+    private static TestingServer zookeeperServer;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        zookeeperServer = new TestingServer(true);
+    }
 
     @BeforeEach
-    public void before() throws Exception {
+    public void beforeEach() {
         inputDir = workingDir.resolve("input");
         input2Dir = workingDir.resolve("input2");
         outputDir = workingDir.resolve("output");
@@ -70,12 +76,11 @@ public class PatentMetadataRetrieverJobTest {
         outputReportDir = workingDir.resolve("report");
         outputReport2Dir = workingDir.resolve("report2");
         cacheRootDir = workingDir.resolve("cache");
-        zookeeperServer = new TestingServer(true);
     }
 
-    @AfterEach
-    public void after() throws IOException {
-        zookeeperServer.stop();
+    @AfterAll
+    public static void after() throws IOException {
+        zookeeperServer.close();
     }
 
     @Test

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/CachedWebCrawlerJobTest.java
@@ -20,7 +20,8 @@ import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ha.ZKFailoverController;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -66,10 +67,15 @@ public class CachedWebCrawlerJobTest {
     
     private Path cacheRootDir;
     
-    private TestingServer zookeeperServer;
-    
+    private static TestingServer zookeeperServer;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        zookeeperServer = new TestingServer(true);
+    }
+
     @BeforeEach
-    public void before() throws Exception {
+    public void beforeEach() {
         inputPath = workingDir + "/spark_webcrawler/input";
         input2Path = workingDir + "/spark_webcrawler/input2";
         outputPath = workingDir + "/spark_webcrawler/output";
@@ -79,12 +85,11 @@ public class CachedWebCrawlerJobTest {
         outputReportPath = workingDir + "/spark_webcrawler/report";
         outputReport2Path = workingDir + "/spark_webcrawler/report2";
         cacheRootDir = new Path(workingDir + "/spark_webcrawler/cache");
-        zookeeperServer = new TestingServer(true);
     }
     
-    @AfterEach
-    public void after() throws IOException {
-        zookeeperServer.stop();
+    @AfterAll
+    public static void afterAll() throws IOException {
+        zookeeperServer.close();
     }
     
     


### PR DESCRIPTION
This PR is an attempt to eliminate `java.net.ConnectException` from integration tests. Inside this PR we're converting instances of `org.apache.curator.test.TestingServer` used in tests to static variables and using `close()` rather than `stop()` for server termination. Local testing shows that this may be the cause of the exceptions. However, further changes may be required and integration tests log must be checked for exceptions afterwards.

Linked issue: #1173 .