### PR TITLE
Closes #1272: Align InfoSpace importer with the recent updates in Oaf model related to the introduction of instance.alternateIdentifiers

### DIFF
--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverter.java
@@ -1,26 +1,16 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
-import java.time.Year;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import eu.dnetlib.dhp.schema.oaf.*;
+import eu.dnetlib.iis.importer.schemas.DataSetReference;
+import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
-import eu.dnetlib.dhp.schema.oaf.Author;
-import eu.dnetlib.dhp.schema.oaf.Dataset;
-import eu.dnetlib.dhp.schema.oaf.Field;
-import eu.dnetlib.dhp.schema.oaf.OafEntity;
-import eu.dnetlib.dhp.schema.oaf.Result;
-import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
-import eu.dnetlib.iis.importer.schemas.DataSetReference;
-import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
+import java.time.Year;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * {@link Dataset} containing dataset details to {@link DataSetReference} converter.
@@ -150,9 +140,10 @@ public class DatasetMetadataConverter implements OafEntityToAvroConverter<Result
      * Handles additional identifiers.
      * 
      */
-    private void handleAdditionalIds(OafEntity oafEntity, DataSetReference.Builder metaBuilder) {
-        if (CollectionUtils.isNotEmpty(oafEntity.getPid())) {
-            List<StructuredProperty> filtered = oafEntity.getPid().stream()
+    private void handleAdditionalIds(Result result, DataSetReference.Builder metaBuilder) {
+        List<StructuredProperty> pid = MetadataConverterUtils.extractPid(result);
+        if (CollectionUtils.isNotEmpty(pid)) {
+            List<StructuredProperty> filtered = pid.stream()
                     .filter(x -> StringUtils.isNotBlank(x.getQualifier().getClassid()))
                     .filter(x -> StringUtils.isNotBlank(x.getValue()))
                     .filter(x -> fieldApprover.approve(x.getDataInfo()))

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverter.java
@@ -1,35 +1,21 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
-import java.io.IOException;
-import java.time.Year;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-
 import com.google.common.base.Preconditions;
-
-import eu.dnetlib.dhp.schema.oaf.Field;
-import eu.dnetlib.dhp.schema.oaf.Instance;
-import eu.dnetlib.dhp.schema.oaf.Journal;
-import eu.dnetlib.dhp.schema.oaf.KeyValue;
-import eu.dnetlib.dhp.schema.oaf.OafEntity;
-import eu.dnetlib.dhp.schema.oaf.Publication;
-import eu.dnetlib.dhp.schema.oaf.Qualifier;
-import eu.dnetlib.dhp.schema.oaf.Result;
-import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
+import eu.dnetlib.dhp.schema.oaf.*;
 import eu.dnetlib.iis.common.InfoSpaceConstants;
 import eu.dnetlib.iis.importer.schemas.Author;
 import eu.dnetlib.iis.importer.schemas.DocumentMetadata;
 import eu.dnetlib.iis.importer.schemas.PublicationType;
 import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.time.Year;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * {@link Result} containing document details to {@link DocumentMetadata} converter.
@@ -193,10 +179,10 @@ public class DocumentMetadataConverter implements OafEntityToAvroConverter<Resul
      * Handles additional identifiers.
      * 
      */
-    private void handleAdditionalIds(OafEntity oafEntity, DocumentMetadata.Builder metaBuilder) {
-        // setting additional identifiers
-        if (CollectionUtils.isNotEmpty(oafEntity.getPid())) {
-            Map<CharSequence, CharSequence> additionalIds = oafEntity.getPid().stream()
+    private void handleAdditionalIds(Result result, DocumentMetadata.Builder metaBuilder) {
+        List<StructuredProperty> pid = MetadataConverterUtils.extractPid(result);
+        if (CollectionUtils.isNotEmpty(pid)) {
+            Map<CharSequence, CharSequence> additionalIds = pid.stream()
                     .filter(x -> StringUtils.isNotBlank(x.getQualifier().getClassid()))
                     .filter(x -> StringUtils.isNotBlank(x.getValue()))
                     .filter(x -> fieldApprover.approve(x.getDataInfo()))

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -1,17 +1,18 @@
 package eu.dnetlib.iis.wf.importer.infospace.converter;
 
-import java.time.Year;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import eu.dnetlib.dhp.schema.oaf.Instance;
+import eu.dnetlib.dhp.schema.oaf.Result;
+import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
+import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
-import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
-import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Static class with metadata conversion utilities.
@@ -60,5 +61,31 @@ public abstract class MetadataConverterUtils {
             return null;
         }
     }
-    
+
+    /**
+     * Returns pid list constructed from a {@link Result}. Pid list is constructed from {@link Instance#pid} field if it's not empty.
+     * Otherwise it's constructed from {@link Instance#alternateIdentifier} field. In any other case an empty list is
+     * returned.
+     */
+    public static List<StructuredProperty> extractPid(Result result) {
+        if (Objects.isNull(result.getInstance())) {
+            return Collections.emptyList();
+        }
+
+        List<StructuredProperty> pid = result.getInstance().stream()
+                .map(x -> Optional.ofNullable(x.getPid()).map(Collection::stream))
+                .filter(Optional::isPresent)
+                .flatMap(Optional::get)
+                .collect(Collectors.toList());
+
+        if (CollectionUtils.isNotEmpty(pid)) {
+            return pid;
+        }
+
+        return result.getInstance().stream()
+                .map(x -> Optional.ofNullable(x.getAlternateIdentifier()).map(Collection::stream))
+                .filter(Optional::isPresent)
+                .flatMap(Optional::get)
+                .collect(Collectors.toList());
+    }
 }

--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtils.java
@@ -63,8 +63,8 @@ public abstract class MetadataConverterUtils {
     }
 
     /**
-     * Returns pid list constructed from a {@link Result}. Pid list is constructed from {@link Instance#pid} field if it's not empty.
-     * Otherwise it's constructed from {@link Instance#alternateIdentifier} field. In any other case an empty list is
+     * Returns pid list constructed from a {@link Result}. Pid list is constructed from {@link Instance#pid} fields if they're not empty.
+     * Otherwise it's constructed from {@link Instance#alternateIdentifier} fields. In any other case an empty list is
      * returned.
      */
     public static List<StructuredProperty> extractPid(Result result) {

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DatasetMetadataConverterTest.java
@@ -240,9 +240,11 @@ public class DatasetMetadataConverterTest {
         
         addDescription(result, ABSTRACT);
 
-        if (result.getPid() == null) {
-            result.setPid(new ArrayList<>());
-        }
+        result.getInstance().forEach(instance -> {
+            if (instance.getPid() == null) {
+                instance.setPid(new ArrayList<>());
+            }
+        });
         
         extIdentifiers.entrySet().stream().map(entry -> {
             StructuredProperty structPid = new StructuredProperty();
@@ -252,9 +254,9 @@ public class DatasetMetadataConverterTest {
             structPid.setQualifier(pidQualifier);
             return structPid;
         }).forEach(pid -> {
-            result.getPid().add(pid);
+            result.getInstance().forEach(instance -> instance.getPid().add(pid));
             // testing for dealing with duplicates
-            result.getPid().add(pid);
+            result.getInstance().forEach(instance -> instance.getPid().add(pid));
         });
         
         Field<String> dateOfAcc = new Field<>();

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverterTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/DocumentMetadataConverterTest.java
@@ -242,7 +242,7 @@ public class DocumentMetadataConverterTest {
             return subject;
         }).forEach(result.getSubject()::add);
 
-        result.setPid(Lists.newArrayList());
+        result.getInstance().forEach(instance -> instance.setPid(Lists.newArrayList()));
         EXT_IDENTIFIERS.entrySet().stream().map(entry -> {
             StructuredProperty pid = new StructuredProperty();
             pid.setValue(entry.getValue());
@@ -250,7 +250,7 @@ public class DocumentMetadataConverterTest {
             pidType.setClassid(entry.getKey());
             pid.setQualifier(pidType);
             return pid;
-        }).forEach(result.getPid()::add);
+        }).forEach(pid -> result.getInstance().forEach(instance -> instance.getPid().add(pid)));
         
         Journal journal = new Journal();
         journal.setName(JOURNAL);

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -12,10 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Year;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -171,8 +168,8 @@ public class MetadataConverterUtilsTest {
         }
 
         @Test
-        @DisplayName("Pid list is returned for instance list of element without pid list and with alternate identifier list")
-        public void givenAResultWithInstanceOfElementWithoutPidListAndWithAlternateIdentifierList_whenPidListIsExtracted_thenAlternateIdentifierListIsReturned() {
+        @DisplayName("Pid list is returned for instance list of element with alternate identifier list")
+        public void givenAResultWithInstanceOfElementWithAlternateIdentifierList_whenPidListIsExtracted_thenPidListIsReturned() {
             StructuredProperty pid = mock(StructuredProperty.class);
             Instance instance = new Instance();
             instance.setAlternateIdentifier(Collections.singletonList(pid));
@@ -183,6 +180,24 @@ public class MetadataConverterUtilsTest {
 
             assertThat(pidList.size(), equalTo(1));
             assertThat(pidList, hasItem(pid));
+        }
+
+        @Test
+        @DisplayName("Pid list is returned for instance list of element with pid list and with alternate identifier list")
+        public void givenAResultWithInstanceOfElementWithPidListAndWithAlternateIdentifierList_whenPidListIsExtracted_thenUnionListIsReturned() {
+            StructuredProperty pid1 = mock(StructuredProperty.class);
+            StructuredProperty pid2 = mock(StructuredProperty.class);
+            Instance instance = new Instance();
+            instance.setPid(Arrays.asList(pid1, pid2));
+            instance.setAlternateIdentifier(Arrays.asList(pid1, pid2));
+            Result result = new Result();
+            result.setInstance(Collections.singletonList(instance));
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList.size(), equalTo(2));
+            assertThat(pidList, hasItem(pid1));
+            assertThat(pidList, hasItem(pid2));
         }
     }
 }

--- a/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
+++ b/iis-wf/iis-wf-import/src/test/java/eu/dnetlib/iis/wf/importer/infospace/converter/MetadataConverterUtilsTest.java
@@ -2,16 +2,25 @@ package eu.dnetlib.iis.wf.importer.infospace.converter;
 
 import com.google.common.collect.Lists;
 import eu.dnetlib.dhp.schema.oaf.DataInfo;
+import eu.dnetlib.dhp.schema.oaf.Instance;
+import eu.dnetlib.dhp.schema.oaf.Result;
 import eu.dnetlib.dhp.schema.oaf.StructuredProperty;
 import eu.dnetlib.iis.wf.importer.infospace.approver.FieldApprover;
 import org.apache.log4j.Logger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Year;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
@@ -96,5 +105,84 @@ public class MetadataConverterUtilsTest {
         structProp.setDataInfo(dataInfo);
         return structProp;
     }
-    
+
+    @Nested
+    public class ExtractPidTest {
+
+        @Test
+        @DisplayName("Empty pid list is returned for result with null instance list")
+        public void givenAResultWithNullInstanceList_whenPidListIsExtracted_thenEmptyCollectionIsReturned() {
+            Result result = new Result();
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList, empty());
+        }
+
+        @Test
+        @DisplayName("Empty pid list is returned for result with empty instance list")
+        public void givenAResultWithEmptyInstanceList_whenPidListIsExtracted_thenEmptyCollectionIsReturned() {
+            Result result = new Result();
+            result.setInstance(Collections.emptyList());
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList, empty());
+        }
+
+        @Test
+        @DisplayName("Empty pid list is returned for result with instance list of element without pid list and without alternate identifier list")
+        public void givenAResultWithInstanceListOfElementWithoutPidListAndAlternateIdentifierList_whenPidListIsExtracted_thenEmptyCollectionIsReturned() {
+            Result result = new Result();
+            result.setInstance(Collections.singletonList(new Instance()));
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList, empty());
+        }
+
+        @Test
+        @DisplayName("Empty pid list is returned for result with instance list of element with empty pid list and empty alternate identifier list")
+        public void givenAResultWithInstanceListOfElementWithEmptyPidListAndEmptyAlternateIdentifierList_whenPidListIsExtracted_thenEmptyCollectionIsReturned() {
+            Instance instance = new Instance();
+            instance.setPid(Collections.emptyList());
+            instance.setAlternateIdentifier(Collections.emptyList());
+            Result result = new Result();
+            result.setInstance(Collections.singletonList(instance));
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList, empty());
+        }
+
+        @Test
+        @DisplayName("Pid list is returned for instance list of element with pid list")
+        public void givenAResultWithInstanceOfElementWithPidList_whenPidListIsExtracted_thenPidListIsReturned() {
+            StructuredProperty pid = mock(StructuredProperty.class);
+            Instance instance = new Instance();
+            instance.setPid(Collections.singletonList(pid));
+            Result result = new Result();
+            result.setInstance(Collections.singletonList(instance));
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList.size(), equalTo(1));
+            assertThat(pidList, hasItem(pid));
+        }
+
+        @Test
+        @DisplayName("Pid list is returned for instance list of element without pid list and with alternate identifier list")
+        public void givenAResultWithInstanceOfElementWithoutPidListAndWithAlternateIdentifierList_whenPidListIsExtracted_thenAlternateIdentifierListIsReturned() {
+            StructuredProperty pid = mock(StructuredProperty.class);
+            Instance instance = new Instance();
+            instance.setAlternateIdentifier(Collections.singletonList(pid));
+            Result result = new Result();
+            result.setInstance(Collections.singletonList(instance));
+
+            List<StructuredProperty> pidList = MetadataConverterUtils.extractPid(result);
+
+            assertThat(pidList.size(), equalTo(1));
+            assertThat(pidList, hasItem(pid));
+        }
+    }
 }

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/output/dataset.json
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/output/dataset.json
@@ -38,8 +38,8 @@
 }
 {
   "id": "50|opentrials__::98053cee8d1792ba9c0889d5c4189cec",
-  "referenceType": "euctr",
-  "idForGivenType": "EUCTR2013-001884-21",
+  "referenceType": "unspecified",
+  "idForGivenType": "",
   "creatorNames": [
     "Bhamidimarri, Kalyan R",
     "Jalan, Rajiv",
@@ -75,8 +75,5 @@
   "publicationYear": "2013",
   "formats": null,
   "resourceTypeValue": "0037",
-  "alternateIdentifiers": {
-    "euctr": "EUCTR2013-001884-21",
-    "nct": "NCT01829347"
-  }
+  "alternateIdentifiers": null
 }

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/output/document.json
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/output/document.json
@@ -10,10 +10,7 @@
     "CERIF",
     "DataCite"
   ],
