### PR TITLE
Closes #1178: Consider checking the output directory validity in a prior stage

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -429,8 +429,24 @@
             <delete path="${nameNode}${workingDir}" />
             <mkdir path="${nameNode}${workingDir}" />
         </fs>
-        <ok to="copy-version" />
+        <ok to="validate-output" />
         <error to="fail" />
+    </action>
+
+    <action name="validate-output">
+        <fs>
+            <touchz path="${nameNode}${output_remote_location}/validate_output_timestamp"/>
+        </fs>
+        <ok to="validate-output-cleanup"/>
+        <error to="fail"/>
+    </action>
+
+    <action name="validate-output-cleanup">
+        <fs>
+            <delete path="${nameNode}${output_remote_location}/validate_output_timestamp"/>
+        </fs>
+        <ok to="copy-version"/>
+        <error to="fail"/>
     </action>
 
     <action name="copy-version">
@@ -977,7 +993,8 @@
 
     <kill name="fail">
         <message>Unfortunately, the process failed -- error message:
-            [${wf:errorMessage(wf:lastErrorNode())}]</message>
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
     </kill>
 
     <end name="end" />

--- a/iis-wf/iis-wf-primary/src/test/java/eu/dnetlib/iis/wf/primary/main/WorkflowTest.java
+++ b/iis-wf/iis-wf-primary/src/test/java/eu/dnetlib/iis/wf/primary/main/WorkflowTest.java
@@ -1,0 +1,14 @@
+package eu.dnetlib.iis.wf.primary.main;
+
+import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class WorkflowTest extends AbstractOozieWorkflowTestCase {
+
+    @Test
+    @DisplayName("Primary main workflow fails on output without write permissions")
+    public void givenPrimaryMainWorkflow_whenExecutedOnOutputWithoutWritePermission_thenWorkflowFails() {
+        testWorkflow("eu/dnetlib/iis/wf/primary/main/output-validation");
+    }
+}

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/import.txt
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/import.txt
@@ -1,0 +1,2 @@
+## This is a classpath-based import file (this header is required)
+primary_main classpath eu/dnetlib/iis/wf/primary/main/oozie_app

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/workflow.xml
@@ -1,0 +1,90 @@
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="test-primary_main_output_validation">
+
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapreduce.job.queuename</name>
+                <value>${queueName}</value>
+            </property>
+        </configuration>
+    </global>
+
+    <start to="primary_main"/>
+
+    <action name="primary_main">
+        <sub-workflow>
+            <app-path>${wf:appPath()}/primary_main</app-path>
+            <propagate-configuration/>
+            <configuration>
+                <property>
+                    <name>import_islookup_service_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>import_infospace_graph_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>import_patent_tsv</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>ingest_pmc_cache_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>metadataextraction_cache_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>software_webcrawl_cache_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>patent_cache_location</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>citationmatchingFuzzyNumberOfPartitions</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>export_patent_date_of_collection</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>output_remote_location</name>
+                    <value>/user/root/</value>
+                </property>
+                <property>
+                    <name>sparkDriverMemory</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>sparkExecutorMemory</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>sparkExecutorCores</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+                <property>
+                    <name>metric_pusher_address</name>
+                    <value>$UNDEFINED$</value>
+                </property>
+            </configuration>
+        </sub-workflow>
+        <ok to="fail"/>
+        <error to="end"/>
+    </action>
+
+    <kill name="fail">
+        <message>Unfortunately, the process failed -- error message:
+            [${wf:errorMessage(wf:lastErrorNode())}]
+        </message>
+    </kill>
+
+    <end name="end"/>
+</workflow-app>

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/main/output-validation/oozie_app/workflow.xml
@@ -11,7 +11,16 @@
         </configuration>
     </global>
 
-    <start to="primary_main"/>
+    <start to="init"/>
+
+    <action name="init">
+        <fs>
+            <mkdir path="/tmp/${wf:id()}"/>
+            <chmod path="/tmp/${wf:id()}" permissions="dr-xr-xr-x"/>
+        </fs>
+        <ok to="primary_main"/>
+        <error to="fail"/>
+    </action>
 
     <action name="primary_main">
         <sub-workflow>
@@ -56,7 +65,7 @@
                 </property>
                 <property>
                     <name>output_remote_location</name>
-                    <value>/user/root/</value>
+                    <value>/tmp/${wf:id()}</value>
                 </property>
                 <property>
                     <name>sparkDriverMemory</name>
@@ -77,7 +86,15 @@
             </configuration>
         </sub-workflow>
         <ok to="fail"/>
-        <error to="end"/>
+        <error to="cleanup"/>
+    </action>
+
+    <action name="cleanup">
+        <fs>
+            <delete path="/tmp/${wf:id()}"/>
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
     </action>
 
     <kill name="fail">


### PR DESCRIPTION
This PR adds output location validation for `primary_main` workflow. It is done using oozie's `fs` action with `touchz` command. This command creates an empty file under user specified path using current time as file's creation time. If the file cannot be created an error is raised which marks the output location as not valid. This behavior is easily testable so I've also added a workflow test. 

One thing we might consider is whether to remove the created file - currently it is removed but we could leave it as a marker of workflow execution start. 