### PR TITLE
Closes #1212: Align IIS with the recent updates in Oaf model related to PID provenance

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -168,12 +168,13 @@ public class PatentExporterJob {
         return qualifier;
     }
 
-    private static Instance buildOafEntityResultInstance(Patent patent, String patentEpoUrlRoot) {
+    private static Instance buildOafEntityResultInstance(Patent patent, String patentEpoUrlRoot, List<StructuredProperty> pids) {
         Instance instance = new Instance();
         instance.setInstancetype(buildOafEntityResultInstanceInstancetype());
         instance.setHostedby(buildOafEntityPatentKeyValue());
         instance.setCollectedfrom(buildOafEntityPatentKeyValue());
         instance.setUrl(Collections.singletonList(buildOafEntityResultInstanceUrl(patent, patentEpoUrlRoot)));
+        instance.setPid(pids);
         return instance;
     }
 
@@ -388,7 +389,7 @@ public class PatentExporterJob {
             result.setCountry(buildOafEntityResultMetadataCountries(patent.getApplicantCountryCodes()));
         }
         
-        result.setInstance(Collections.singletonList(buildOafEntityResultInstance(patent, patentEpoUrlRoot)));
+        result.setInstance(Collections.singletonList(buildOafEntityResultInstance(patent, patentEpoUrlRoot, pids)));
         return result;
     }
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
@@ -81,6 +81,11 @@ payload.instance[0].pid[0].qualifier.classid=epo_id
 payload.instance[0].pid[0].qualifier.classname=epo_id
 payload.instance[0].pid[0].qualifier.schemeid=dnet:pid_types
 payload.instance[0].pid[0].qualifier.schemename=dnet:pid_types
+payload.instance[0].pid[1].value=EP20000103094
+payload.instance[0].pid[1].qualifier.classid=epo_nr_epodoc
+payload.instance[0].pid[1].qualifier.classname=epo_nr_epodoc
+payload.instance[0].pid[1].qualifier.schemeid=dnet:pid_types
+payload.instance[0].pid[1].qualifier.schemename=dnet:pid_types
 
 payload.collectedfrom[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.collectedfrom[0].value=European Patent Office/PATSTAT

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1.properties
@@ -76,6 +76,11 @@ payload.instance[0].hostedby.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b3
 payload.instance[0].hostedby.value=European Patent Office/PATSTAT
 payload.instance[0].collectedfrom.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.instance[0].collectedfrom.value=European Patent Office/PATSTAT
+payload.instance[0].pid[0].value=EPpatent1
+payload.instance[0].pid[0].qualifier.classid=epo_id
+payload.instance[0].pid[0].qualifier.classname=epo_id
+payload.instance[0].pid[0].qualifier.schemeid=dnet:pid_types
+payload.instance[0].pid[0].qualifier.schemename=dnet:pid_types
 
 payload.collectedfrom[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.collectedfrom[0].value=European Patent Office/PATSTAT

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
@@ -76,6 +76,11 @@ payload.instance[0].hostedby.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b3
 payload.instance[0].hostedby.value=European Patent Office/PATSTAT
 payload.instance[0].collectedfrom.key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.instance[0].collectedfrom.value=European Patent Office/PATSTAT
+payload.instance[0].pid[0].value=EPpatent2
+payload.instance[0].pid[0].qualifier.classid=epo_id
+payload.instance[0].pid[0].qualifier.classname=epo_id
+payload.instance[0].pid[0].qualifier.schemeid=dnet:pid_types
+payload.instance[0].pid[0].qualifier.schemename=dnet:pid_types
 
 payload.collectedfrom[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.collectedfrom[0].value=European Patent Office/PATSTAT

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2.properties
@@ -81,6 +81,11 @@ payload.instance[0].pid[0].qualifier.classid=epo_id
 payload.instance[0].pid[0].qualifier.classname=epo_id
 payload.instance[0].pid[0].qualifier.schemeid=dnet:pid_types
 payload.instance[0].pid[0].qualifier.schemename=dnet:pid_types
+payload.instance[0].pid[1].value=EP20010119799
+payload.instance[0].pid[1].qualifier.classid=epo_nr_epodoc
+payload.instance[0].pid[1].qualifier.classname=epo_nr_epodoc
+payload.instance[0].pid[1].qualifier.schemeid=dnet:pid_types
+payload.instance[0].pid[1].qualifier.schemename=dnet:pid_types
 
 payload.collectedfrom[0].key=10|openaire____::79e8e56d43f34eb7698bfb7535d1b37a
 payload.collectedfrom[0].value=European Patent Office/PATSTAT


### PR DESCRIPTION
NOTE: IIS will fail to build after merging this PR because this PR requires the new version of `dhp-schemas` lib, which is updated in #1226 .