### PR TITLE
Closes #1184: Refactor tests with SparkSession to use common base class for SparkSession management

### DIFF
--- a/iis-common/src/test/java/eu/dnetlib/iis/common/SlowTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/SlowTest.java
@@ -2,16 +2,14 @@ package eu.dnetlib.iis.common;
 
 import org.junit.jupiter.api.Tag;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Slow test markup.
  * <p>
  * Slow tests are unit tests with long execution time.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Tag("SlowTest")

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkSession.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkSession.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  */
 @SlowTest
 public class TestWithSharedSparkSession {
-    private static transient SparkSession _spark;
+    private static SparkSession _spark;
     protected boolean initialized = false;
 
     public SparkSession spark() {
@@ -26,6 +26,7 @@ public class TestWithSharedSparkSession {
 
         if (!initialized) {
             SparkConf conf = new SparkConf();
+            conf.setAppName(getClass().getSimpleName());
             conf.setMaster("local");
             conf.set("spark.driver.host", "localhost");
             conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkSession.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkSession.java
@@ -1,5 +1,6 @@
 package eu.dnetlib.iis.common.spark;
 
+import eu.dnetlib.iis.common.SlowTest;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
@@ -10,6 +11,7 @@ import java.util.Objects;
 /**
  * Support for tests using {@link SparkSession} - extends this class to access SparkSession in local mode.
  */
+@SlowTest
 public class TestWithSharedSparkSession {
     private static transient SparkSession _spark;
     protected boolean initialized = false;
@@ -26,6 +28,7 @@ public class TestWithSharedSparkSession {
             SparkConf conf = new SparkConf();
             conf.setMaster("local");
             conf.set("spark.driver.host", "localhost");
+            conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
             _spark = SparkSession.builder().config(conf).getOrCreate();
         }
     }

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDataFrameSupportTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDataFrameSupportTest.java
@@ -1,19 +1,16 @@
 package eu.dnetlib.iis.common.spark.avro;
 
-import eu.dnetlib.iis.common.SlowTest;
 import eu.dnetlib.iis.common.avro.Person;
+import eu.dnetlib.iis.common.spark.TestWithSharedSparkSession;
 import eu.dnetlib.iis.common.utils.AvroTestUtils;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.avro.SchemaConverters;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,28 +21,17 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SlowTest
-public class AvroDataFrameSupportTest {
+public class AvroDataFrameSupportTest extends TestWithSharedSparkSession {
 
-    private static SparkSession spark;
-    private static AvroDataFrameSupport avroDataFrameSupport;
+    private AvroDataFrameSupport avroDataFrameSupport;
 
     @TempDir
     public static Path workingDir;
 
-    @BeforeAll
-    public static void beforeAll() {
-        SparkConf conf = new SparkConf();
-        conf.setMaster("local");
-        conf.set("spark.driver.host", "localhost");
-        conf.setAppName(AvroDataFrameSupportTest.class.getSimpleName());
-        spark = SparkSession.builder().config(conf).getOrCreate();
-        avroDataFrameSupport = new AvroDataFrameSupport(spark);
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        spark.stop();
+    @BeforeEach
+    public void beforeEach() {
+        super.beforeEach();
+        avroDataFrameSupport = new AvroDataFrameSupport(spark());
     }
 
     @Test
@@ -115,7 +101,7 @@ public class AvroDataFrameSupportTest {
         // given
         Path outputDir = workingDir.resolve("output1");
         Row personRow = RowFactory.create(1, "name", 2);
-        Dataset<Row> df = spark.createDataFrame(
+        Dataset<Row> df = spark().createDataFrame(
                 Collections.singletonList(personRow),
                 (StructType) SchemaConverters.toSqlType(Person.SCHEMA$).dataType()
         );
@@ -137,7 +123,7 @@ public class AvroDataFrameSupportTest {
         // given
         Path outputDir = workingDir.resolve("output2");
         Row personRow = RowFactory.create(1, "name", 2);
-        Dataset<Row> df = spark.createDataFrame(
+        Dataset<Row> df = spark().createDataFrame(
                 Collections.singletonList(personRow),
                 (StructType) SchemaConverters.toSqlType(Person.SCHEMA$).dataType()
         );
@@ -159,7 +145,7 @@ public class AvroDataFrameSupportTest {
         // given
         Row personRow = RowFactory.create(1, "name", 2);
         List<Row> data = Collections.singletonList(personRow);
-        Dataset<Row> df = spark.createDataFrame(
+        Dataset<Row> df = spark().createDataFrame(
                 data, (StructType) SchemaConverters.toSqlType(Person.SCHEMA$).dataType()
         );
 

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDatasetSupportTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDatasetSupportTest.java
@@ -1,18 +1,15 @@
 package eu.dnetlib.iis.common.spark.avro;
 
-import eu.dnetlib.iis.common.SlowTest;
 import eu.dnetlib.iis.common.avro.Person;
+import eu.dnetlib.iis.common.spark.TestWithSharedSparkSession;
 import eu.dnetlib.iis.common.utils.AvroTestUtils;
 import org.apache.avro.Schema;
-import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.avro.SchemaConverters;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -23,27 +20,16 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SlowTest
-public class AvroDatasetSupportTest {
-    private static SparkSession spark;
-    private static AvroDatasetSupport avroDatasetSupport;
+public class AvroDatasetSupportTest extends TestWithSharedSparkSession {
+    private AvroDatasetSupport avroDatasetSupport;
 
     @TempDir
     public static Path workingDir;
 
-    @BeforeAll
-    public static void beforeAll() {
-        SparkConf conf = new SparkConf();
-        conf.setMaster("local");
-        conf.set("spark.driver.host", "localhost");
-        conf.setAppName(AvroDatasetSupportTest.class.getSimpleName());
-        spark = SparkSession.builder().config(conf).getOrCreate();
-        avroDatasetSupport = new AvroDatasetSupport(spark);
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        spark.stop();
+    @BeforeEach
+    public void beforeEach() {
+        super.beforeEach();
+        avroDatasetSupport = new AvroDatasetSupport(spark());
     }
 
     @Test
@@ -69,7 +55,7 @@ public class AvroDatasetSupportTest {
         // given
         Path outputDir = workingDir.resolve("output");
         Person person = Person.newBuilder().setId(1).setName("name").setAge(2).build();
-        Dataset<Person> ds = spark.createDataset(
+        Dataset<Person> ds = spark().createDataset(
                 Collections.singletonList(person),
                 Encoders.kryo(Person.class)
         );
@@ -88,7 +74,7 @@ public class AvroDatasetSupportTest {
     public void toDFShouldRunProperly() {
         // given
         Person person = Person.newBuilder().setId(1).setName("name").setAge(2).build();
-        Dataset<Person> ds = spark.createDataset(
+        Dataset<Person> ds = spark().createDataset(
                 Collections.singletonList(person),
                 Encoders.kryo(Person.class)
         );

--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/tara/TaraReferenceExtractionIOUtilsTest.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/project/tara/TaraReferenceExtractionIOUtilsTest.java
@@ -1,15 +1,11 @@
 package eu.dnetlib.iis.wf.referenceextraction.project.tara;
 
-import eu.dnetlib.iis.common.SlowTest;
+import eu.dnetlib.iis.common.spark.TestWithSharedSparkSession;
 import eu.dnetlib.iis.common.spark.avro.AvroDataFrameSupport;
 import eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject;
-import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.avro.SchemaConverters;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -22,24 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.*;
 
-@SlowTest
-public class TaraReferenceExtractionIOUtilsTest {
-
-    private static SparkSession spark;
-
-    @BeforeAll
-    public static void beforeAll() {
-        SparkConf conf = new SparkConf();
-        conf.setMaster("local");
-        conf.set("spark.driver.host", "localhost");
-        conf.setAppName(TaraReferenceExtractionIOUtilsTest.class.getSimpleName());
-        spark = SparkSession.builder().config(conf).getOrCreate();
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        spark.stop();
-    }
+public class TaraReferenceExtractionIOUtilsTest extends TestWithSharedSparkSession {
 
     @Test
     public void clearOutputShouldRunProperly() throws IOException {
@@ -62,7 +41,7 @@ public class TaraReferenceExtractionIOUtilsTest {
                 .setConfidenceLevel(1.0f)
                 .build();
         List<DocumentToProject> documentToProjectList = Collections.singletonList(documentToProject);
-        Dataset<Row> documentToProjectDF = new AvroDataFrameSupport(spark).createDataFrame(
+        Dataset<Row> documentToProjectDF = new AvroDataFrameSupport(spark()).createDataFrame(
                 documentToProjectList,
                 DocumentToProject.SCHEMA$);
         AvroDataStoreWriter writer = mock(AvroDataStoreWriter.class);


### PR DESCRIPTION
This PR closes #1184 .

Each test extending `eu.dnetlib.iis.common.spark.TestWithSharedSparkSession` will automatically be tagged as slow test.

One thing to note is that if a test extending `eu.dnetlib.iis.common.spark.TestWithSharedSparkSession` has also `BeforeEach` method then test's `BeforeEach` method must call base class `BeforeEach` method by using `super.beforeEach()`.