### PR TITLE
#1251and #1252: Alignment with updates in OAF model - dependencies update

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/pom.xml
+++ b/iis-wf/iis-wf-export-actionmanager/pom.xml
@@ -40,12 +40,6 @@
         </dependency>
 
         <dependency>
-            <groupId>eu.dnetlib.dhp</groupId>
-            <artifactId>dhp-common</artifactId>
-            <version>1.2.4-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
             <dependency>
                 <groupId>eu.dnetlib.dhp</groupId>
                 <artifactId>dhp-schemas</artifactId>
-                <version>1.2.4-SNAPSHOT</version>
+                <version>[2.0.0, 3.0.0)</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR updates dnet dependencies after release of `dhp-schemas` lib. 

`dhp-common` dependency is removed because `IdentifierFactory` class was moved to `dhp-schemas`. I've used the same version range as in other dnet dependencies. 