### PR TITLE
Closes #1281: Fix schema nullability for datastores written and read using avro format

### DIFF
--- a/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDataFrameReader.scala
+++ b/iis-common/src/main/scala/eu/dnetlib/iis/common/spark/avro/AvroDataFrameReader.scala
@@ -31,9 +31,10 @@ class AvroDataFrameReader(val spark: SparkSession) extends Serializable {
    * @return DataFrame with data read from given path.
    */
   def read(path: String, avroSchema: Schema): DataFrame = {
-    spark.read
+    val in = spark.read
       .format("avro")
       .option("avroSchema", avroSchema.toString)
       .load(path)
+    spark.createDataFrame(in.rdd, SchemaConverters.toSqlType(avroSchema).dataType.asInstanceOf[StructType])
   }
 }

--- a/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDataFrameReaderTest.java
+++ b/iis-common/src/test/java/eu/dnetlib/iis/common/spark/avro/AvroDataFrameReaderTest.java
@@ -3,7 +3,6 @@ package eu.dnetlib.iis.common.spark.avro;
 import eu.dnetlib.iis.common.avro.Person;
 import eu.dnetlib.iis.common.spark.TestWithSharedSparkSession;
 import eu.dnetlib.iis.common.utils.AvroTestUtils;
-import org.apache.avro.Schema;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.avro.SchemaConverters;
@@ -40,7 +39,7 @@ class AvroDataFrameReaderTest extends TestWithSharedSparkSession {
         Dataset<Row> result = reader.read(inputDir.toString(),
                 (StructType) SchemaConverters.toSqlType(Person.SCHEMA$).dataType());
 
-        assertSchemasEqualIgnoringNullability(Person.SCHEMA$, result.schema());
+        assertEquals(SchemaConverters.toSqlType(Person.SCHEMA$).dataType(), result.schema());
         List<Row> rows = result.collectAsList();
         assertEquals(1, rows.size());
         Row row = rows.get(0);
@@ -58,16 +57,12 @@ class AvroDataFrameReaderTest extends TestWithSharedSparkSession {
 
         Dataset<Row> result = reader.read(inputDir.toString(), Person.SCHEMA$);
 
-        assertSchemasEqualIgnoringNullability(Person.SCHEMA$, result.schema());
+        assertEquals(SchemaConverters.toSqlType(Person.SCHEMA$).dataType(), result.schema());
         List<Row> rows = result.collectAsList();
         assertEquals(1, rows.size());
         Row row = rows.get(0);
         assertEquals(person.getId(), row.getAs("id"));
         assertEquals(person.getName(), row.getAs("name"));
         assertEquals(person.getAge(), row.getAs("age"));
-    }
-
-    private static void assertSchemasEqualIgnoringNullability(Schema avroSchema, StructType sqlSchema) {
-        assertEquals(SchemaConverters.toSqlType(avroSchema).dataType().asNullable(), sqlSchema.asNullable());
     }
 }


### PR DESCRIPTION
According to online search setting fields to nullable when reading an avro datastore using spark-avro package is intentional. However, with our code base this can be unnatural - reading and saving a dataframe of avro type should not require any additional steps. This PR fixes this by mapping dataframe read from avro datastore to desired schema. 

Additionally a minor improvement is done to `AvroDatasetReader` to reduce code duplication.  