### PR TITLE
Closes #1234: Multiple requests when retrieving content from external services

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJob.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/patent/PatentMetadataRetrieverJob.java
@@ -89,7 +89,6 @@ public class PatentMetadataRetrieverJob {
             JavaRDD<DocumentText> cachedSources = DocumentTextCacheStorageUtils.getRddOrEmpty(sc, avroLoader, cacheRootDir,
                     existingCacheId, CacheRecordType.text, DocumentText.class)
                     .filter(x -> StringUtils.isNotBlank(x.getText()));
-            cachedSources.cache();
             JavaRDD<Fault> cachedFaults = DocumentTextCacheStorageUtils.getRddOrEmpty(sc, avroLoader, cacheRootDir,
                     existingCacheId, CacheRecordType.fault, Fault.class);
 
@@ -106,7 +105,6 @@ public class PatentMetadataRetrieverJob {
             JavaRDD<DocumentText> entitiesReturnedFromCache = inputJoinedWithCache
                     .filter(x -> x._2._2.isPresent() && x._2._2.get().isPresent())
                     .values().map(x -> x._2.get().get());
-            entitiesReturnedFromCache.cache();
 
             JavaPairRDD<CharSequence, FacadeContentRetrieverResponse<String>> returnedFromRemoteService =
                     retrieveFromRemoteService(toBeProcessed, contentRetriever);


### PR DESCRIPTION
This PR removes multiple requests to external service in `CachedWebCrawlerJob` and cleans up caching in `PatentMetadataRetrieverJob`.

To remove multiple requests to external services both jobs need to cache responses from services. `CachedWebCrawlerJob` did not do that so multiple requests were sent. `PatentMetadataRetrieverJob` did that so there were no multiple requests. Running both jobs with and without caching of other RDDs along the way showed that we only need to cache service responses, other caching is done 'implicitly' when shuffling between Spark stages. I'm attaching links to Spark History for `CachedWebCrawlerJob` runs here
* [application_1613369572041_2819](http://iis-cdh5-test-gw.ocean.icm.edu.pl:18089/history/application_1613369572041_2819/1/jobs/) - caching only response from external service
* [application_1613369572041_2838](http://iis-cdh5-test-gw.ocean.icm.edu.pl:18089/history/application_1613369572041_2838/1/jobs/) - caching response from external service plus other caches/persists already in the job
* [application_1613369572041_3064](http://iis-cdh5-test-gw.ocean.icm.edu.pl:18089/history/application_1613369572041_3064/1/jobs/) - no cache

The results for `PatentMetadataRetrieverJob` are the same.

Tests are added to check if both jobs request a content from external service only once.