### PR TITLE
Closes #1280: Remove compression for avro datastores saved using spark-avro lib

### DIFF
--- a/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDataFrameWriter.scala
+++ b/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDataFrameWriter.scala
@@ -32,6 +32,7 @@ class AvroDataFrameWriter(df: DataFrame) extends Serializable {
       .write
       .format("avro")
       .option("avroSchema", avroSchema.toString)
+      .option("compression", "uncompressed")
       .save(path)
   }
 }

--- a/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDatasetWriter.scala
+++ b/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDatasetWriter.scala
@@ -23,6 +23,7 @@ class AvroDatasetWriter[T <: SpecificRecordBase](ds: Dataset[T]) extends Seriali
       .write
       .format("avro")
       .option("avroSchema", avroSchema.toString)
+      .option("compression", "uncompressed")
       .save(path)
   }
 }

--- a/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDatasetWriter.scala
+++ b/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDatasetWriter.scala
@@ -19,11 +19,7 @@ class AvroDatasetWriter[T <: SpecificRecordBase](ds: Dataset[T]) extends Seriali
    * @param avroSchema Avro schema of the records.
    */
   def write(path: String, avroSchema: Schema): Unit = {
-    new AvroDatasetSupport(ds.sparkSession).toDF(ds, avroSchema)
-      .write
-      .format("avro")
-      .option("avroSchema", avroSchema.toString)
-      .option("compression", "uncompressed")
-      .save(path)
+    new AvroDataFrameWriter(new AvroDatasetSupport(ds.sparkSession).toDF(ds, avroSchema))
+      .write(path, avroSchema)
   }
 }


### PR DESCRIPTION
This PR removes compression when saving dataframes of Avro types. Avro dataset writer is also slightly improved, to reduce code duplication.

NOTE: there are no unit tests for checking the compression of saved Avro dataframes. This is because the compression does not affect the support of Avro datastores in IIS - we can read and write Avro datastores with and without compression without any issues using either spark-utils or spark-avro libs. The problem with compression manifests itself when external tools are used to process Avro files, like `hdfs dfs -text` or `avro2json`. The changes were manually tested using those tools.