### PR TITLE
Bump xstream from 1.4.9 to 1.4.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.9</version>
+                <version>1.4.15</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Bumps xstream from 1.4.9 to 1.4.15. 

This version bump was found necessary by Dependabot following a security vulnerability found in xstream. The original PR is #1195 but it used a different version of xstream which did not pass CI.

Merging of this PR will stop Dependabot from requesting the update and creating PRs.  