### PR TITLE
Closes #1050: Handle trust level threshold in citation matching exporter module

### DIFF
--- a/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/AbstractExtraInfoSerDe.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/AbstractExtraInfoSerDe.java
@@ -12,11 +12,11 @@ import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
  * @author mhorst
  *
  */
-public abstract class AbstractExtraInfoConverter<T> implements ExtraInfoConverter<T> {
+public abstract class AbstractExtraInfoSerDe<T> implements ExtraInfoSerDe<T> {
 
 	private final XStream xstream;
 	
-	public AbstractExtraInfoConverter() {
+	public AbstractExtraInfoSerDe() {
 		xstream = new XStream(new DomDriver());
 		xstream.setMode(XStream.NO_REFERENCES);
 		

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/CitationsExtraInfoSerDe.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/CitationsExtraInfoSerDe.java
@@ -10,9 +10,9 @@ import eu.dnetlib.iis.common.model.extrainfo.citations.BlobCitationEntry;
  * @author mhorst
  *
  */
-public class CitationsExtraInfoConverter extends AbstractExtraInfoConverter<SortedSet<BlobCitationEntry>> {
+public class CitationsExtraInfoSerDe extends AbstractExtraInfoSerDe<SortedSet<BlobCitationEntry>> {
 
-	public CitationsExtraInfoConverter() {
+	public CitationsExtraInfoSerDe() {
 	    super();
 		getXstream().processAnnotations(BlobCitationEntry.class);
 		getXstream().alias("citations", SortedSet.class);

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/ExtraInfoSerDe.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/model/extrainfo/converter/ExtraInfoSerDe.java
@@ -6,7 +6,7 @@ package eu.dnetlib.iis.common.model.extrainfo.converter;
  *
  * @param <T>
  */
-public interface ExtraInfoConverter<T> {
+public interface ExtraInfoSerDe<T> {
 
 	/**
 	 * Serializes object to its XML representation.

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/model/extrainfo/converter/CitationsExtraInfoSerDeTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/model/extrainfo/converter/CitationsExtraInfoSerDeTest.java
@@ -15,24 +15,24 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author mhorst
  *
  */
-public class CitationsExtraInfoConverterTest {
+public class CitationsExtraInfoSerDeTest {
 
-    CitationsExtraInfoConverter converter = new CitationsExtraInfoConverter();
+    CitationsExtraInfoSerDe serDe = new CitationsExtraInfoSerDe();
     
     @Test
     public void testSerializeNull() throws Exception {
-        String result = converter.serialize(null);
+        String result = serDe.serialize(null);
         assertEquals("<null/>", result);
     }
     
     @Test
     public void testDeserializeNull() {
-        assertThrows(NullPointerException.class, () -> converter.deserialize(null));
+        assertThrows(NullPointerException.class, () -> serDe.deserialize(null));
     }
     
     @Test
     public void testGetXStream() throws Exception {
-        assertNotNull(converter.getXstream());
+        assertNotNull(serDe.getXstream());
     }
     
     @Test
@@ -57,8 +57,8 @@ public class CitationsExtraInfoConverterTest {
         entrySet.add(entry);
         
         // execute
-        String resultStr = converter.serialize(entrySet);
-        SortedSet<BlobCitationEntry> resultSet = converter.deserialize(resultStr);
+        String resultStr = serDe.serialize(entrySet);
+        SortedSet<BlobCitationEntry> resultSet = serDe.deserialize(resultStr);
         
         // assert
         assertNotNull(resultSet);

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
@@ -1,14 +1,5 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.conf.Configuration;
-
 import eu.dnetlib.dhp.schema.oaf.ExtraInfo;
 import eu.dnetlib.dhp.schema.oaf.Result;
 import eu.dnetlib.iis.common.InfoSpaceConstants;
@@ -18,12 +9,20 @@ import eu.dnetlib.iis.common.model.extrainfo.citations.BlobCitationEntry;
 import eu.dnetlib.iis.common.model.extrainfo.converter.CitationsExtraInfoConverter;
 import eu.dnetlib.iis.export.schemas.Citations;
 import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
+import eu.dnetlib.iis.wf.export.actionmanager.entity.ConfidenceLevelUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * {@link Citations} based action builder module.
- * 
- * @author mhorst
  *
+ * @author mhorst
  */
 public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFactory<Citations, Result> {
 
@@ -31,50 +30,50 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
     private static final String EXTRA_INFO_TYPOLOGY = ExtraInfoConstants.TYPOLOGY_CITATIONS;
 
     // ------------------------ CONSTRUCTORS --------------------------
-    
+
     public CitationsActionBuilderModuleFactory() {
         super(AlgorithmName.document_referencedDocuments);
     }
 
     // ------------------------ LOGIC ---------------------------------
-    
+
     @Override
     public ActionBuilderModule<Citations, Result> instantiate(Configuration config) {
         return new CitationActionBuilderModule(provideTrustLevelThreshold(config));
     }
 
     // ------------------------ INNER CLASS  --------------------------
-    
+
     class CitationActionBuilderModule extends AbstractEntityBuilderModule<Citations, Result> {
 
-        private CitationsExtraInfoConverter converter = new CitationsExtraInfoConverter();
+        private CitationsExtraInfoConverter citationsExtraInfoConverter = new CitationsExtraInfoConverter();
+        private CitationEntriesConverter citationEntriesConverter = new CitationEntriesConverter();
 
         // ------------------------ CONSTRUCTORS --------------------------
-        
+
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param agent action manager agent details
-         * @param actionSetId action set identifier
          */
         public CitationActionBuilderModule(Float trustLevelThreshold) {
             super(trustLevelThreshold, buildInferenceProvenance());
         }
 
         // ------------------------ LOGIC --------------------------
-        
+
         @Override
         protected Class<Result> getResultClass() {
             return Result.class;
         }
-        
+
         @Override
         protected Result convert(Citations source) {
             if (CollectionUtils.isNotEmpty(source.getCitations())) {
                 Result result = new Result();
                 result.setId(source.getDocumentId().toString());
-                
+
                 ExtraInfo extraInfo = new ExtraInfo();
-                extraInfo.setValue(converter.serialize(normalize(source.getCitations())));
+                extraInfo.setValue(citationsExtraInfoConverter.serialize(
+                        citationEntriesConverter.convert(source.getCitations(), getTrustLevelThreshold())));
                 extraInfo.setName(EXTRA_INFO_NAME);
                 extraInfo.setTypology(EXTRA_INFO_TYPOLOGY);
                 extraInfo.setProvenance(this.getInferenceProvenance());
@@ -82,37 +81,131 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
                 result.setExtraInfo(Collections.singletonList(extraInfo));
 
                 return result;
-            } else {
-                return null;    
+            }
+            return null;
+        }
+
+        public void setCitationsExtraInfoConverter(CitationsExtraInfoConverter citationsExtraInfoConverter) {
+            this.citationsExtraInfoConverter = citationsExtraInfoConverter;
+        }
+
+        public void setCitationEntriesConverter(CitationEntriesConverter citationEntriesConverter) {
+            this.citationEntriesConverter = citationEntriesConverter;
+        }
+    }
+
+    /**
+     * Allows citation entry list to be converted to blob citation entry list.
+     */
+    public static class CitationEntriesConverter {
+        private TrustLevelConverter trustLevelConverter = new TrustLevelConverter(InfoSpaceConstants.CONFIDENCE_TO_TRUST_LEVEL_FACTOR);
+        private CitationEntryMatchValidator citationEntryMatchValidator = new CitationEntryMatchValidator();
+        private CitationEntryNormalizer citationEntryNormalizer = new CitationEntryNormalizer();
+        private BlobCitationEntryBuilder blobCitationEntryBuilder = new BlobCitationEntryBuilder();
+
+        public SortedSet<BlobCitationEntry> convert(List<CitationEntry> source, Float trustLevelThreshold) {
+            if (source != null) {
+                Float confidenceLevelThreshold = trustLevelConverter.convert(trustLevelThreshold);
+                return source.stream()
+                        .map(citationEntry -> citationEntryNormalizer.normalize(citationEntry,
+                                citationEntryMatchValidator.validate(citationEntry, confidenceLevelThreshold)
+                        ))
+                        .map(citationEntry -> blobCitationEntryBuilder.build(citationEntry))
+                        .collect(Collectors.toCollection(TreeSet::new));
+            }
+            return null;
+        }
+
+        /**
+         * Allows trust level threshold to be converted to confidence level threshold.
+         */
+        public static class TrustLevelConverter {
+            private Float conversionFactor;
+
+            public TrustLevelConverter(Float conversionFactor) {
+                this.conversionFactor = conversionFactor;
+            }
+
+            public Float convert(Float trustLevelThreshold) {
+                return Optional.ofNullable(trustLevelThreshold)
+                        .map(x -> x / conversionFactor)
+                        .orElse(null);
             }
         }
 
-        // ------------------------ PRIVATE --------------------------
-        
         /**
-         * Performs confidence level normalization. Removes empty lists. 
-         * Removes 50| prefix from publication identifier.
-         * 
-         * @param source list of citations to be normalized
-         * @return {@link BlobCitationEntry} objects having confidence level value normalized
+         * Allows to validate citation entry match.
          */
-        private SortedSet<BlobCitationEntry> normalize(List<CitationEntry> source) {
-            if (source != null) {
-                SortedSet<BlobCitationEntry> results = new TreeSet<BlobCitationEntry>();
-                for (CitationEntry currentEntry : source) {
-                    if (currentEntry.getExternalDestinationDocumentIds().isEmpty()) {
-                        currentEntry.setExternalDestinationDocumentIds(null);
-                    }
-                    if (currentEntry.getDestinationDocumentId() != null) {
-                        currentEntry.setDestinationDocumentId(
-                                StringUtils.split(currentEntry.getDestinationDocumentId().toString(),
-                                        InfoSpaceConstants.ROW_PREFIX_SEPARATOR)[1]);
-                    }
-                    results.add(CitationsActionBuilderModuleUtils.build(currentEntry));
+        public static class CitationEntryMatchValidator {
+            private ConfidenceLevelValidator confidenceLevelValidator = new ConfidenceLevelValidator();
+
+            public Boolean validate(CitationEntry citationEntry, Float confidenceLevelThreshold) {
+                if (Objects.isNull(citationEntry.getConfidenceLevel())) {
+                    return false;
                 }
-                return results;
-            } else {
-                return null;
+                return confidenceLevelValidator.validate(citationEntry.getConfidenceLevel(), confidenceLevelThreshold);
+            }
+
+            /**
+             * Allows to validate confidence level against threshold using {@link ConfidenceLevelUtils}.
+             */
+            public static class ConfidenceLevelValidator {
+                private BiFunction<Float, Float, Boolean> thresholdValidatorFn = ConfidenceLevelUtils::isValidConfidenceLevel;
+
+                public Boolean validate(Float confidenceLevel, Float confidenceLevelThreshold) {
+                    return thresholdValidatorFn.apply(confidenceLevel, confidenceLevelThreshold);
+                }
+            }
+        }
+
+        /**
+         * Allows to normalize a citation entry based on match validity.
+         */
+        public static class CitationEntryNormalizer {
+            private ValidMatchCitationEntryNormalizer validMatchCitationEntryNormalizer = new ValidMatchCitationEntryNormalizer();
+            private InvalidMatchCitationEntryNormalizer invalidMatchCitationEntryNormalizer = new InvalidMatchCitationEntryNormalizer();
+
+            public CitationEntry normalize(CitationEntry citationEntry, Boolean isMatchValid) {
+                if (isMatchValid) {
+                    return validMatchCitationEntryNormalizer.normalize(citationEntry);
+                }
+                return invalidMatchCitationEntryNormalizer.normalize(citationEntry);
+            }
+
+            /**
+             * Allows to normalize a valid match citation entry.
+             * * removes '50|' prefix from publication identifier
+             */
+            public static class ValidMatchCitationEntryNormalizer {
+                private Function<CharSequence, CharSequence> destinationDocumentIdNormalizerFn = destinationDocumentId ->
+                        StringUtils.split(destinationDocumentId.toString(), InfoSpaceConstants.ROW_PREFIX_SEPARATOR)[1];
+
+                public CitationEntry normalize(CitationEntry citationEntry) {
+                    citationEntry.setDestinationDocumentId(destinationDocumentIdNormalizerFn.apply(citationEntry.getDestinationDocumentId()));
+                    return citationEntry;
+                }
+            }
+
+            /**
+             * Allows to normalize an invalid match citation entry.
+             */
+            public static class InvalidMatchCitationEntryNormalizer {
+                public CitationEntry normalize(CitationEntry citationEntry) {
+                    citationEntry.setDestinationDocumentId(null);
+                    citationEntry.setConfidenceLevel(null);
+                    return citationEntry;
+                }
+            }
+        }
+
+        /**
+         * Allows to build a blob citation entry from citation entry using {@link CitationsActionBuilderModuleUtils}.
+         */
+        public static class BlobCitationEntryBuilder {
+            private Function<CitationEntry, BlobCitationEntry> builderFn = CitationsActionBuilderModuleUtils::build;
+
+            public BlobCitationEntry build(CitationEntry citationEntry) {
+                return builderFn.apply(citationEntry);
             }
         }
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
@@ -95,7 +95,7 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
     }
 
     /**
-     * Allows citation entry list to be converted to blob citation entry list.
+     * Allows citation entry list to be converted to blob citation entry set.
      */
     public static class CitationEntriesConverter {
         private TrustLevelConverter trustLevelConverter = new TrustLevelConverter(InfoSpaceConstants.CONFIDENCE_TO_TRUST_LEVEL_FACTOR);

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
@@ -165,27 +165,17 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
          * Allows to normalize a citation entry.
          */
         public static class CitationEntryNormalizer {
-            private DestinationDocumentIdNormalizer destinationDocumentIdNormalizer = new DestinationDocumentIdNormalizer();
+            /**
+             * Normalizes destination document id by removing '50|' prefix from publication identifier
+             */
+            private Function<CharSequence, CharSequence> destinationDocumentIdNormalizerFn = destinationDocumentId ->
+                    StringUtils.split(destinationDocumentId.toString(), InfoSpaceConstants.ROW_PREFIX_SEPARATOR)[1];
 
             public CitationEntry normalize(CitationEntry citationEntry) {
                 if (Objects.nonNull(citationEntry.getDestinationDocumentId())) {
-                    return destinationDocumentIdNormalizer.normalize(citationEntry);
+                    citationEntry.setDestinationDocumentId(destinationDocumentIdNormalizerFn.apply(citationEntry.getDestinationDocumentId()));
                 }
                 return citationEntry;
-            }
-
-            /**
-             * Allows to normalize a destination document id of citation entry
-             * * removes '50|' prefix from publication identifier
-             */
-            public static class DestinationDocumentIdNormalizer {
-                private Function<CharSequence, CharSequence> destinationDocumentIdNormalizerFn = destinationDocumentId ->
-                        StringUtils.split(destinationDocumentId.toString(), InfoSpaceConstants.ROW_PREFIX_SEPARATOR)[1];
-
-                public CitationEntry normalize(CitationEntry citationEntry) {
-                    citationEntry.setDestinationDocumentId(destinationDocumentIdNormalizerFn.apply(citationEntry.getDestinationDocumentId()));
-                    return citationEntry;
-                }
             }
         }
 

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
@@ -165,21 +165,20 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
          * Allows to normalize a citation entry.
          */
         public static class CitationEntryNormalizer {
-            private CitationEntryMatchChecker citationEntryMatchChecker = new CitationEntryMatchChecker();
-            private MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer = new MatchingResultCitationEntryNormalizer();
+            private DestinationDocumentIdNormalizer destinationDocumentIdNormalizer = new DestinationDocumentIdNormalizer();
 
             public CitationEntry normalize(CitationEntry citationEntry) {
-                if (citationEntryMatchChecker.isMatchingResult(citationEntry)) {
-                    return matchingResultCitationEntryNormalizer.normalize(citationEntry);
+                if (Objects.nonNull(citationEntry.getDestinationDocumentId())) {
+                    return destinationDocumentIdNormalizer.normalize(citationEntry);
                 }
                 return citationEntry;
             }
 
             /**
-             * Allows to normalize a citation entry containing the outcome of citation matching
+             * Allows to normalize a destination document id of citation entry
              * * removes '50|' prefix from publication identifier
              */
-            public static class MatchingResultCitationEntryNormalizer {
+            public static class DestinationDocumentIdNormalizer {
                 private Function<CharSequence, CharSequence> destinationDocumentIdNormalizerFn = destinationDocumentId ->
                         StringUtils.split(destinationDocumentId.toString(), InfoSpaceConstants.ROW_PREFIX_SEPARATOR)[1];
 

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactory.java
@@ -133,13 +133,25 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
         }
 
         /**
+         * Allows to check if a citation entry contains the outcome of citation matching.
+         */
+        public static class CitationEntryMatchChecker {
+
+            public Boolean isMatchingResult(CitationEntry citationEntry) {
+                return Objects.nonNull(citationEntry.getConfidenceLevel()) &&
+                        Objects.nonNull(citationEntry.getDestinationDocumentId());
+            }
+        }
+
+        /**
          * Allows to validate confidence level of citation entry using {@link ConfidenceLevelUtils}.
          */
         public static class ConfidenceLevelValidator {
+            private CitationEntryMatchChecker citationEntryMatchChecker = new CitationEntryMatchChecker();
             private BiFunction<Float, Float, Boolean> thresholdValidatorFn = ConfidenceLevelUtils::isValidConfidenceLevel;
 
             public CitationEntry validate(CitationEntry citationEntry, Float confidenceLevelThreshold) {
-                if (isMatchingResult(citationEntry) &&
+                if (citationEntryMatchChecker.isMatchingResult(citationEntry) &&
                         !thresholdValidatorFn.apply(citationEntry.getConfidenceLevel(), confidenceLevelThreshold)) {
                     citationEntry.setConfidenceLevel(null);
                     citationEntry.setDestinationDocumentId(null);
@@ -153,10 +165,11 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
          * Allows to normalize a citation entry.
          */
         public static class CitationEntryNormalizer {
+            private CitationEntryMatchChecker citationEntryMatchChecker = new CitationEntryMatchChecker();
             private MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer = new MatchingResultCitationEntryNormalizer();
 
             public CitationEntry normalize(CitationEntry citationEntry) {
-                if (isMatchingResult(citationEntry)) {
+                if (citationEntryMatchChecker.isMatchingResult(citationEntry)) {
                     return matchingResultCitationEntryNormalizer.normalize(citationEntry);
                 }
                 return citationEntry;
@@ -186,11 +199,6 @@ public class CitationsActionBuilderModuleFactory extends AbstractActionBuilderFa
             public BlobCitationEntry build(CitationEntry citationEntry) {
                 return builderFn.apply(citationEntry);
             }
-        }
-
-        private static Boolean isMatchingResult(CitationEntry citationEntry) {
-            return Objects.nonNull(citationEntry.getConfidenceLevel()) &&
-                    Objects.nonNull(citationEntry.getDestinationDocumentId());
         }
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -132,6 +132,11 @@
             <description>document_referencedDatasets trust level threshold</description>
         </property>
         <property>
+            <name>trust_level_threshold_document_referencedDocuments</name>
+            <value>$UNDEFINED$</value>
+            <description>document_referencedDocuments trust level threshold</description>
+        </property>
+        <property>
             <name>trust_level_threshold_document_pdb</name>
             <value>$UNDEFINED$</value>
             <description>document to protein databank trust level threshold</description>
@@ -251,6 +256,10 @@
             <property>
                 <name>export.trust.level.threshold.document_referencedDatasets</name>
                 <value>${trust_level_threshold_document_referencedDatasets}</value>
+            </property>
+            <property>
+                <name>export.trust.level.threshold.document_referencedDocuments</name>
+                <value>${trust_level_threshold_document_referencedDocuments}</value>
             </property>
             <property>
                 <name>export.trust.level.threshold.document_pdb</name>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
@@ -284,11 +284,8 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         @Nested
         public class CitationEntryNormalizerTest {
 
-            @Mock
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer destinationDocumentIdNormalizer;
-
-            @InjectMocks
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer =
+                    new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer();
 
             @Test
             @DisplayName("Citation entry without destination document id is not normalized")
@@ -299,38 +296,19 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
                 CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
 
                 assertSame(result, citationEntry);
-                verify(destinationDocumentIdNormalizer, never()).normalize(citationEntry);
+                verify(citationEntry, never()).setDestinationDocumentId(any());
             }
 
             @Test
-            @DisplayName("Citation entry with destination document id is normalized using normalizer")
+            @DisplayName("Citation entry with destination document id is normalized using normalizer function")
             public void givenNormalizer_whenCitationEntryWithDestinationDocumentIdIsNormalized_thenProperNormalizerIsUsed() {
                 CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
-                CitationEntry normalizedCitationEntry = mock(CitationEntry.class);
-                when(destinationDocumentIdNormalizer.normalize(citationEntry)).thenReturn(normalizedCitationEntry);
+                when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
 
                 CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
 
-                assertSame(normalizedCitationEntry, result);
-            }
-
-            @Nested
-            public class DestinationDocumentIdNormalizerTest {
-
-                @Test
-                @DisplayName("Destination document id is properly normalized")
-                public void givenNormalizer_whenDestinationDocumentIdIsNormalized_thenProperResultIsReturned() {
-                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer destinationDocumentIdNormalizer =
-                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer();
-                    CitationEntry citationEntry = mock(CitationEntry.class);
-                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
-
-                    CitationEntry result = destinationDocumentIdNormalizer.normalize(citationEntry);
-
-                    assertSame(citationEntry, result);
-                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
-                }
+                assertSame(result, citationEntry);
+                verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
             }
         }
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
@@ -9,7 +9,6 @@ import eu.dnetlib.iis.common.model.extrainfo.citations.BlobCitationEntry;
 import eu.dnetlib.iis.common.model.extrainfo.converter.CitationsExtraInfoSerDe;
 import eu.dnetlib.iis.export.schemas.Citations;
 import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
-import eu.dnetlib.iis.wf.export.actionmanager.module.CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker.CheckResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,240 +104,237 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         assertEquals("value", extraInfo.getValue());
     }
 
-    @Nested
-    public class CitationEntriesConverterTest {
-
-        @Mock
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter;
-
-        @Mock
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
-
-        @Mock
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
-
-        @Mock
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
-
-        @Mock
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
-
-        @InjectMocks
-        private CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter;
-
-        @Test
-        @DisplayName("Null citation entries are converted to null")
-        public void givenConverter_whenNullCitationEntriesAreConverted_thenNullIsReturned() {
-            assertNull(citationEntriesConverter.convert(null, trustLevelThreshold));
-        }
-
-        @Test
-        @DisplayName("Empty citation entries are converted to empty blob citation entries")
-        public void givenConverter_whenEmptyCitationEntriesAreConverted_thenEmptyCollectionIsReturned() {
-            assertTrue(citationEntriesConverter.convert(Collections.emptyList(), trustLevelThreshold).isEmpty());
-
-            verify(trustLevelConverter, atLeastOnce()).convert(trustLevelThreshold);
-        }
-
-        @Test
-        @DisplayName("Non-empty citation entries are converted to non-empty blob citation entries")
-        public void givenConverter_whenNonEmptyCitationEntriesAreConverted_thenNonEmptyCollectionIsReturned() {
-            CitationEntry notMatchingResultCitationEntry = mock(CitationEntry.class);
-            CitationEntry matchingResultCitationEntry = mock(CitationEntry.class);
-            CitationEntry normalizedMatchingResultCitationEntry = mock(CitationEntry.class);
-            BlobCitationEntry blobCitationEntryForNotMatchingResultCitationEntry = mock(BlobCitationEntry.class);
-            BlobCitationEntry blobCitationEntryForMatchingResultCitationEntry = mock(BlobCitationEntry.class);
-            when(trustLevelConverter.convert(trustLevelThreshold)).thenReturn(0.1f);
-            when(citationEntryMatchChecker.check(notMatchingResultCitationEntry)).thenReturn(CheckResult.NO_MATCHING_RESULT);
-            when(citationEntryMatchChecker.check(matchingResultCitationEntry)).thenReturn(CheckResult.MATCHING_RESULT);
-            when(confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry, 0.1f))
-                    .thenReturn(true);
-            when(confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, matchingResultCitationEntry, 0.1f))
-                    .thenReturn(true);
-            when(citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry))
-                    .thenReturn(notMatchingResultCitationEntry);
-            when(citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, matchingResultCitationEntry))
-                    .thenReturn(normalizedMatchingResultCitationEntry);
-            when(blobCitationEntryBuilder.build(notMatchingResultCitationEntry)).thenReturn(
-                    blobCitationEntryForNotMatchingResultCitationEntry);
-            when(blobCitationEntryBuilder.build(normalizedMatchingResultCitationEntry)).thenReturn(
-                    blobCitationEntryForMatchingResultCitationEntry);
-
-            SortedSet<BlobCitationEntry> result = citationEntriesConverter.convert(
-                    Arrays.asList(notMatchingResultCitationEntry, matchingResultCitationEntry), trustLevelThreshold);
-
-            assertEquals(2, result.size());
-            assertThat(result, hasItems(blobCitationEntryForNotMatchingResultCitationEntry,
-                    blobCitationEntryForMatchingResultCitationEntry));
-        }
-
-        @Nested
-        public class TrustLevelConverterTest {
-
-            @Test
-            @DisplayName("Null trust level threshold is converted to null")
-            public void givenConverter_whenNullValueIsConverted_thenNullIsReturned() {
-                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
-                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
-
-                Float result = trustLevelConverter.convert(null);
-
-                assertNull(result);
-            }
-
-            @Test
-            @DisplayName("Trust level threshold is converted to confidence level threshold using scaling factor")
-            public void givenConverter_whenAFloatValueIsConverted_thenProperValueIsReturned() {
-                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
-                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
-
-                Float result = trustLevelConverter.convert(trustLevelThreshold);
-
-                assertEquals(trustLevelThreshold / 0.9f, result);
-            }
-        }
-
-        @Nested
-        public class CitationEntryMatchCheckerTest {
-
-            @InjectMocks
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
-
-            @Test
-            @DisplayName("Citation entry with null confidence level does not contain a result of citation matching")
-            public void givenChecker_whenCitationEntryWithNullConfidenceLevelIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntry.getConfidenceLevel()).thenReturn(null);
-
-                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-
-                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
-            }
-
-            @Test
-            @DisplayName("Citation entry with null destination document id does not contain a result of citation matching")
-            public void givenChecker_whenCitationEntryWithNullDestinationDocumentIdIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-                when(citationEntry.getDestinationDocumentId()).thenReturn(null);
-
-                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-
-                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
-            }
-
-            @Test
-            @DisplayName("Citation entry with non null confidence level and non null destination document id contains a result of citation matching")
-            public void givenChecker_whenCitationEntryWithNonNullConfidenceLevelAndDestinationDocumentIdIsChecked_thenCitationEntryContainsAMatchingResult() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
-
-                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-
-                assertEquals(CheckResult.MATCHING_RESULT, result);
-            }
-        }
-
-        @Nested
-        public class ConfidenceLevelValidatorTest {
-
-            @Mock
-            private BiFunction<Float, Float, Boolean> thresholdValidatorFn;
-
-            @InjectMocks
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
-
-            @Test
-            @DisplayName("Citation entry without a result of citation matching is valid against any threshold")
-            public void givenValidator_whenCitationEntryThatWithoutCitationMatchingResultIsValidated_thenTrueIsReturned() {
-                Boolean result = confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, mock(CitationEntry.class), trustLevelThreshold);
-
-                assertTrue(result);
-                verify(thresholdValidatorFn, never()).apply(anyFloat(), eq(trustLevelThreshold));
-            }
-
-            @Test
-            @DisplayName("Citation entry with a result of citation matching is validated using utils")
-            public void givenValidator_whenCitationEntryWithACitationMatchingResultIsValidated_thenUtilsIsUsed() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-
-                confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, citationEntry, trustLevelThreshold);
-
-                verify(thresholdValidatorFn, atLeastOnce()).apply(0.1f, trustLevelThreshold);
-            }
-        }
-
-        @Nested
-        public class CitationEntryNormalizerTest {
-
-            @Mock
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer;
-
-            @InjectMocks
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
-
-            @Test
-            @DisplayName("Citation entry without a result of citation matching is not normalized")
-            public void givenNormalizer_whenCitationEntryWithoutACitationMatchingResultIsNormalized_thenTheSameInstanceIsReturned() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-
-                CitationEntry result = citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, citationEntry);
-
-                assertSame(result, citationEntry);
-                verify(matchingResultCitationEntryNormalizer, never()).normalize(citationEntry);
-            }
-
-            @Test
-            @DisplayName("Citation entry with a result of citation matching is normalized using normalizer")
-            public void givenNormalizer_whenCitationEntryWithACitationMatchingResultIsNormalized_thenProperNormalizerIsUsed() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-
-                citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, citationEntry);
-
-                verify(matchingResultCitationEntryNormalizer, atLeastOnce()).normalize(citationEntry);
-            }
-
-            @Nested
-            public class MatchingResultCitationEntryNormalizerTest {
-
-                @Test
-                @DisplayName("Citation entry is properly normalized")
-                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
-                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer =
-                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer();
-                    CitationEntry citationEntry = mock(CitationEntry.class);
-                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
-
-                    CitationEntry result = matchingResultCitationEntryNormalizer.normalize(citationEntry);
-
-                    assertSame(citationEntry, result);
-                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
-                }
-            }
-        }
-
-        @Nested
-        public class BlobCitationEntryBuilderTest {
-
-            @Mock
-            private Function<CitationEntry, BlobCitationEntry> builderFn;
-
-            @InjectMocks
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
-
-            @Test
-            @DisplayName("Blob citation entry is build from citation entry")
-            public void givenBuilder_whenBlobCitationEntryIsBuild_thenBuilderIsUsed() {
-                CitationEntry citationEntry = mock(CitationEntry.class);
-
-                blobCitationEntryBuilder.build(citationEntry);
-
-                verify(builderFn, atLeastOnce()).apply(citationEntry);
-            }
-        }
-    }
+//    @Nested
+//    public class CitationEntriesConverterTest {
+//
+//        @Mock
+//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter;
+//
+//        @Mock
+//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
+//
+//        @Mock
+//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+//
+//        @Mock
+//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+//
+//        @InjectMocks
+//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter;
+//
+//        @Test
+//        @DisplayName("Null citation entries are converted to null")
+//        public void givenConverter_whenNullCitationEntriesAreConverted_thenNullIsReturned() {
+//            assertNull(citationEntriesConverter.convert(null, trustLevelThreshold));
+//        }
+//
+//        @Test
+//        @DisplayName("Empty citation entries are converted to empty blob citation entries")
+//        public void givenConverter_whenEmptyCitationEntriesAreConverted_thenEmptyCollectionIsReturned() {
+//            assertTrue(citationEntriesConverter.convert(Collections.emptyList(), trustLevelThreshold).isEmpty());
+//
+//            verify(trustLevelConverter, atLeastOnce()).convert(trustLevelThreshold);
+//        }
+//
+//        @Test
+//        @DisplayName("Non-empty citation entries are converted to non-empty blob citation entries")
+//        public void givenConverter_whenNonEmptyCitationEntriesAreConverted_thenNonEmptyCollectionIsReturned() {
+//            CitationEntry notMatchingResultCitationEntry = mock(CitationEntry.class);
+//            CitationEntry matchingResultCitationEntry = mock(CitationEntry.class);
+//            CitationEntry normalizedMatchingResultCitationEntry = mock(CitationEntry.class);
+//            BlobCitationEntry blobCitationEntryForNotMatchingResultCitationEntry = mock(BlobCitationEntry.class);
+//            BlobCitationEntry blobCitationEntryForMatchingResultCitationEntry = mock(BlobCitationEntry.class);
+//            when(trustLevelConverter.convert(trustLevelThreshold)).thenReturn(0.1f);
+//            when(citationEntryMatchChecker.check(notMatchingResultCitationEntry)).thenReturn(CheckResult.NO_MATCHING_RESULT);
+//            when(citationEntryMatchChecker.check(matchingResultCitationEntry)).thenReturn(CheckResult.MATCHING_RESULT);
+//            when(confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry, 0.1f))
+//                    .thenReturn(true);
+//            when(confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, matchingResultCitationEntry, 0.1f))
+//                    .thenReturn(true);
+//            when(citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry))
+//                    .thenReturn(notMatchingResultCitationEntry);
+//            when(citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, matchingResultCitationEntry))
+//                    .thenReturn(normalizedMatchingResultCitationEntry);
+//            when(blobCitationEntryBuilder.build(notMatchingResultCitationEntry)).thenReturn(
+//                    blobCitationEntryForNotMatchingResultCitationEntry);
+//            when(blobCitationEntryBuilder.build(normalizedMatchingResultCitationEntry)).thenReturn(
+//                    blobCitationEntryForMatchingResultCitationEntry);
+//
+//            SortedSet<BlobCitationEntry> result = citationEntriesConverter.convert(
+//                    Arrays.asList(notMatchingResultCitationEntry, matchingResultCitationEntry), trustLevelThreshold);
+//
+//            assertEquals(2, result.size());
+//            assertThat(result, hasItems(blobCitationEntryForNotMatchingResultCitationEntry,
+//                    blobCitationEntryForMatchingResultCitationEntry));
+//        }
+//
+//        @Nested
+//        public class TrustLevelConverterTest {
+//
+//            @Test
+//            @DisplayName("Null trust level threshold is converted to null")
+//            public void givenConverter_whenNullValueIsConverted_thenNullIsReturned() {
+//                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
+//                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
+//
+//                Float result = trustLevelConverter.convert(null);
+//
+//                assertNull(result);
+//            }
+//
+//            @Test
+//            @DisplayName("Trust level threshold is converted to confidence level threshold using scaling factor")
+//            public void givenConverter_whenAFloatValueIsConverted_thenProperValueIsReturned() {
+//                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
+//                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
+//
+//                Float result = trustLevelConverter.convert(trustLevelThreshold);
+//
+//                assertEquals(trustLevelThreshold / 0.9f, result);
+//            }
+//        }
+//
+//        @Nested
+//        public class CitationEntryMatchCheckerTest {
+//
+//            @InjectMocks
+//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
+//
+//            @Test
+//            @DisplayName("Citation entry with null confidence level does not contain a result of citation matching")
+//            public void givenChecker_whenCitationEntryWithNullConfidenceLevelIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//                when(citationEntry.getConfidenceLevel()).thenReturn(null);
+//
+//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
+//
+//                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
+//            }
+//
+//            @Test
+//            @DisplayName("Citation entry with null destination document id does not contain a result of citation matching")
+//            public void givenChecker_whenCitationEntryWithNullDestinationDocumentIdIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+//                when(citationEntry.getDestinationDocumentId()).thenReturn(null);
+//
+//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
+//
+//                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
+//            }
+//
+//            @Test
+//            @DisplayName("Citation entry with non null confidence level and non null destination document id contains a result of citation matching")
+//            public void givenChecker_whenCitationEntryWithNonNullConfidenceLevelAndDestinationDocumentIdIsChecked_thenCitationEntryContainsAMatchingResult() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+//                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
+//
+//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
+//
+//                assertEquals(CheckResult.MATCHING_RESULT, result);
+//            }
+//        }
+//
+//        @Nested
+//        public class ConfidenceLevelValidatorTest {
+//
+//            @Mock
+//            private BiFunction<Float, Float, Boolean> thresholdValidatorFn;
+//
+//            @InjectMocks
+//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
+//
+//            @Test
+//            @DisplayName("Citation entry without a result of citation matching is valid against any threshold")
+//            public void givenValidator_whenCitationEntryThatWithoutCitationMatchingResultIsValidated_thenTrueIsReturned() {
+//                Boolean result = confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, mock(CitationEntry.class), trustLevelThreshold);
+//
+//                assertTrue(result);
+//                verify(thresholdValidatorFn, never()).apply(anyFloat(), eq(trustLevelThreshold));
+//            }
+//
+//            @Test
+//            @DisplayName("Citation entry with a result of citation matching is validated using utils")
+//            public void givenValidator_whenCitationEntryWithACitationMatchingResultIsValidated_thenUtilsIsUsed() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+//
+//                confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, citationEntry, trustLevelThreshold);
+//
+//                verify(thresholdValidatorFn, atLeastOnce()).apply(0.1f, trustLevelThreshold);
+//            }
+//        }
+//
+//        @Nested
+//        public class CitationEntryNormalizerTest {
+//
+//            @Mock
+//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer;
+//
+//            @InjectMocks
+//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+//
+//            @Test
+//            @DisplayName("Citation entry without a result of citation matching is not normalized")
+//            public void givenNormalizer_whenCitationEntryWithoutACitationMatchingResultIsNormalized_thenTheSameInstanceIsReturned() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//
+//                CitationEntry result = citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, citationEntry);
+//
+//                assertSame(result, citationEntry);
+//                verify(matchingResultCitationEntryNormalizer, never()).normalize(citationEntry);
+//            }
+//
+//            @Test
+//            @DisplayName("Citation entry with a result of citation matching is normalized using normalizer")
+//            public void givenNormalizer_whenCitationEntryWithACitationMatchingResultIsNormalized_thenProperNormalizerIsUsed() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//
+//                citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, citationEntry);
+//
+//                verify(matchingResultCitationEntryNormalizer, atLeastOnce()).normalize(citationEntry);
+//            }
+//
+//            @Nested
+//            public class MatchingResultCitationEntryNormalizerTest {
+//
+//                @Test
+//                @DisplayName("Citation entry is properly normalized")
+//                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
+//                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer =
+//                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer();
+//                    CitationEntry citationEntry = mock(CitationEntry.class);
+//                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
+//
+//                    CitationEntry result = matchingResultCitationEntryNormalizer.normalize(citationEntry);
+//
+//                    assertSame(citationEntry, result);
+//                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
+//                }
+//            }
+//        }
+//
+//        @Nested
+//        public class BlobCitationEntryBuilderTest {
+//
+//            @Mock
+//            private Function<CitationEntry, BlobCitationEntry> builderFn;
+//
+//            @InjectMocks
+//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+//
+//            @Test
+//            @DisplayName("Blob citation entry is build from citation entry")
+//            public void givenBuilder_whenBlobCitationEntryIsBuild_thenBuilderIsUsed() {
+//                CitationEntry citationEntry = mock(CitationEntry.class);
+//
+//                blobCitationEntryBuilder.build(citationEntry);
+//
+//                verify(builderFn, atLeastOnce()).apply(citationEntry);
+//            }
+//        }
+//    }
 
     // ----------------------- PRIVATE --------------------------
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
@@ -104,237 +104,259 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         assertEquals("value", extraInfo.getValue());
     }
 
-//    @Nested
-//    public class CitationEntriesConverterTest {
-//
-//        @Mock
-//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter;
-//
-//        @Mock
-//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
-//
-//        @Mock
-//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
-//
-//        @Mock
-//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
-//
-//        @InjectMocks
-//        private CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter;
-//
-//        @Test
-//        @DisplayName("Null citation entries are converted to null")
-//        public void givenConverter_whenNullCitationEntriesAreConverted_thenNullIsReturned() {
-//            assertNull(citationEntriesConverter.convert(null, trustLevelThreshold));
-//        }
-//
-//        @Test
-//        @DisplayName("Empty citation entries are converted to empty blob citation entries")
-//        public void givenConverter_whenEmptyCitationEntriesAreConverted_thenEmptyCollectionIsReturned() {
-//            assertTrue(citationEntriesConverter.convert(Collections.emptyList(), trustLevelThreshold).isEmpty());
-//
-//            verify(trustLevelConverter, atLeastOnce()).convert(trustLevelThreshold);
-//        }
-//
-//        @Test
-//        @DisplayName("Non-empty citation entries are converted to non-empty blob citation entries")
-//        public void givenConverter_whenNonEmptyCitationEntriesAreConverted_thenNonEmptyCollectionIsReturned() {
-//            CitationEntry notMatchingResultCitationEntry = mock(CitationEntry.class);
-//            CitationEntry matchingResultCitationEntry = mock(CitationEntry.class);
-//            CitationEntry normalizedMatchingResultCitationEntry = mock(CitationEntry.class);
-//            BlobCitationEntry blobCitationEntryForNotMatchingResultCitationEntry = mock(BlobCitationEntry.class);
-//            BlobCitationEntry blobCitationEntryForMatchingResultCitationEntry = mock(BlobCitationEntry.class);
-//            when(trustLevelConverter.convert(trustLevelThreshold)).thenReturn(0.1f);
-//            when(citationEntryMatchChecker.check(notMatchingResultCitationEntry)).thenReturn(CheckResult.NO_MATCHING_RESULT);
-//            when(citationEntryMatchChecker.check(matchingResultCitationEntry)).thenReturn(CheckResult.MATCHING_RESULT);
-//            when(confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry, 0.1f))
-//                    .thenReturn(true);
-//            when(confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, matchingResultCitationEntry, 0.1f))
-//                    .thenReturn(true);
-//            when(citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, notMatchingResultCitationEntry))
-//                    .thenReturn(notMatchingResultCitationEntry);
-//            when(citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, matchingResultCitationEntry))
-//                    .thenReturn(normalizedMatchingResultCitationEntry);
-//            when(blobCitationEntryBuilder.build(notMatchingResultCitationEntry)).thenReturn(
-//                    blobCitationEntryForNotMatchingResultCitationEntry);
-//            when(blobCitationEntryBuilder.build(normalizedMatchingResultCitationEntry)).thenReturn(
-//                    blobCitationEntryForMatchingResultCitationEntry);
-//
-//            SortedSet<BlobCitationEntry> result = citationEntriesConverter.convert(
-//                    Arrays.asList(notMatchingResultCitationEntry, matchingResultCitationEntry), trustLevelThreshold);
-//
-//            assertEquals(2, result.size());
-//            assertThat(result, hasItems(blobCitationEntryForNotMatchingResultCitationEntry,
-//                    blobCitationEntryForMatchingResultCitationEntry));
-//        }
-//
-//        @Nested
-//        public class TrustLevelConverterTest {
-//
-//            @Test
-//            @DisplayName("Null trust level threshold is converted to null")
-//            public void givenConverter_whenNullValueIsConverted_thenNullIsReturned() {
-//                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
-//                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
-//
-//                Float result = trustLevelConverter.convert(null);
-//
-//                assertNull(result);
-//            }
-//
-//            @Test
-//            @DisplayName("Trust level threshold is converted to confidence level threshold using scaling factor")
-//            public void givenConverter_whenAFloatValueIsConverted_thenProperValueIsReturned() {
-//                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
-//                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
-//
-//                Float result = trustLevelConverter.convert(trustLevelThreshold);
-//
-//                assertEquals(trustLevelThreshold / 0.9f, result);
-//            }
-//        }
-//
-//        @Nested
-//        public class CitationEntryMatchCheckerTest {
-//
-//            @InjectMocks
-//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
-//
-//            @Test
-//            @DisplayName("Citation entry with null confidence level does not contain a result of citation matching")
-//            public void givenChecker_whenCitationEntryWithNullConfidenceLevelIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//                when(citationEntry.getConfidenceLevel()).thenReturn(null);
-//
-//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-//
-//                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
-//            }
-//
-//            @Test
-//            @DisplayName("Citation entry with null destination document id does not contain a result of citation matching")
-//            public void givenChecker_whenCitationEntryWithNullDestinationDocumentIdIsChecked_thenCitationEntryDoesNotContainAMatchingResult() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-//                when(citationEntry.getDestinationDocumentId()).thenReturn(null);
-//
-//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-//
-//                assertEquals(CheckResult.NO_MATCHING_RESULT, result);
-//            }
-//
-//            @Test
-//            @DisplayName("Citation entry with non null confidence level and non null destination document id contains a result of citation matching")
-//            public void givenChecker_whenCitationEntryWithNonNullConfidenceLevelAndDestinationDocumentIdIsChecked_thenCitationEntryContainsAMatchingResult() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-//                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
-//
-//                CheckResult result = citationEntryMatchChecker.check(citationEntry);
-//
-//                assertEquals(CheckResult.MATCHING_RESULT, result);
-//            }
-//        }
-//
-//        @Nested
-//        public class ConfidenceLevelValidatorTest {
-//
-//            @Mock
-//            private BiFunction<Float, Float, Boolean> thresholdValidatorFn;
-//
-//            @InjectMocks
-//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
-//
-//            @Test
-//            @DisplayName("Citation entry without a result of citation matching is valid against any threshold")
-//            public void givenValidator_whenCitationEntryThatWithoutCitationMatchingResultIsValidated_thenTrueIsReturned() {
-//                Boolean result = confidenceLevelValidator.validate(CheckResult.NO_MATCHING_RESULT, mock(CitationEntry.class), trustLevelThreshold);
-//
-//                assertTrue(result);
-//                verify(thresholdValidatorFn, never()).apply(anyFloat(), eq(trustLevelThreshold));
-//            }
-//
-//            @Test
-//            @DisplayName("Citation entry with a result of citation matching is validated using utils")
-//            public void givenValidator_whenCitationEntryWithACitationMatchingResultIsValidated_thenUtilsIsUsed() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
-//
-//                confidenceLevelValidator.validate(CheckResult.MATCHING_RESULT, citationEntry, trustLevelThreshold);
-//
-//                verify(thresholdValidatorFn, atLeastOnce()).apply(0.1f, trustLevelThreshold);
-//            }
-//        }
-//
-//        @Nested
-//        public class CitationEntryNormalizerTest {
-//
-//            @Mock
-//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer;
-//
-//            @InjectMocks
-//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
-//
-//            @Test
-//            @DisplayName("Citation entry without a result of citation matching is not normalized")
-//            public void givenNormalizer_whenCitationEntryWithoutACitationMatchingResultIsNormalized_thenTheSameInstanceIsReturned() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//
-//                CitationEntry result = citationEntryNormalizer.normalize(CheckResult.NO_MATCHING_RESULT, citationEntry);
-//
-//                assertSame(result, citationEntry);
-//                verify(matchingResultCitationEntryNormalizer, never()).normalize(citationEntry);
-//            }
-//
-//            @Test
-//            @DisplayName("Citation entry with a result of citation matching is normalized using normalizer")
-//            public void givenNormalizer_whenCitationEntryWithACitationMatchingResultIsNormalized_thenProperNormalizerIsUsed() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//
-//                citationEntryNormalizer.normalize(CheckResult.MATCHING_RESULT, citationEntry);
-//
-//                verify(matchingResultCitationEntryNormalizer, atLeastOnce()).normalize(citationEntry);
-//            }
-//
-//            @Nested
-//            public class MatchingResultCitationEntryNormalizerTest {
-//
-//                @Test
-//                @DisplayName("Citation entry is properly normalized")
-//                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
-//                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer =
-//                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer();
-//                    CitationEntry citationEntry = mock(CitationEntry.class);
-//                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
-//
-//                    CitationEntry result = matchingResultCitationEntryNormalizer.normalize(citationEntry);
-//
-//                    assertSame(citationEntry, result);
-//                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
-//                }
-//            }
-//        }
-//
-//        @Nested
-//        public class BlobCitationEntryBuilderTest {
-//
-//            @Mock
-//            private Function<CitationEntry, BlobCitationEntry> builderFn;
-//
-//            @InjectMocks
-//            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
-//
-//            @Test
-//            @DisplayName("Blob citation entry is build from citation entry")
-//            public void givenBuilder_whenBlobCitationEntryIsBuild_thenBuilderIsUsed() {
-//                CitationEntry citationEntry = mock(CitationEntry.class);
-//
-//                blobCitationEntryBuilder.build(citationEntry);
-//
-//                verify(builderFn, atLeastOnce()).apply(citationEntry);
-//            }
-//        }
-//    }
+    @Nested
+    public class CitationEntriesConverterTest {
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+
+        @InjectMocks
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter;
+
+        @Test
+        @DisplayName("Null citation entries are converted to null")
+        public void givenConverter_whenNullCitationEntriesAreConverted_thenNullIsReturned() {
+            assertNull(citationEntriesConverter.convert(null, trustLevelThreshold));
+        }
+
+        @Test
+        @DisplayName("Empty citation entries are converted to empty blob citation entries")
+        public void givenConverter_whenEmptyCitationEntriesAreConverted_thenEmptyCollectionIsReturned() {
+            assertTrue(citationEntriesConverter.convert(Collections.emptyList(), trustLevelThreshold).isEmpty());
+
+            verify(trustLevelConverter, atLeastOnce()).convert(trustLevelThreshold);
+        }
+
+        @Test
+        @DisplayName("Non-empty citation entries are converted to non-empty blob citation entries")
+        public void givenConverter_whenNonEmptyCitationEntriesAreConverted_thenNonEmptyCollectionIsReturned() {
+            CitationEntry notMatchingResultCitationEntry = mock(CitationEntry.class);
+            CitationEntry matchingResultCitationEntry = mock(CitationEntry.class);
+            CitationEntry normalizedMatchingResultCitationEntry = mock(CitationEntry.class);
+            BlobCitationEntry blobCitationEntryForNotMatchingResultCitationEntry = mock(BlobCitationEntry.class);
+            BlobCitationEntry blobCitationEntryForMatchingResultCitationEntry = mock(BlobCitationEntry.class);
+            when(trustLevelConverter.convert(trustLevelThreshold)).thenReturn(0.1f);
+            when(confidenceLevelValidator.validate(notMatchingResultCitationEntry, 0.1f))
+                    .thenReturn(notMatchingResultCitationEntry);
+            when(confidenceLevelValidator.validate(matchingResultCitationEntry, 0.1f))
+                    .thenReturn(matchingResultCitationEntry);
+            when(citationEntryNormalizer.normalize(notMatchingResultCitationEntry))
+                    .thenReturn(notMatchingResultCitationEntry);
+            when(citationEntryNormalizer.normalize(matchingResultCitationEntry))
+                    .thenReturn(normalizedMatchingResultCitationEntry);
+            when(blobCitationEntryBuilder.build(notMatchingResultCitationEntry)).thenReturn(
+                    blobCitationEntryForNotMatchingResultCitationEntry);
+            when(blobCitationEntryBuilder.build(normalizedMatchingResultCitationEntry)).thenReturn(
+                    blobCitationEntryForMatchingResultCitationEntry);
+
+            SortedSet<BlobCitationEntry> result = citationEntriesConverter.convert(
+                    Arrays.asList(notMatchingResultCitationEntry, matchingResultCitationEntry), trustLevelThreshold);
+
+            assertEquals(2, result.size());
+            assertThat(result, hasItems(blobCitationEntryForNotMatchingResultCitationEntry,
+                    blobCitationEntryForMatchingResultCitationEntry));
+        }
+
+        @Nested
+        public class TrustLevelConverterTest {
+
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
+                    new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
+
+            @Test
+            @DisplayName("Null trust level threshold is converted to null")
+            public void givenConverter_whenNullValueIsConverted_thenNullIsReturned() {
+                Float result = trustLevelConverter.convert(null);
+
+                assertNull(result);
+            }
+
+            @Test
+            @DisplayName("Trust level threshold is converted to confidence level threshold using scaling factor")
+            public void givenConverter_whenAFloatValueIsConverted_thenProperValueIsReturned() {
+                Float result = trustLevelConverter.convert(trustLevelThreshold);
+
+                assertEquals(trustLevelThreshold / 0.9f, result);
+            }
+        }
+
+        @Nested
+        public class CitationEntryMatchCheckerTest {
+
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker =
+                    new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker();
+
+            @Test
+            @DisplayName("Citation entry with null confidence level does not contain a result of citation matching")
+            public void givenChecker_whenCitationEntryWithNullConfidenceLevelIsChecked_thenFalseIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(null);
+
+                assertFalse(citationEntryMatchChecker.isMatchingResult(citationEntry));
+            }
+
+            @Test
+            @DisplayName("Citation entry with null destination document id does not contain a result of citation matching")
+            public void givenChecker_whenCitationEntryWithNullDestinationDocumentIdIsChecked_thenFalseIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+                when(citationEntry.getDestinationDocumentId()).thenReturn(null);
+
+                assertFalse(citationEntryMatchChecker.isMatchingResult(citationEntry));
+            }
+
+            @Test
+            @DisplayName("Citation entry with non null confidence level and non null destination document id contains a result of citation matching")
+            public void givenChecker_whenCitationEntryWithNonNullConfidenceLevelAndDestinationDocumentIdIsChecked_thenTrueIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
+
+                assertTrue(citationEntryMatchChecker.isMatchingResult(citationEntry));
+            }
+        }
+
+        @Nested
+        public class ConfidenceLevelValidatorTest {
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
+
+            @Mock
+            private BiFunction<Float, Float, Boolean> thresholdValidatorFn;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.ConfidenceLevelValidator confidenceLevelValidator;
+
+            @Test
+            @DisplayName("Citation entry without a result of citation matching is valid against any threshold")
+            public void givenValidator_whenCitationEntryWithoutACitationMatchingResultIsValidated_thenTheSameCitationEntryIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(false);
+
+                CitationEntry result = confidenceLevelValidator.validate(citationEntry, trustLevelThreshold);
+
+                assertSame(citationEntry, result);
+                verify(citationEntry, never()).setConfidenceLevel(null);
+                verify(citationEntry, never()).setDestinationDocumentId(null);
+            }
+
+            @Test
+            @DisplayName("Citation entry with a result of citation matching and confidence level above threshold is valid")
+            public void givenValidator_whenCitationEntryWithACitationMatchingResultAndConfidenceLevelAboveThresholdIsValidated_thenTheSameCitationEntryIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(0.6f);
+                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(true);
+                when(thresholdValidatorFn.apply(0.6f, trustLevelThreshold)).thenReturn(true);
+
+                CitationEntry result = confidenceLevelValidator.validate(citationEntry, trustLevelThreshold);
+
+                assertSame(citationEntry, result);
+                verify(citationEntry, never()).setConfidenceLevel(null);
+                verify(citationEntry, never()).setDestinationDocumentId(null);
+            }
+
+            @Test
+            @DisplayName("Citation entry with a result of citation matching and confidence level below threshold is not valid")
+            public void givenValidator_whenCitationEntryWithACitationMatchingResultAndConfidenceLevelBelowThresholdIsValidated_thenMatchingResultIsRemovedFromCitationEntry() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(0.4f);
+                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(true);
+                when(thresholdValidatorFn.apply(0.4f, trustLevelThreshold)).thenReturn(false);
+
+                CitationEntry result = confidenceLevelValidator.validate(citationEntry, trustLevelThreshold);
+
+                assertSame(citationEntry, result);
+                verify(citationEntry, atLeastOnce()).setConfidenceLevel(null);
+                verify(citationEntry, atLeastOnce()).setDestinationDocumentId(null);
+            }
+        }
+
+        @Nested
+        public class CitationEntryNormalizerTest {
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+
+            @Test
+            @DisplayName("Citation entry without a result of citation matching is not normalized")
+            public void givenNormalizer_whenCitationEntryWithoutACitationMatchingResultIsNormalized_thenTheSameInstanceIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(false);
+
+                CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
+
+                assertSame(result, citationEntry);
+                verify(matchingResultCitationEntryNormalizer, never()).normalize(citationEntry);
+            }
+
+            @Test
+            @DisplayName("Citation entry with a result of citation matching is normalized using normalizer")
+            public void givenNormalizer_whenCitationEntryWithACitationMatchingResultIsNormalized_thenProperNormalizerIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(true);
+                CitationEntry normalizedCitationEntry = mock(CitationEntry.class);
+                when(matchingResultCitationEntryNormalizer.normalize(citationEntry)).thenReturn(normalizedCitationEntry);
+
+                CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
+
+                assertSame(normalizedCitationEntry, result);
+            }
+
+            @Nested
+            public class MatchingResultCitationEntryNormalizerTest {
+
+                @Test
+                @DisplayName("Citation entry is properly normalized")
+                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
+                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer =
+                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer();
+                    CitationEntry citationEntry = mock(CitationEntry.class);
+                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
+
+                    CitationEntry result = matchingResultCitationEntryNormalizer.normalize(citationEntry);
+
+                    assertSame(citationEntry, result);
+                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
+                }
+            }
+        }
+
+        @Nested
+        public class BlobCitationEntryBuilderTest {
+
+            @Mock
+            private Function<CitationEntry, BlobCitationEntry> builderFn;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+
+            @Test
+            @DisplayName("Blob citation entry is build from citation entry")
+            public void givenBuilder_whenBlobCitationEntryIsBuild_thenBuilderIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+
+                blobCitationEntryBuilder.build(citationEntry);
+
+                verify(builderFn, atLeastOnce()).apply(citationEntry);
+            }
+        }
+    }
 
     // ----------------------- PRIVATE --------------------------
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
@@ -1,37 +1,45 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import com.google.common.collect.Lists;
 import eu.dnetlib.dhp.schema.action.AtomicAction;
 import eu.dnetlib.dhp.schema.oaf.ExtraInfo;
 import eu.dnetlib.dhp.schema.oaf.Result;
 import eu.dnetlib.iis.common.citations.schemas.CitationEntry;
 import eu.dnetlib.iis.common.model.extrainfo.ExtraInfoConstants;
 import eu.dnetlib.iis.common.model.extrainfo.citations.BlobCitationEntry;
