### PR TITLE
Closes #1234: Multiple requests when retrieving content from external services - FIX

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/TestServiceFacadeFactories.java
+++ b/iis-wf/iis-wf-referenceextraction/src/test/java/eu/dnetlib/iis/wf/referenceextraction/patent/TestServiceFacadeFactories.java
@@ -35,37 +35,36 @@ public class TestServiceFacadeFactories {
 
         private static final String classPathRoot = "/eu/dnetlib/iis/wf/referenceextraction/patent/data/mock_facade_storage/";
 
-        public static Set<String> retrievedUrls;
+        public static class Retriever extends FacadeContentRetriever<ImportedPatent, String> {
+            public final Set<String> retrievedUrls = new HashSet<>();
+
+            @Override
+            protected String buildUrl(ImportedPatent objToBuildUrl) {
+                StringBuilder strBuilder = new StringBuilder();
+                strBuilder.append(objToBuildUrl.getPublnAuth());
+                strBuilder.append('.');
+                strBuilder.append(objToBuildUrl.getPublnNr());
+                strBuilder.append('.');
+                strBuilder.append(objToBuildUrl.getPublnKind());
+                strBuilder.append(".xml");
+                return strBuilder.toString();
+            }
+
+            @Override
+            protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) throws Exception {
+                if (retrievedUrls.contains(url)) {
+                    throw new RuntimeException("requesting already processed url: " + url);
+                }
+                FacadeContentRetrieverResponse.Success<String> result = FacadeContentRetrieverResponse
+                        .success(ClassPathResourceProvider.getResourceContent(classPathRoot + url));
+                retrievedUrls.add(url);
+                return result;
+            }
+        }
 
         @Override
         public FacadeContentRetriever<ImportedPatent, String> instantiate(Map<String, String> parameters) {
-            retrievedUrls = new HashSet<>();
-
-            return new FacadeContentRetriever<ImportedPatent, String>() {
-
-                @Override
-                protected String buildUrl(ImportedPatent objToBuildUrl) {
-                    StringBuilder strBuilder = new StringBuilder();
-                    strBuilder.append(objToBuildUrl.getPublnAuth());
-                    strBuilder.append('.');
-                    strBuilder.append(objToBuildUrl.getPublnNr());
-                    strBuilder.append('.');
-                    strBuilder.append(objToBuildUrl.getPublnKind());
-                    strBuilder.append(".xml");
-                    return strBuilder.toString();
-                }
-
-                @Override
-                protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) {
-                    if (retrievedUrls.contains(url)) {
-                        throw new RuntimeException("requesting already processed url: " + url);
-                    }
-                    FacadeContentRetrieverResponse.Success<String> result = FacadeContentRetrieverResponse
-                            .success(ClassPathResourceProvider.getResourceContent(classPathRoot + url));
-                    retrievedUrls.add(url);
-                    return result;
-                }
-            };
+            return new Retriever();
         }
     }
 
@@ -79,46 +78,44 @@ public class TestServiceFacadeFactories {
 
         private static final String expectedParamValue = "testValue";
 
-        public static Set<String> retrievedUrls;
+        public static class Retriever extends FacadeContentRetriever<ImportedPatent, String> {
+            public final Set<String> retrievedUrls = new HashSet<>();
+
+            @Override
+            protected String buildUrl(ImportedPatent objToBuildUrl) {
+                StringBuilder strBuilder = new StringBuilder();
+                strBuilder.append(objToBuildUrl.getApplnAuth());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getApplnNr());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnAuth());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnNr());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnKind());
+                return strBuilder.toString();
+            }
+
+            @Override
+            protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) throws Exception {
+                if (retrievedUrls.contains(url)) {
+                    throw new RuntimeException("requesting already processed url: " + url);
+                }
+                FacadeContentRetrieverResponse<String> result = url.contains("non-existing") ?
+                        FacadeContentRetrieverResponse
+                                .persistentFailure(new PatentWebServiceFacadeException("unable to find element"))
+                        : FacadeContentRetrieverResponse.success(url);
+                retrievedUrls.add(url);
+                return result;
+            }
+        }
 
         @Override
         public FacadeContentRetriever<ImportedPatent, String> instantiate(Map<String, String> parameters) {
             String paramValue = parameters.get(expectedParamName);
             Preconditions.checkArgument(expectedParamValue.equals(paramValue),
                     "'%s' parameter value: '%s' is different than the expected one: '%s'", expectedParamName, paramValue, expectedParamValue);
-
-            retrievedUrls = new HashSet<>();
-
-            return new FacadeContentRetriever<ImportedPatent, String>() {
-
-                @Override
-                protected String buildUrl(ImportedPatent objToBuildUrl) {
-                    StringBuilder strBuilder = new StringBuilder();
-                    strBuilder.append(objToBuildUrl.getApplnAuth());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getApplnNr());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnAuth());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnNr());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnKind());
-                    return strBuilder.toString();
-                }
-
-                @Override
-                protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) {
-                    if (retrievedUrls.contains(url)) {
-                        throw new RuntimeException("requesting already processed url: " + url);
-                    }
-                    FacadeContentRetrieverResponse<String> result = url.contains("non-existing") ?
-                            FacadeContentRetrieverResponse
-                                    .persistentFailure(new PatentWebServiceFacadeException("unable to find element"))
-                            : FacadeContentRetrieverResponse.success(url);
-                    retrievedUrls.add(url);
-                    return result;
-                }
-            };
+            return new Retriever();
         }
     }
 
