### PR TITLE
Closes #1183: Refactor Spark jobs to use SparkSessionSupport for externalization of SparkSession management

### DIFF
--- a/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
@@ -41,7 +41,7 @@ public class SparkSessionSupport {
      * when SparkSession is shared e.g. created in tests. Allows to reuse SparkSession created externally.
      *
      * @param conf               SparkConf instance
-     * @param sharedSparkSession When true will stop SparkSession
+     * @param sharedSparkSession When true will not stop SparkSession
      * @param job                Job using constructed SparkSession
      */
     public static void runWithSparkSession(Function<SparkConf, SparkSession> sparkSessionBuilder,

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
@@ -20,49 +20,49 @@ public class SparkSessionSupport {
 
     /**
      * Runs a given job using SparkSession created using default builder and supplied SparkConf. Stops SparkSession
-     * when SparkSession is managed. Allows to reuse SparkSession created externally.
+     * when SparkSession is shared e.g. created in tests. Allows to reuse SparkSession created externally.
      *
-     * @param conf                  SparkConf instance
-     * @param isSparkSessionManaged When true will stop SparkSession
-     * @param job                   Job using constructed SparkSession
+     * @param conf               SparkConf instance
+     * @param sharedSparkSession When true will not stop SparkSession
+     * @param job                Job using constructed SparkSession
      */
     public static void runWithSparkSession(SparkConf conf,
-                                           Boolean isSparkSessionManaged,
+                                           Boolean sharedSparkSession,
                                            Job job) {
         runWithSparkSession(
                 SparkSessionFactory::withConfAndKryo,
                 conf,
-                isSparkSessionManaged,
+                sharedSparkSession,
                 job);
     }
 
     /**
      * Runs a given job using SparkSession created using supplied builder and supplied SparkConf. Stops SparkSession
-     * when SparkSession is managed. Allows to reuse SparkSession created externally.
+     * when SparkSession is shared e.g. created in tests. Allows to reuse SparkSession created externally.
      *
-     * @param conf                  SparkConf instance
-     * @param isSparkSessionManaged When true will stop SparkSession
-     * @param job                   Job using constructed SparkSession
+     * @param conf               SparkConf instance
+     * @param sharedSparkSession When true will stop SparkSession
+     * @param job                Job using constructed SparkSession
      */
     public static void runWithSparkSession(Function<SparkConf, SparkSession> sparkSessionBuilder,
                                            SparkConf conf,
-                                           Boolean isSparkSessionManaged,
+                                           Boolean sharedSparkSession,
                                            Job job) {
         runWithSparkSession(
                 sparkSessionBuilder.apply(conf),
-                isSparkSessionManaged,
+                sharedSparkSession,
                 job);
     }
 
     private static void runWithSparkSession(SparkSession spark,
-                                            Boolean isSparkSessionManaged,
+                                            Boolean sharedSparkSession,
                                             Job job) {
         try {
             job.accept(spark);
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            if (Objects.nonNull(spark) && isSparkSessionManaged) {
+            if (Objects.nonNull(spark) && !sharedSparkSession) {
                 spark.stop();
             }
         }

--- a/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
+++ b/iis-common/src/main/java/eu/dnetlib/iis/common/spark/SparkSessionSupport.java
@@ -22,17 +22,17 @@ public class SparkSessionSupport {
      * Runs a given job using SparkSession created using default builder and supplied SparkConf. Stops SparkSession
      * when SparkSession is shared e.g. created in tests. Allows to reuse SparkSession created externally.
      *
-     * @param conf               SparkConf instance
-     * @param sharedSparkSession When true will not stop SparkSession
-     * @param job                Job using constructed SparkSession
+     * @param conf                 SparkConf instance
+     * @param isSparkSessionShared When true will not stop SparkSession
+     * @param job                  Job using constructed SparkSession
      */
     public static void runWithSparkSession(SparkConf conf,
-                                           Boolean sharedSparkSession,
+                                           Boolean isSparkSessionShared,
                                            Job job) {
         runWithSparkSession(
                 SparkSessionFactory::withConfAndKryo,
                 conf,
-                sharedSparkSession,
+                isSparkSessionShared,
                 job);
     }
 
@@ -40,29 +40,29 @@ public class SparkSessionSupport {
      * Runs a given job using SparkSession created using supplied builder and supplied SparkConf. Stops SparkSession
      * when SparkSession is shared e.g. created in tests. Allows to reuse SparkSession created externally.
      *
-     * @param conf               SparkConf instance
-     * @param sharedSparkSession When true will not stop SparkSession
-     * @param job                Job using constructed SparkSession
+     * @param conf                 SparkConf instance
+     * @param isSparkSessionShared When true will not stop SparkSession
+     * @param job                  Job using constructed SparkSession
      */
     public static void runWithSparkSession(Function<SparkConf, SparkSession> sparkSessionBuilder,
                                            SparkConf conf,
-                                           Boolean sharedSparkSession,
+                                           Boolean isSparkSessionShared,
                                            Job job) {
         runWithSparkSession(
                 sparkSessionBuilder.apply(conf),
-                sharedSparkSession,
+                isSparkSessionShared,
                 job);
     }
 
     private static void runWithSparkSession(SparkSession spark,
-                                            Boolean sharedSparkSession,
+                                            Boolean isSparkSessionShared,
                                             Job job) {
         try {
             job.accept(spark);
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            if (Objects.nonNull(spark) && !sharedSparkSession) {
+            if (Objects.nonNull(spark) && !isSparkSessionShared) {
                 spark.stop();
             }
         }

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/SparkSessionSupportTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/SparkSessionSupportTest.java
@@ -22,14 +22,14 @@ class SparkSessionSupportTest {
 
         @Test
         @DisplayName("SparkSession is not stopped")
-        public void givenSparkSessionBuilderAndJob_whenRunWithNotManagedSparkSession_thenSparkSessionIsNotStopped() throws Exception {
+        public void givenSparkSessionBuilderAndJob_whenRunWithSharedSparkSession_thenSparkSessionIsNotStopped() throws Exception {
             SparkSession spark = mock(SparkSession.class);
             SparkConf conf = mock(SparkConf.class);
             Function<SparkConf, SparkSession> sparkSessionBuilder = mock(Function.class);
             when(sparkSessionBuilder.apply(conf)).thenReturn(spark);
             Job job = mock(Job.class);
 
-            runWithSparkSession(sparkSessionBuilder, conf, false, job);
+            runWithSparkSession(sparkSessionBuilder, conf, true, job);
 
             verify(sparkSessionBuilder).apply(conf);
             verify(job).accept(spark);
@@ -38,14 +38,14 @@ class SparkSessionSupportTest {
 
         @Test
         @DisplayName("SparkSession is stopped")
-        public void givenSparkSessionBuilderAndJob_whenRunWithManagedSparkSession_thenSparkSessionIsStopped() throws Exception {
+        public void givenSparkSessionBuilderAndJob_whenRunWithNotSharedSparkSession_thenSparkSessionIsStopped() throws Exception {
             SparkSession spark = mock(SparkSession.class);
             SparkConf conf = mock(SparkConf.class);
             Function<SparkConf, SparkSession> sparkSessionBuilder = mock(Function.class);
             when(sparkSessionBuilder.apply(conf)).thenReturn(spark);
             Job job = mock(Job.class);
 
-            runWithSparkSession(sparkSessionBuilder, conf, true, job);
+            runWithSparkSession(sparkSessionBuilder, conf, false, job);
 
             verify(sparkSessionBuilder).apply(conf);
             verify(job).accept(spark);

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
@@ -33,7 +33,7 @@ public class CitationRelationExporterJob {
         Float trustLevelThreshold = ConfidenceLevelUtils.evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
         logger.info("Trust level threshold to be used: {}.", trustLevelThreshold);
 
-        runWithSparkSession(new SparkConf(), params.isSparkSessionManaged, spark -> {
+        runWithSparkSession(new SparkConf(), params.sharedSparkSession, spark -> {
             clearOutput(spark, params.outputRelationPath, params.outputReportPath);
 
             Dataset<Row> citations = readCitations(spark, params.inputCitationsPath);
@@ -54,8 +54,8 @@ public class CitationRelationExporterJob {
 
     @Parameters(separators = "=")
     private static class JobParameters {
-        @Parameter(names = "-isSparkSessionManaged", arity = 1)
-        private Boolean isSparkSessionManaged = Boolean.TRUE;
+        @Parameter(names = "-sharedSparkSession")
+        private Boolean sharedSparkSession = Boolean.FALSE;
 
         @Parameter(names = "-inputCitationsPath", required = true)
         private String inputCitationsPath;

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
@@ -33,7 +33,7 @@ public class CitationRelationExporterJob {
         Float trustLevelThreshold = ConfidenceLevelUtils.evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
         logger.info("Trust level threshold to be used: {}.", trustLevelThreshold);
 
-        runWithSparkSession(new SparkConf(), params.sharedSparkSession, spark -> {
+        runWithSparkSession(new SparkConf(), params.isSparkSessionShared, spark -> {
             clearOutput(spark, params.outputRelationPath, params.outputReportPath);
 
             Dataset<Row> citations = readCitations(spark, params.inputCitationsPath);
@@ -55,7 +55,7 @@ public class CitationRelationExporterJob {
     @Parameters(separators = "=")
     private static class JobParameters {
         @Parameter(names = "-sharedSparkSession")
-        private Boolean sharedSparkSession = Boolean.FALSE;
+        private Boolean isSparkSessionShared = Boolean.FALSE;
 
         @Parameter(names = "-inputCitationsPath", required = true)
         private String inputCitationsPath;

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
@@ -55,7 +55,7 @@ class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
         Path outputReportPath = rootOutputPath.resolve("report");
 
         CitationRelationExporterJob.main(new String[]{
-                "-isSparkSessionManaged", Boolean.FALSE.toString(),
+                "-sharedSparkSession",
                 "-inputCitationsPath", inputCitationsPath.toString(),
                 "-outputRelationPath", outputRelationPath.toString(),
                 "-outputReportPath", outputReportPath.toString(),

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
@@ -411,7 +411,7 @@ public class ImportInformationSpaceJob {
     @Parameters(separators = "=")
     private static class ImportInformationSpaceJobParameters {
 
-        @Parameter(names = "-sharedSparkSession", required = false)
+        @Parameter(names = "-sharedSparkSession")
         private Boolean sharedSparkSession = Boolean.FALSE;
         
         @Parameter(names = "-skipDeletedByInference", required = true)

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJob.java
@@ -121,7 +121,7 @@ public class ImportInformationSpaceJob {
         SparkConf conf = SparkConfHelper.withKryo(new SparkConf());
         conf.registerKryoClasses(OafModelUtils.provideOafClasses());
 
-        runWithSparkSession(conf, params.sharedSparkSession, session -> {
+        runWithSparkSession(conf, params.isSparkSessionShared, session -> {
             session = SparkSession.builder().config(conf).getOrCreate();
             JavaSparkContext sc = JavaSparkContext.fromSparkContext(session.sparkContext());
 
@@ -412,7 +412,7 @@ public class ImportInformationSpaceJob {
     private static class ImportInformationSpaceJobParameters {
 
         @Parameter(names = "-sharedSparkSession")
-        private Boolean sharedSparkSession = Boolean.FALSE;
+        private Boolean isSparkSessionShared = Boolean.FALSE;
         
         @Parameter(names = "-skipDeletedByInference", required = true)
         private String skipDeletedByInference;

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/ImportInformationSpaceJobTest.java
@@ -89,7 +89,7 @@ public class ImportInformationSpaceJobTest extends TestWithSharedSparkSession {
         
         // when
         ImportInformationSpaceJob.main(new String[]{
-                "-sparkSessionManagedOutside",
+                "-sharedSparkSession",
                 "-skipDeletedByInference", Boolean.TRUE.toString(),
                 "-trustLevelThreshold", "0.7",
                 "-inferenceProvenanceBlacklist", "iis",


### PR DESCRIPTION
Refactors Spark jobs to use `SparkSessionSupport` for running jobs that share `SparkSession` with tests.

I've changed the way we mark `SparkSession` to be not stopped after job finished. `SparkSessionSupport` used a flag `isSparkSessionManaged` and when the flag was set to `true` the session was stopped after running user code. So to not stop the session user had to set the flag to `false`. I've changed this to the way it is done in `eu.dnetlib.iis.wf.importer.infospace.ImportInformationSpaceJob` where an 'opposite' flag was used, that is when the value of the flag is `true` the session is not closed. This allows a more convenient usage of the flag because we only have to pass the flag as job argument and this will set the flag to `true`. We do not have to provide any explicit value for the flag. The default value of `false` means that the session will be stopped at the end. This refactoring forced a name change for the flag so I've used a more flag-oriented name of `sharedSparkSession`.