-import eu.dnetlib.iis.common.model.extrainfo.citations.TypedId;
 import eu.dnetlib.iis.common.model.extrainfo.converter.CitationsExtraInfoConverter;
 import eu.dnetlib.iis.export.schemas.Citations;
 import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
-import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.*;
-import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author mhorst
- * 
  */
+@ExtendWith(MockitoExtension.class)
 public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuilderModuleFactoryTest<Citations, Result> {
 
 
     private String docId = "documentId";
 
-    
+
     // ----------------------- CONSTRUCTORS -------------------
-    
-    
+
+
     public CitationsActionBuilderModuleFactoryTest() throws Exception {
         super(CitationsActionBuilderModuleFactory.class, AlgorithmName.document_referencedDocuments);
     }
@@ -39,10 +47,11 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
     // ----------------------- TESTS --------------------------
 
     @Test
+    @DisplayName("Empty atomic action list is build from citations with empty citation entry list")
     public void testBuildEmptyCitations() throws Exception {
         // given
-        ActionBuilderModule<Citations, Result> module =  factory.instantiate(config);
-        
+        ActionBuilderModule<Citations, Result> module = factory.instantiate(config);
+
         // execute
         List<AtomicAction<Result>> actions = module.build(
                 Citations.newBuilder().setCitations(Collections.emptyList()).setDocumentId(docId).build());
@@ -51,18 +60,30 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         assertNotNull(actions);
         assertEquals(0, actions.size());
     }
-    
+
     @Test
+    @DisplayName("Non-empty atomic action list is build from citations with non-empty citation entry list")
     public void testBuild() throws Exception {
         // given
-        ActionBuilderModule<Citations, Result> module =  factory.instantiate(config);
-        CitationEntry citationEntry = buildCitationEntry();
-        Citations.Builder builder = Citations.newBuilder();
-        builder.setDocumentId(docId);
-        builder.setCitations(Lists.newArrayList(citationEntry));
-        
+        CitationsActionBuilderModuleFactory.CitationActionBuilderModule module = (CitationsActionBuilderModuleFactory.CitationActionBuilderModule)
+                factory.instantiate(config);
+        CitationEntry citationEntry = buildCitationEntry(0.9f);
+        List<CitationEntry> citationEntries = Collections.singletonList(citationEntry);
+        Citations citations = Citations.newBuilder()
+                .setDocumentId(docId)
+                .setCitations(citationEntries)
+                .build();
+        TreeSet<BlobCitationEntry> blobCitationEntries = new TreeSet<>(Collections.singletonList(mock(BlobCitationEntry.class)));
+        CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter =
+                mock(CitationsActionBuilderModuleFactory.CitationEntriesConverter.class);
+        when(citationEntriesConverter.convert(citationEntries, trustLevelThreshold)).thenReturn(blobCitationEntries);
+        module.setCitationEntriesConverter(citationEntriesConverter);
+        CitationsExtraInfoConverter citationsExtraInfoConverter = mock(CitationsExtraInfoConverter.class);
+        when(citationsExtraInfoConverter.serialize(blobCitationEntries)).thenReturn("value");
+        module.setCitationsExtraInfoConverter(citationsExtraInfoConverter);
+
         // execute
-        List<AtomicAction<Result>> actions = module.build(builder.build());
+        List<AtomicAction<Result>> actions = module.build(citations);
 
         // assert
         assertNotNull(actions);
@@ -70,73 +91,7 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         AtomicAction<Result> action = actions.get(0);
         assertNotNull(action);
         assertEquals(Result.class, action.getClazz());
-        assertOaf(action.getPayload(), citationEntry);
-    }
-
-    @Test
-    public void testConversion() {
-        SortedSet<BlobCitationEntry> sortedCitations = new TreeSet<BlobCitationEntry>();
-        
-        CitationEntry.Builder rawTextCitationEntryBuilder = CitationEntry.newBuilder();
-        rawTextCitationEntryBuilder.setPosition(44);
-        rawTextCitationEntryBuilder.setRawText("[44] S. Mukhi and R. Nigam, “Constraints on ’rare’ dyon decays,” JHEP 12 (2008) 056, 0809.1157.");
-        rawTextCitationEntryBuilder.setExternalDestinationDocumentIds(Collections.<CharSequence,CharSequence>emptyMap());
-        
-        CitationEntry.Builder internalCitationEntryBuilder = CitationEntry.newBuilder();
-        internalCitationEntryBuilder.setRawText("Rugama, Y., Kloosterman, J. L., Winkelman, A., 2004. Prog. Nucl. Energy 44, 1-12.");
-        internalCitationEntryBuilder.setPosition(100);
-        internalCitationEntryBuilder.setDestinationDocumentId("od______2367::00247be440c2188b82d5905b5b1e22bb");
-        internalCitationEntryBuilder.setConfidenceLevel(0.8f);
-        internalCitationEntryBuilder.setExternalDestinationDocumentIds(Collections.<CharSequence,CharSequence>emptyMap());
-        
-        CitationEntry.Builder externalPmidCitationEntryBuilder = CitationEntry.newBuilder();
-        externalPmidCitationEntryBuilder.setRawText("[5] A. Sen, “Walls of Marginal Stability and Dyon Spectrum in N=4 Supersymmetric String Theories,” JHEP 05 (2007) 039, hep-th/0702141.");
-        externalPmidCitationEntryBuilder.setPosition(5);
-        Map<CharSequence, CharSequence> externalPmidDestinationDocumentIds = new HashMap<CharSequence, CharSequence>();
-        externalPmidDestinationDocumentIds.put("pmid", "20856923");
-        externalPmidCitationEntryBuilder.setExternalDestinationDocumentIds(externalPmidDestinationDocumentIds);
-        
-        CitationEntry.Builder externalDoiCitationEntryBuilder = CitationEntry.newBuilder();
-        externalDoiCitationEntryBuilder.setRawText("[17] N. Koblitz. Hyperelliptic cryptosystems. J. Cryptology, 1(3):139–150, 1989.");
-        externalDoiCitationEntryBuilder.setPosition(17);
-        Map<CharSequence, CharSequence> externalDoiDestinationDocumentIds = new HashMap<CharSequence, CharSequence>();
-        externalDoiDestinationDocumentIds.put("doi", "10.1186/1753-6561-5-S6-P38");
-        externalDoiDestinationDocumentIds.put("custom-id", "12345");
-        externalDoiCitationEntryBuilder.setExternalDestinationDocumentIds(externalDoiDestinationDocumentIds);
-        
-        sortedCitations.add(CitationsActionBuilderModuleUtils.build(internalCitationEntryBuilder.build()));
-        sortedCitations.add(CitationsActionBuilderModuleUtils.build(externalPmidCitationEntryBuilder.build()));
-        sortedCitations.add(CitationsActionBuilderModuleUtils.build(externalDoiCitationEntryBuilder.build()));
-        sortedCitations.add(CitationsActionBuilderModuleUtils.build(rawTextCitationEntryBuilder.build()));
-        
-        CitationsExtraInfoConverter converter = new CitationsExtraInfoConverter();
-        String citationsXML = converter.serialize(sortedCitations);
-        
-//      checking deserialization
-        SortedSet<BlobCitationEntry> deserializedCitations = (SortedSet<BlobCitationEntry>) converter.deserialize(citationsXML);
-        assertEquals(sortedCitations.size(), deserializedCitations.size());
-        Iterator<BlobCitationEntry> sortedIt = sortedCitations.iterator();
-        Iterator<BlobCitationEntry> deserializedIt = deserializedCitations.iterator();
-        for (int i=0; i<sortedCitations.size(); i++) {
-            assertEquals(sortedIt.next(), deserializedIt.next());
-        }
-    }
-    
-    // ----------------------- PRIVATE --------------------------
-
-    private CitationEntry buildCitationEntry() {
-        CitationEntry.Builder citationEntryBuilder = CitationEntry.newBuilder();
-        citationEntryBuilder.setPosition(1);
-        citationEntryBuilder.setRawText("citation raw text");
-        citationEntryBuilder.setDestinationDocumentId("50|dest-id");
-        Map<CharSequence, CharSequence> extIds = new HashMap<>();
-        extIds.put("extIdType", "extIdValue");
-        citationEntryBuilder.setExternalDestinationDocumentIds(extIds);
-        citationEntryBuilder.setConfidenceLevel(0.9f);
-        return citationEntryBuilder.build();
-    }
-
-    private void assertOaf(Result result, CitationEntry sourceEntry) {
+        Result result = action.getPayload();
         assertNotNull(result);
         assertEquals(docId, result.getId());
         assertNotNull(result.getExtraInfo());
@@ -147,25 +102,236 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         assertEquals(ExtraInfoConstants.TYPOLOGY_CITATIONS, extraInfo.getTypology());
         assertEquals(StaticConfigurationProvider.ACTION_TRUST_0_9, extraInfo.getTrust());
         assertEquals(((AbstractActionBuilderFactory<Citations, Result>) factory).buildInferenceProvenance(), extraInfo.getProvenance());
-
-        assertTrue(StringUtils.isNotBlank(extraInfo.getValue()));
-        CitationsExtraInfoConverter converter = new CitationsExtraInfoConverter();
-        Set<BlobCitationEntry> citationEntries = converter.deserialize(extraInfo.getValue());
-        assertNotNull(citationEntries);
-        assertEquals(1, citationEntries.size());
-        BlobCitationEntry citationEntry = citationEntries.iterator().next();
-        assertNotNull(citationEntry);
-        assertEquals(sourceEntry.getPosition().intValue(), citationEntry.getPosition());
-        assertEquals(sourceEntry.getRawText(), citationEntry.getRawText());
-        List<TypedId> ids = citationEntry.getIdentifiers();
-        assertNotNull(ids);
-        assertEquals(2, ids.size());
-        assertEquals(ExtraInfoConstants.CITATION_TYPE_OPENAIRE, ids.get(0).getType());
-        assertEquals(sourceEntry.getDestinationDocumentId(), ids.get(0).getValue());
-        Entry<CharSequence, CharSequence> sourceExtIdEntry = sourceEntry.getExternalDestinationDocumentIds()
-                .entrySet().iterator().next();
-        assertEquals(sourceExtIdEntry.getKey(), ids.get(1).getType());
-        assertEquals(sourceExtIdEntry.getValue(), ids.get(1).getValue());
+        assertEquals("value", extraInfo.getValue());
     }
-    
+
+    @Nested
+    public class CitationEntriesConverterTest {
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchValidator citationEntryMatchValidator;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+
+        @Mock
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+
+        @InjectMocks
+        private CitationsActionBuilderModuleFactory.CitationEntriesConverter citationEntriesConverter;
+
+        @Test
+        @DisplayName("Null citation entries are converted to null")
+        public void givenConverter_whenNullCitationEntriesAreConverted_thenNullIsReturned() {
+            assertNull(citationEntriesConverter.convert(null, trustLevelThreshold));
+        }
+
+        @Test
+        @DisplayName("Empty citation entries are converted to empty blob citation entries")
+        public void givenConverter_whenEmptyCitationEntriesAreConverted_thenEmptyCollectionIsReturned() {
+            assertTrue(citationEntriesConverter.convert(Collections.emptyList(), trustLevelThreshold).isEmpty());
+
+            verify(trustLevelConverter, atLeastOnce()).convert(trustLevelThreshold);
+        }
+
+        @Test
+        @DisplayName("Non-empty citation entries are converted to non-empty blob citation entries")
+        public void givenConverter_whenNonEmptyCitationEntriesAreConverted_thenNonEmptyCollectionIsReturned() {
+            CitationEntry citationEntry = mock(CitationEntry.class);
+            CitationEntry normalizedCitationEntry = mock(CitationEntry.class);
+            BlobCitationEntry blobCitationEntry = mock(BlobCitationEntry.class);
+            when(trustLevelConverter.convert(trustLevelThreshold)).thenReturn(0.1f);
+            when(citationEntryMatchValidator.validate(citationEntry, 0.1f)).thenReturn(true);
+            when(citationEntryNormalizer.normalize(citationEntry, true)).thenReturn(normalizedCitationEntry);
+            when(blobCitationEntryBuilder.build(normalizedCitationEntry)).thenReturn(blobCitationEntry);
+
+            SortedSet<BlobCitationEntry> result = citationEntriesConverter.convert(
+                    Collections.singletonList(citationEntry), trustLevelThreshold);
+
+            assertEquals(1, result.size());
+            assertSame(blobCitationEntry, result.first());
+        }
+
+        @Nested
+        public class TrustLevelConverterTest {
+
+            @Test
+            @DisplayName("Null trust level threshold is converted to null")
+            public void givenConverter_whenNullValueIsConverted_thenNullIsReturned() {
+                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
+                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
+
+                Float result = trustLevelConverter.convert(null);
+
+                assertNull(result);
+            }
+
+            @Test
+            @DisplayName("Trust level threshold is converted to confidence level threshold using scaling factor")
+            public void givenConverter_whenAFloatValueIsConverted_thenProperValueIsReturned() {
+                CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter trustLevelConverter =
+                        new CitationsActionBuilderModuleFactory.CitationEntriesConverter.TrustLevelConverter(0.9f);
+
+                Float result = trustLevelConverter.convert(trustLevelThreshold);
+
+                assertEquals(trustLevelThreshold / 0.9f, result);
+            }
+        }
+
+        @Nested
+        public class CitationEntryMatchValidatorTest {
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchValidator.ConfidenceLevelValidator confidenceLevelValidator;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchValidator citationEntryMatchValidator;
+
+            @Test
+            @DisplayName("Citation entry with null confidence level is not valid")
+            public void givenValidator_whenCitationEntryWithNullConfidenceLevelIsConverted_thenFalseIsReturned() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(null);
+
+                Boolean result = citationEntryMatchValidator.validate(citationEntry, 0.5f);
+
+                assertFalse(result);
+            }
+
+            @Test
+            @DisplayName("Citation entry with non-null confidence level is validated against threshold")
+            public void givenValidator_whenCitationEntryWithNonNullConfidenceLevelIsConverted_thenThresholdValidatorIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+                when(citationEntry.getConfidenceLevel()).thenReturn(0.1f);
+
+                citationEntryMatchValidator.validate(citationEntry, 0.5f);
+
+                verify(confidenceLevelValidator, atLeastOnce()).validate(0.1f, 0.5f);
+            }
+
+            @Nested
+            public class ConfidenceLevelValidatorTest {
+
+                @Mock
+                private BiFunction<Float, Float, Boolean> thresholdValidatorFn;
+
+                @InjectMocks
+                private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchValidator.ConfidenceLevelValidator confidenceLevelValidator;
+
+                @Test
+                @DisplayName("Non-null confidence level is validated using validator")
+                public void givenValidator_whenNonNullConfidenceLevelIsValidated_thenValidatorIsUsed() {
+                    confidenceLevelValidator.validate(0.1f, trustLevelThreshold);
+
+                    verify(thresholdValidatorFn, atLeastOnce()).apply(0.1f, trustLevelThreshold);
+                }
+            }
+        }
+
+        @Nested
+        public class CitationEntryNormalizerTest {
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.ValidMatchCitationEntryNormalizer validMatchCitationEntryNormalizer;
+
+            @Mock
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.InvalidMatchCitationEntryNormalizer invalidMatchCitationEntryNormalizer;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
+
+            @Test
+            @DisplayName("Valid match citation entry is normalized using normalizer")
+            public void givenNormalizer_whenValidMatchCitationEntryIsNormalized_thenProperNormalizerIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+
+                citationEntryNormalizer.normalize(citationEntry, true);
+
+                verify(validMatchCitationEntryNormalizer, atLeastOnce()).normalize(citationEntry);
+                verify(invalidMatchCitationEntryNormalizer, never()).normalize(citationEntry);
+            }
+
+            @Test
+            @DisplayName("Invalid match citation entry is normalized using normalizer")
+            public void givenNormalizer_whenInvalidMatchCitationEntryIsNormalized_thenProperNormalizerIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+
+                citationEntryNormalizer.normalize(citationEntry, false);
+
+                verify(validMatchCitationEntryNormalizer, never()).normalize(citationEntry);
+                verify(invalidMatchCitationEntryNormalizer, atLeastOnce()).normalize(citationEntry);
+            }
+
+            @Nested
+            public class ValidMatchCitationEntryNormalizerTest {
+
+                @Test
+                @DisplayName("Valid match citation entry is properly normalized")
+                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
+                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.ValidMatchCitationEntryNormalizer validMatchCitationEntryNormalizer =
+                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.ValidMatchCitationEntryNormalizer();
+                    CitationEntry citationEntry = mock(CitationEntry.class);
+                    when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
+
+                    CitationEntry result = validMatchCitationEntryNormalizer.normalize(citationEntry);
+
+                    assertSame(citationEntry, result);
+                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");
+                }
+            }
+
+            @Nested
+            public class InvalidMatchCitationEntryNormalizerTest {
+
+                @Test
+                @DisplayName("Invalid match citation entry is properly normalized")
+                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
+                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.InvalidMatchCitationEntryNormalizer invalidMatchCitationEntryNormalizer =
+                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.InvalidMatchCitationEntryNormalizer();
+                    CitationEntry citationEntry = mock(CitationEntry.class);
+
+                    CitationEntry result = invalidMatchCitationEntryNormalizer.normalize(citationEntry);
+
+                    assertSame(citationEntry, result);
+                    verify(citationEntry, atLeastOnce()).setDestinationDocumentId(null);
+                    verify(citationEntry, atLeastOnce()).setConfidenceLevel(null);
+                }
+            }
+        }
+
+        @Nested
+        public class BlobCitationEntryBuilderTest {
+
+            @Mock
+            private Function<CitationEntry, BlobCitationEntry> builderFn;
+
+            @InjectMocks
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.BlobCitationEntryBuilder blobCitationEntryBuilder;
+
+            @Test
+            @DisplayName("Blob citation entry is build from citation entry")
+            public void givenBuilder_whenBlobCitationEntryIsBuild_thenBuilderIsUsed() {
+                CitationEntry citationEntry = mock(CitationEntry.class);
+
+                blobCitationEntryBuilder.build(citationEntry);
+
+                verify(builderFn, atLeastOnce()).apply(citationEntry);
+            }
+        }
+    }
+
+    // ----------------------- PRIVATE --------------------------
+
+    private CitationEntry buildCitationEntry(Float confidenceLevel) {
+        CitationEntry.Builder citationEntryBuilder = CitationEntry.newBuilder();
+        citationEntryBuilder.setPosition(1);
+        citationEntryBuilder.setRawText("citation raw text");
+        citationEntryBuilder.setDestinationDocumentId("50|dest-id");
+        citationEntryBuilder.setExternalDestinationDocumentIds(Collections.singletonMap("extIdType", "extIdValue"));
+        citationEntryBuilder.setConfidenceLevel(confidenceLevel);
+        return citationEntryBuilder.build();
+    }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleFactoryTest.java
@@ -285,33 +285,30 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
         public class CitationEntryNormalizerTest {
 
             @Mock
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryMatchChecker citationEntryMatchChecker;
-
-            @Mock
-            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer;
+            private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer destinationDocumentIdNormalizer;
 
             @InjectMocks
             private CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer citationEntryNormalizer;
 
             @Test
-            @DisplayName("Citation entry without a result of citation matching is not normalized")
-            public void givenNormalizer_whenCitationEntryWithoutACitationMatchingResultIsNormalized_thenTheSameInstanceIsReturned() {
+            @DisplayName("Citation entry without destination document id is not normalized")
+            public void givenNormalizer_whenCitationEntryWithoutDestinationDocumentIdIsNormalized_thenTheSameInstanceIsReturned() {
                 CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(false);
+                when(citationEntry.getDestinationDocumentId()).thenReturn(null);
 
                 CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
 
                 assertSame(result, citationEntry);
-                verify(matchingResultCitationEntryNormalizer, never()).normalize(citationEntry);
+                verify(destinationDocumentIdNormalizer, never()).normalize(citationEntry);
             }
 
             @Test
-            @DisplayName("Citation entry with a result of citation matching is normalized using normalizer")
-            public void givenNormalizer_whenCitationEntryWithACitationMatchingResultIsNormalized_thenProperNormalizerIsUsed() {
+            @DisplayName("Citation entry with destination document id is normalized using normalizer")
+            public void givenNormalizer_whenCitationEntryWithDestinationDocumentIdIsNormalized_thenProperNormalizerIsUsed() {
                 CitationEntry citationEntry = mock(CitationEntry.class);
-                when(citationEntryMatchChecker.isMatchingResult(citationEntry)).thenReturn(true);
+                when(citationEntry.getDestinationDocumentId()).thenReturn("destination document id");
                 CitationEntry normalizedCitationEntry = mock(CitationEntry.class);
-                when(matchingResultCitationEntryNormalizer.normalize(citationEntry)).thenReturn(normalizedCitationEntry);
+                when(destinationDocumentIdNormalizer.normalize(citationEntry)).thenReturn(normalizedCitationEntry);
 
                 CitationEntry result = citationEntryNormalizer.normalize(citationEntry);
 
@@ -319,17 +316,17 @@ public class CitationsActionBuilderModuleFactoryTest extends AbstractActionBuild
             }
 
             @Nested
-            public class MatchingResultCitationEntryNormalizerTest {
+            public class DestinationDocumentIdNormalizerTest {
 
                 @Test
-                @DisplayName("Citation entry is properly normalized")
-                public void givenNormalizer_whenCitationEntryIsNormalized_thenProperResultIsReturned() {
-                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer matchingResultCitationEntryNormalizer =
-                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.MatchingResultCitationEntryNormalizer();
+                @DisplayName("Destination document id is properly normalized")
+                public void givenNormalizer_whenDestinationDocumentIdIsNormalized_thenProperResultIsReturned() {
+                    CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer destinationDocumentIdNormalizer =
+                            new CitationsActionBuilderModuleFactory.CitationEntriesConverter.CitationEntryNormalizer.DestinationDocumentIdNormalizer();
                     CitationEntry citationEntry = mock(CitationEntry.class);
                     when(citationEntry.getDestinationDocumentId()).thenReturn("prefix|destination document id");
 
-                    CitationEntry result = matchingResultCitationEntryNormalizer.normalize(citationEntry);
+                    CitationEntry result = destinationDocumentIdNormalizer.normalize(citationEntry);
 
                     assertSame(citationEntry, result);
                     verify(citationEntry, atLeastOnce()).setDestinationDocumentId("destination document id");

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleUtilsTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/CitationsActionBuilderModuleUtilsTest.java
@@ -1,0 +1,285 @@
+package eu.dnetlib.iis.wf.export.actionmanager.module;
+
+import eu.dnetlib.iis.common.InfoSpaceConstants;
+import eu.dnetlib.iis.common.citations.schemas.CitationEntry;
+import eu.dnetlib.iis.common.model.extrainfo.ExtraInfoConstants;
+import eu.dnetlib.iis.common.model.extrainfo.citations.TypedId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CitationsActionBuilderModuleUtilsTest {
+
+    @Test
+    @DisplayName("CitationEntry is converted to BlobCitationEntry using value functions")
+    public void givenCitationEntry_whenConvertedToBlobCitationEntry_thenBuildersAreUsed() {
+        CitationEntry citationEntry = mock(CitationEntry.class);
+        Function<CitationEntry, Integer> positionFn = mock(Function.class);
+        when(positionFn.apply(citationEntry)).thenReturn(-1);
+        Function<CitationEntry, String> rawTextFn = mock(Function.class);
+        when(rawTextFn.apply(citationEntry)).thenReturn("raw text");
+        Function<CitationEntry, List<TypedId>> identifiersFn = mock(Function.class);
+        when(identifiersFn.apply(citationEntry)).thenReturn(Collections.singletonList(mock(TypedId.class)));
+
+        CitationsActionBuilderModuleUtils.build(citationEntry, positionFn, rawTextFn, identifiersFn);
+
+        verify(positionFn).apply(citationEntry);
+        verify(rawTextFn).apply(citationEntry);
+        verify(identifiersFn).apply(citationEntry);
+    }
+
+    @Nested
+    public class PositionBuilderTest {
+
+        @Test
+        @DisplayName("Position is build from citation entry")
+        public void givenCitationEntry_whenPositionValueIsBuild_thenProperValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, null, null, null, Collections.emptyMap());
+
+            Integer result = CitationsActionBuilderModuleUtils.PositionBuilder.build(citationEntry);
+
+            assertEquals(5, result);
+        }
+    }
+
+    @Nested
+    public class RawTextBuilderTest {
+
+        @Test
+        @DisplayName("Null raw text string is build from citation entry")
+        public void givenCitationEntryWithNullRawText_whenRawTextValueIsBuild_thenNullValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, null, null, null, Collections.emptyMap());
+
+            String result = CitationsActionBuilderModuleUtils.RawTextBuilder.build(citationEntry);
+
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("Non-null raw text string is build from citation entry")
+        public void givenCitationEntryWithNonNullRawText_whenRawTextValueIsBuild_thenNonNullValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, "raw text", null, null, Collections.emptyMap());
+
+            String result = CitationsActionBuilderModuleUtils.RawTextBuilder.build(citationEntry);
+
+            assertEquals("raw text", result);
+        }
+    }
+
+    @Nested
+    public class IdentifiersBuilderTest {
+
+        @Test
+        @DisplayName("Null identifiers are build from citation entry")
+        public void givenCitationEntryWithInvalidDestinationDocumentIdAndInvalidExternalDestinationDocumentIds_whenIdentifiersValueIsBuild_thenNullValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, null, null, null, Collections.emptyMap());
+            Function<CitationEntry, Boolean> destinationDocumentIdValidator = mock(Function.class);
+            when(destinationDocumentIdValidator.apply(citationEntry)).thenReturn(false);
+            Function<CitationEntry, TypedId> typedIdFromDestinationDocumentIdFn = mock(Function.class);
+            Function<CitationEntry, Boolean> externalDestinationDocumentIdsValidator = mock(Function.class);
+            when(externalDestinationDocumentIdsValidator.apply(citationEntry)).thenReturn(false);
+            Function<CitationEntry, List<TypedId>> typedIdsFromExternalDestinationDocumentIdsFn = mock(Function.class);
+
+            List<TypedId> result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.build(citationEntry,
+                    destinationDocumentIdValidator,
+                    typedIdFromDestinationDocumentIdFn,
+                    externalDestinationDocumentIdsValidator,
+                    typedIdsFromExternalDestinationDocumentIdsFn);
+
+            assertNull(result);
+            verify(typedIdFromDestinationDocumentIdFn, never()).apply(any());
+            verify(typedIdsFromExternalDestinationDocumentIdsFn, never()).apply(any());
+        }
+
+        @Test
+        @DisplayName("Non-null identifiers are build from citation entry with destination document id")
+        public void givenCitationEntryWithValidDestinationDocumentIdAndInvalidExternalDestinationDocumentIds_whenIdentifiersValueIsBuild_thenProperValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, null, "destination document id", null, Collections.emptyMap());
+            Function<CitationEntry, Boolean> destinationDocumentIdValidator = mock(Function.class);
+            when(destinationDocumentIdValidator.apply(citationEntry)).thenReturn(true);
+            TypedId typedId = mock(TypedId.class);
+            Function<CitationEntry, TypedId> typedIdFromDestinationDocumentIdFn = mock(Function.class);
+            when(typedIdFromDestinationDocumentIdFn.apply(citationEntry)).thenReturn(typedId);
+            Function<CitationEntry, Boolean> externalDestinationDocumentIdsValidator = mock(Function.class);
+            when(externalDestinationDocumentIdsValidator.apply(citationEntry)).thenReturn(false);
+            Function<CitationEntry, List<TypedId>> typedIdsFromExternalDestinationDocumentIdsFn = mock(Function.class);
+
+            List<TypedId> result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.build(citationEntry,
+                    destinationDocumentIdValidator,
+                    typedIdFromDestinationDocumentIdFn,
+                    externalDestinationDocumentIdsValidator,
+                    typedIdsFromExternalDestinationDocumentIdsFn);
+
+            assertEquals(Collections.singletonList(typedId), result);
+            verify(typedIdsFromExternalDestinationDocumentIdsFn, never()).apply(any());
+        }
+
+        @Test
+        @DisplayName("Non-null identifiers are build from citation entry with destination document id and external destination document id")
+        public void givenCitationEntryWithValidDestinationDocumentIdAndValidExternalDestinationDocumentIds_whenIdentifiersValueIsBuild_thenProperValueIsReturned() {
+            CitationEntry citationEntry = buildCitationEntry(
+                    5, null, "destination document id", null, Collections.emptyMap());
+            Function<CitationEntry, Boolean> destinationDocumentIdValidator = mock(Function.class);
+            when(destinationDocumentIdValidator.apply(citationEntry)).thenReturn(true);
+            TypedId typedId1 = mock(TypedId.class);
+            Function<CitationEntry, TypedId> typedIdFromDestinationDocumentIdFn = mock(Function.class);
+            when(typedIdFromDestinationDocumentIdFn.apply(citationEntry)).thenReturn(typedId1);
+            Function<CitationEntry, Boolean> externalDestinationDocumentIdsValidator = mock(Function.class);
+            when(externalDestinationDocumentIdsValidator.apply(citationEntry)).thenReturn(true);
+            TypedId typedId2 = mock(TypedId.class);
+            Function<CitationEntry, List<TypedId>> typedIdsFromExternalDestinationDocumentIdsFn = mock(Function.class);
+            when(typedIdsFromExternalDestinationDocumentIdsFn.apply(citationEntry)).thenReturn(Collections.singletonList(typedId2));
+
+            List<TypedId> result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.build(citationEntry,
+                    destinationDocumentIdValidator,
+                    typedIdFromDestinationDocumentIdFn,
+                    externalDestinationDocumentIdsValidator,
+                    typedIdsFromExternalDestinationDocumentIdsFn);
+
+            assertEquals(Arrays.asList(typedId1, typedId2), result);
+        }
+
+        @Nested
+        public class TypedIdFromDestinationDocumentIdBuilderTest {
+
+            @Test
+            @DisplayName("Null destination document id is invalid")
+            public void givenCitationEntryWithNullDestinationDocumentId_whenValidated_thenIsInvalid() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, null, null, Collections.emptyMap());
+
+                Boolean result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdFromDestinationDocumentIdBuilder.isValid(
+                        citationEntry);
+
+                assertFalse(result);
+            }
+
+            @Test
+            @DisplayName("Non-null destination document id is valid")
+            public void givenCitationEntryWithNonNullDestinationDocumentId_whenValidated_thenIsValid() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, "destination document id", null, Collections.emptyMap());
+
+                Boolean result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdFromDestinationDocumentIdBuilder.isValid(
+                        citationEntry);
+
+                assertTrue(result);
+            }
+
+            @Test
+            @DisplayName("TypedId is build from citation entry using confidence level builder")
+            public void givenCitationEntry_whenTypedIdValueIsBuild_thenConfidenceValueBuilderIsUsedAndProperValueIsReturned() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, "destination document id", null, Collections.emptyMap());
+                Function<CitationEntry, Float> confidenceLevelFn = mock(Function.class);
+                when(confidenceLevelFn.apply(citationEntry)).thenReturn(1f);
+
+                TypedId result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdFromDestinationDocumentIdBuilder.build(
+                        citationEntry, confidenceLevelFn);
+
+                assertEquals(new TypedId("destination document id", ExtraInfoConstants.CITATION_TYPE_OPENAIRE, 1f), result);
+            }
+
+            @Nested
+            public class ConfidenceLevelBuilderTest {
+
+                @Test
+                @DisplayName("Confidence level is build from citation entry with null confidence level")
+                public void givenCitationEntryWithNullConfidenceLevel_whenConfidenceLevelValueIsBuild_thenProperValueIsReturned() {
+                    CitationEntry citationEntry = buildCitationEntry(
+                            5, null, "destination document id", null, Collections.emptyMap());
+
+                    Float result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdFromDestinationDocumentIdBuilder.ConfidenceLevelBuilder.build(
+                            citationEntry);
+
+                    assertEquals(1f * InfoSpaceConstants.CONFIDENCE_TO_TRUST_LEVEL_FACTOR, result);
+                }
+
+                @Test
+                @DisplayName("Confidence level is build from citation entry with non-null confidence level")
+                public void givenCitationEntryWithNonNullConfidenceLevel_whenConfidenceLevelValueIsBuild_thenProperValueIsReturned() {
+                    CitationEntry citationEntry = buildCitationEntry(
+                            5, null, "destination document id", 0.5f, Collections.emptyMap());
+
+                    Float result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdFromDestinationDocumentIdBuilder.ConfidenceLevelBuilder.build(
+                            citationEntry);
+
+                    assertEquals(0.5f * InfoSpaceConstants.CONFIDENCE_TO_TRUST_LEVEL_FACTOR, result);
+                }
+            }
+        }
+
+        @Nested
+        public class TypedIdsFromExternalDestinationDocumentIdsBuilderTest {
+
+            @Test
+            @DisplayName("Empty external destination document ids is invalid")
+            public void givenCitationEntryWithEmptyExternalDestinationDocumentIds_whenValidated_thenIsInvalid() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, null, null, Collections.emptyMap());
+
+                Boolean result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdsFromExternalDestinationDocumentIdsBuilder.isValid(
+                        citationEntry);
+
+                assertFalse(result);
+            }
+
+            @Test
+            @DisplayName("Non-empty external destination document ids is valid")
+            public void givenCitationEntryWithNonEmptyExternalDestinationDocumentId_whenValidated_thenIsValid() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, null, null, Collections.singletonMap("key", "value"));
+
+                Boolean result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdsFromExternalDestinationDocumentIdsBuilder.isValid(
+                        citationEntry);
+
+                assertTrue(result);
+            }
+
+            @Test
+            @DisplayName("TypedIds are build from citation entry")
+            public void givenCitationEntryWithNonEmptyExternalDestinationDocumentIds_whenTypedIdsValueIsBuild_thenProperValueIsReturned() {
+                CitationEntry citationEntry = buildCitationEntry(
+                        5, null, null, null, Collections.singletonMap("key", "value"));
+
+                List<TypedId> result = CitationsActionBuilderModuleUtils.IdentifiersBuilder.TypedIdsFromExternalDestinationDocumentIdsBuilder.build(
+                        citationEntry);
+
+                assertEquals(
+                        Collections.singletonList(new TypedId("value", "key", 1f * InfoSpaceConstants.CONFIDENCE_TO_TRUST_LEVEL_FACTOR)),
+                        result);
+            }
+        }
+    }
+
+    private static CitationEntry buildCitationEntry(int position,
+                                                    CharSequence rawText,
+                                                    CharSequence destinationDocumentId,
+                                                    Float confidenceLevel,
+                                                    Map<CharSequence, CharSequence> externalDestinationDocumentIds) {
+        return CitationEntry.newBuilder()
+                .setPosition(position)
+                .setRawText(rawText)
+                .setDestinationDocumentId(destinationDocumentId)
+                .setConfidenceLevel(confidenceLevel)
+                .setExternalDestinationDocumentIds(externalDestinationDocumentIds)
+                .build();
+    }
+}


### PR DESCRIPTION
This PR adds trust level threshold handling in citation matching exporter module.

Inside this PR
* `eu.dnetlib.iis.wf.export.actionmanager.module.CitationsActionBuilderModuleFactory`changes adding trust level threshold handling plus refactorization
* `eu.dnetlib.iis.wf.export.actionmanager.module.CitationsActionBuilderModuleFactory` unit tests addition and refactorization
* `eu.dnetlib.iis.wf.export.actionmanager.module.CitationsActionBuilderModuleUtils` refactorization and unit test addition