@@ -132,46 +129,44 @@ public class TestServiceFacadeFactories {
 
         private static final String expectedParamValue = "testValue";
 
-        public static Set<String> retrievedUrls;
+        public static class Retriever extends FacadeContentRetriever<ImportedPatent, String> {
+            public final Set<String> retrievedUrls = new HashSet<>();
+
+            @Override
+            protected String buildUrl(ImportedPatent objToBuildUrl) {
+                StringBuilder strBuilder = new StringBuilder();
+                strBuilder.append(objToBuildUrl.getApplnAuth());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getApplnNr());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnAuth());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnNr());
+                strBuilder.append('-');
+                strBuilder.append(objToBuildUrl.getPublnKind());
+                return strBuilder.toString();
+            }
+
+            @Override
+            protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) throws Exception {
+                if (retrievedUrls.contains(url)) {
+                    throw new RuntimeException("requesting already processed url: " + url);
+                }
+                FacadeContentRetrieverResponse<String> result = url.contains("non-existing") ?
+                        FacadeContentRetrieverResponse
+                                .transientFailure(new PatentWebServiceFacadeException("unable to find element"))
+                        : FacadeContentRetrieverResponse.success(url);
+                retrievedUrls.add(url);
+                return result;
+            }
+        }
 
         @Override
         public FacadeContentRetriever<ImportedPatent, String> instantiate(Map<String, String> parameters) {
             String paramValue = parameters.get(expectedParamName);
             Preconditions.checkArgument(expectedParamValue.equals(paramValue),
                     "'%s' parameter value: '%s' is different than the expected one: '%s'", expectedParamName, paramValue, expectedParamValue);
-
-            retrievedUrls = new HashSet<>();
-
-            return new FacadeContentRetriever<ImportedPatent, String>() {
-
-                @Override
-                protected String buildUrl(ImportedPatent objToBuildUrl) {
-                    StringBuilder strBuilder = new StringBuilder();
-                    strBuilder.append(objToBuildUrl.getApplnAuth());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getApplnNr());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnAuth());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnNr());
-                    strBuilder.append('-');
-                    strBuilder.append(objToBuildUrl.getPublnKind());
-                    return strBuilder.toString();
-                }
-
-                @Override
-                protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) {
-                    if (retrievedUrls.contains(url)) {
-                        throw new RuntimeException("requesting already processed url: " + url);
-                    }
-                    FacadeContentRetrieverResponse<String> result = url.contains("non-existing") ?
-                            FacadeContentRetrieverResponse
-                                    .transientFailure(new PatentWebServiceFacadeException("unable to find element"))
-                            : FacadeContentRetrieverResponse.success(url);
-                    retrievedUrls.add(url);
-                    return result;
-                }
-            };
+            return new Retriever();
         }
     }
 
@@ -180,20 +175,22 @@ public class TestServiceFacadeFactories {
      */
     public static class ExceptionThrowingFacadeFactory implements ServiceFacadeFactory<FacadeContentRetriever<ImportedPatent, String>>, Serializable {
 
+        public static class Retriever extends FacadeContentRetriever<ImportedPatent, String> {
+
+            @Override
+            protected String buildUrl(ImportedPatent objToBuildUrl) {
+                return "/url/to/patent";
+            }
+
+            @Override
+            protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) throws Exception {
+                throw new RuntimeException("unexpected call for url: " + url);
+            }
+        }
+
         @Override
         public FacadeContentRetriever<ImportedPatent, String> instantiate(Map<String, String> parameters) {
-            return new FacadeContentRetriever<ImportedPatent, String>() {
-
-                @Override
-                protected String buildUrl(ImportedPatent objToBuildUrl) {
-                    return "/url/to/patent";
-                }
-
-                @Override
-                protected FacadeContentRetrieverResponse<String> retrieveContentOrThrow(String url, int retryCount) {
-                    throw new RuntimeException("unexpected call for url: " + url);
-                }
-            };
+            return new Retriever();
         }
     }
 }


### PR DESCRIPTION
This PR fixes failing integration tests after merging #1241 .

#1241 added a check for patent metadata retriever and cached webcrawler test factories making sure that only a single request is sent to external service. This check was implemented using a `Set` holding processed urls. Anonymous implementation of facade content retrievers in test factories caused initialization problems with this set resulting in NPE. This PR fixes this by moving anonymous classes extending `FacadeContentRetrieverResponse` to concrete nested classes within test factories.      