### PR TITLE
Disable concurrent builds to reduce memory usage

### DIFF
--- a/Jenkinsfile.dockerized
+++ b/Jenkinsfile.dockerized
@@ -12,6 +12,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
         timeout time: 60, unit: 'MINUTES'
+	lock('iis-build')
     }
 
     environment {


### PR DESCRIPTION
As described in the issue #1343 builds get killed by the OOM killer
sometimes.

Add disableConcurrentBuilds to the build options to reduce
memory usage whem multiple builds are triggered.