### PR TITLE
Use https for maven.ceon.pl

### DIFF
--- a/iis-wf/pom.xml
+++ b/iis-wf/pom.xml
@@ -33,7 +33,7 @@
         <pluginRepository>
             <id>iis-releases</id>
             <name>iis releases plugin repository</name>
-            <url>http://maven.ceon.pl/artifactory/iis-releases</url>
+            <url>https://maven.ceon.pl/artifactory/iis-releases</url>
             <layout>default</layout>
         </pluginRepository>
     </pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -924,12 +924,12 @@
         <snapshotRepository>
             <id>iis-snapshots</id>
             <name>IIS Snapshots</name>
-            <url>http://maven.ceon.pl/artifactory/iis-snapshots/</url>
+            <url>https://maven.ceon.pl/artifactory/iis-snapshots/</url>
             <layout>default</layout>
         </snapshotRepository>
         <repository>
             <id>iis-releases</id>
-            <url>http://maven.ceon.pl/artifactory/iis-releases/</url>
+            <url>https://maven.ceon.pl/artifactory/iis-releases/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Change http URLs in poms to https.
http access is currently broken on maven.ceon.pl and there is no
reason not to use https here.