### PR TITLE
Closes #1221: Remove empty entries creation in output and cache - FIX

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/data/report_patent_metadata_extraction.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/patent/data/report_patent_metadata_extraction.json
@@ -1,2 +1,2 @@
-{"key":"processing.referenceExtraction.patent.metadataextraction.processed.total", "type":"COUNTER", "value": "7"}
-{"key":"processing.referenceExtraction.patent.metadataextraction.processed.fault", "type":"COUNTER", "value": "6"}
+{"key":"processing.referenceExtraction.patent.metadataextraction.processed.total", "type":"COUNTER", "value": "1"}
+{"key":"processing.referenceExtraction.patent.metadataextraction.processed.fault", "type":"COUNTER", "value": "0"}


### PR DESCRIPTION
Fixing failing integration test suite.

After removing empty records from patent metadata retriever output patent metadata extractor input changes. Instead of 7 input records (1 with non-empty text and 6 with empty text) we have now only 1 input record with non-empty text. This PR fixes report entries to match these changes.