### PR TITLE
Closes #1217: Fix dependency issue causing IIS build failure

### DIFF
--- a/iis-common/pom.xml
+++ b/iis-common/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>eu.dnetlib.dhp</groupId>
             <artifactId>dhp-schemas</artifactId>
+            <classifier>dhp_oaf_model</classifier>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,7 @@
                 <groupId>eu.dnetlib.dhp</groupId>
                 <artifactId>dhp-schemas</artifactId>
                 <version>[1.0.0, 2.0.0)</version>
+                <classifier>dhp_oaf_model</classifier>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR adds classifier for `dhp-schemas` dependency. This is probably a temporary solution which should be reverted when new `dhp-schemas` is released without any classifiers.

NOTE: IIS will fail to build after merging this PR because the new version requires code changes which are done in PR #1224 and in #1225 . 