### PR TITLE
Closes #1326: Documents similarity fails when run on the non-deduplicated graph

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -137,7 +137,7 @@
         </property>
         <property>
             <name>ds_mapredChildJavaOpts</name>
-            <value>-Xmx10g</value>
+            <value>-Xmx12g</value>
             <description>mapred child java opts</description>
         </property>
         <property>


### PR DESCRIPTION
Increasing xmx memory assigned to documents similarity PIG jobs from `10GB` up to `12GB`.