### PR TITLE
Closes #1185: Refactor tests with SparkContext to use common base class for SparkContext management

### DIFF
--- a/iis-common/src/test/java/eu/dnetlib/iis/common/SlowTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/SlowTest.java
@@ -2,16 +2,14 @@ package eu.dnetlib.iis.common;
 
 import org.junit.jupiter.api.Tag;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Slow test markup.
  * <p>
  * Slow tests are unit tests with long execution time.
  */
+@Inherited
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Tag("SlowTest")

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkContext.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkContext.java
@@ -1,0 +1,50 @@
+package eu.dnetlib.iis.common.spark;
+
+import eu.dnetlib.iis.common.SlowTest;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Objects;
+
+/**
+ * Support for tests using {@link org.apache.spark.SparkContext} - extends this class to access SparkContext in local mode.
+ */
+@SlowTest
+public class TestWithSharedSparkContext {
+    private static transient SparkContext _sc;
+    private static transient JavaSparkContext _jsc;
+    protected boolean initialized = false;
+
+    protected SparkContext sc() {
+        return _sc;
+    }
+
+    protected JavaSparkContext jsc() {
+        return _jsc;
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        initialized = Objects.nonNull(_sc);
+
+        if (!initialized) {
+            SparkConf conf = new SparkConf();
+            conf.setAppName(getClass().getSimpleName());
+            conf.setMaster("local");
+            conf.set("spark.driver.host", "localhost");
+            conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+            _sc = new SparkContext(conf);
+            _jsc = new JavaSparkContext(_sc);
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        _sc.stop();
+        _sc = null;
+        _jsc = null;
+    }
+}

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkContext.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/TestWithSharedSparkContext.java
@@ -14,13 +14,9 @@ import java.util.Objects;
  */
 @SlowTest
 public class TestWithSharedSparkContext {
-    private static transient SparkContext _sc;
-    private static transient JavaSparkContext _jsc;
+    private static SparkContext _sc;
+    private static JavaSparkContext _jsc;
     protected boolean initialized = false;
-
-    protected SparkContext sc() {
-        return _sc;
-    }
 
     protected JavaSparkContext jsc() {
         return _jsc;

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/bucket/DocOrgRelationAffOrgJoinerTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/bucket/DocOrgRelationAffOrgJoinerTest.java
@@ -1,17 +1,12 @@
 package eu.dnetlib.iis.wf.affmatching.bucket;
 
 import com.google.common.collect.ImmutableList;
-import eu.dnetlib.iis.common.SlowTest;
-import eu.dnetlib.iis.common.spark.JavaSparkContextFactory;
+import eu.dnetlib.iis.common.spark.TestWithSharedSparkContext;
 import eu.dnetlib.iis.wf.affmatching.bucket.projectorg.model.AffMatchDocumentOrganization;
 import eu.dnetlib.iis.wf.affmatching.bucket.projectorg.read.DocumentOrganizationFetcher;
 import eu.dnetlib.iis.wf.affmatching.model.AffMatchAffiliation;
 import eu.dnetlib.iis.wf.affmatching.model.AffMatchOrganization;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,9 +23,8 @@ import static org.mockito.Mockito.when;
 /**
  * @author madryk
  */
-@SlowTest
 @ExtendWith(MockitoExtension.class)
-public class DocOrgRelationAffOrgJoinerTest {
+public class DocOrgRelationAffOrgJoinerTest extends TestWithSharedSparkContext {
 
     @InjectMocks
     private DocOrgRelationAffOrgJoiner docOrgRelationAffOrgJoiner = new DocOrgRelationAffOrgJoiner();
@@ -38,30 +32,12 @@ public class DocOrgRelationAffOrgJoinerTest {
     @Mock
     private DocumentOrganizationFetcher documentOrganizationFetcher;
 
-    private JavaSparkContext sparkContext;
-
-    @BeforeEach
-    public void setup() {
-        SparkConf conf = new SparkConf();
-        conf.setMaster("local");
-        conf.set("spark.driver.host", "localhost");
-        conf.setAppName(DocOrgRelationAffOrgJoinerTest.class.getSimpleName());
-        sparkContext = JavaSparkContextFactory.withConfAndKryo(conf);
-    }
-    
-    @AfterEach
-    public void cleanup() {
-        if (sparkContext != null) {
-            sparkContext.close();
-        }
-    }
-
     //------------------------ TESTS --------------------------
     
     @Test
     public void join() {
         // given
-        JavaRDD<AffMatchAffiliation> affiliations = sparkContext.parallelize(ImmutableList.of(
+        JavaRDD<AffMatchAffiliation> affiliations = jsc().parallelize(ImmutableList.of(
                 new AffMatchAffiliation("DOC1", 1),
                 new AffMatchAffiliation("DOC1", 2),
                 new AffMatchAffiliation("DOC2", 1), // document not present in documentOrganizations rdd
@@ -69,13 +45,13 @@ public class DocOrgRelationAffOrgJoinerTest {
                 new AffMatchAffiliation("DOC3", 2),
                 new AffMatchAffiliation("DOC3", 3)));
         
-        JavaRDD<AffMatchOrganization> organizations = sparkContext.parallelize(ImmutableList.of(
+        JavaRDD<AffMatchOrganization> organizations = jsc().parallelize(ImmutableList.of(
                 new AffMatchOrganization("ORG1"), // organization not present in documentOrganizations rdd
                 new AffMatchOrganization("ORG2"), 
                 new AffMatchOrganization("ORG3"),
                 new AffMatchOrganization("ORG4")));
         
-        JavaRDD<AffMatchDocumentOrganization> documentOrganizations = sparkContext.parallelize(ImmutableList.of(
+        JavaRDD<AffMatchDocumentOrganization> documentOrganizations = jsc().parallelize(ImmutableList.of(
                 new AffMatchDocumentOrganization("DOC1", "ORG2"),
                 new AffMatchDocumentOrganization("DOC3", "ORG3"),
                 new AffMatchDocumentOrganization("DOC3", "ORG4"),

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/bucket/projectorg/read/DocumentProjectMergerTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/bucket/projectorg/read/DocumentProjectMergerTest.java
@@ -1,13 +1,8 @@
 package eu.dnetlib.iis.wf.affmatching.bucket.projectorg.read;
 
-import eu.dnetlib.iis.common.SlowTest;
-import eu.dnetlib.iis.common.spark.JavaSparkContextFactory;
+import eu.dnetlib.iis.common.spark.TestWithSharedSparkContext;
 import eu.dnetlib.iis.wf.affmatching.bucket.projectorg.model.AffMatchDocumentProject;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,40 +14,21 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 /**
  * @author madryk
  */
-@SlowTest
-public class DocumentProjectMergerTest {
+public class DocumentProjectMergerTest extends TestWithSharedSparkContext {
 
     private DocumentProjectMerger documentProjectMerger = new DocumentProjectMerger();
-
-    private JavaSparkContext sparkContext;
-
-    @BeforeEach
-    public void setup() {
-        SparkConf conf = new SparkConf();
-        conf.setMaster("local");
-        conf.set("spark.driver.host", "localhost");
-        conf.setAppName(DocumentProjectMergerTest.class.getSimpleName());
-        sparkContext = JavaSparkContextFactory.withConfAndKryo(conf);
-    }
-
-    @AfterEach
-    public void cleanup() {
-        if (sparkContext != null) {
-            sparkContext.close();
-        }
-    }
 
     //------------------------ TESTS --------------------------
 
     @Test
     public void merge() {
         // given
-        JavaRDD<AffMatchDocumentProject> firstDocumentProjects = sparkContext.parallelize(of(
+        JavaRDD<AffMatchDocumentProject> firstDocumentProjects = jsc().parallelize(of(
                 new AffMatchDocumentProject("DOC1", "PROJ1", 1f),
                 new AffMatchDocumentProject("DOC1", "PROJ2", 0.6f),
                 new AffMatchDocumentProject("DOC1", "PROJ3", 0.4f),
                 new AffMatchDocumentProject("DOC2", "PROJ4", 0.8f)));
-        JavaRDD<AffMatchDocumentProject> secondDocumentProjects = sparkContext.parallelize(of(
+        JavaRDD<AffMatchDocumentProject> secondDocumentProjects = jsc().parallelize(of(
                 new AffMatchDocumentProject("DOC1", "PROJ1", 0.3f),
                 new AffMatchDocumentProject("DOC1", "PROJ2", 1f),
                 new AffMatchDocumentProject("DOC1", "PROJ4", 0.7f)));


### PR DESCRIPTION
This PR closes #1185  .

Each test extending `eu.dnetlib.iis.common.spark.TestWithSharedSparkContext` will automatically be tagged as slow test.

One thing to note is that if a test extending `eu.dnetlib.iis.common.spark.TestWithSharedSparkContext` has also `BeforeEach` method then test's `BeforeEach` method must call base class `BeforeEach` method by using `super.beforeEach()`.