-  "externalIdentifiers": {
-    "handle": "123456789/7",
-    "doi": "10.1007/978-3-642-35233-1_18"
-  },
+  "externalIdentifiers": null,
   "journal": null,
   "year": 2012,
   "publisher": null,
@@ -251,10 +248,7 @@
   "abstract": "The Lille score will be used to identify subjects with an increased risk of mortality (Lille score failures). The Lille score is a prognostic model combining six reproducible variables at Day 0 and Day 7 of steroid treatment. The Lille score used in this protocol is being used independent of steroid administration during the 7 days of evaluation. A Lille score >0.45 (Lille score failure) indicates that the subject is at substantially increased risk of 30- and 90-day mortality. Subjects with severe acute alcoholic hepatitis (sAAH) are often treated with steroids as soon as their diagnosis is confirmed. This study is to assess treatment with the ELAD System in subjects who have failed per the Lille criteria, independent of steroid administration. ELAD treatment is done continuously for up to 10 days in addition to standard of care treatment. The Control group (those randomized not to receive ELAD treatment) will also get standard of care treatment. Standard of care is defined as the usual",
   "language": "UNKNOWN",
   "keywords": null,
-  "externalIdentifiers": {
-    "euctr": "EUCTR2013-001884-21",
-    "nct": "NCT01829347"
-  },
+  "externalIdentifiers": null,
   "journal": null,
   "year": 2013,
   "publisher": "nct",
@@ -405,9 +399,7 @@
     "Cohort",
     "Surgery"
   ],
-  "externalIdentifiers": {
-    "doi": "10.1183/13993003.00282-2016"
-  },
+  "externalIdentifiers": null,
   "journal": "European Respiratory Journal",
   "year": 2016,
   "publisher": "European Respiratory Society (ERS)",


### PR DESCRIPTION
Note: OAF model changes implemented in this PR do not test well with our current data. Specifically avoiding the use of `Result#pid` field in converters and switching to `Result#instance#pid` or `Result#instance#alternateIdentifier` caused removal of some valid data from importer test outcome because our test data rely on `Result#pid` field. We could consider updating our test input to include changes in the model. 