### PR TITLE
Set timeout only after obtaining the build lock

### DIFF
--- a/Jenkinsfile.dockerized
+++ b/Jenkinsfile.dockerized
@@ -11,8 +11,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout time: 60, unit: 'MINUTES'
 	lock('iis-build')
+	timeout time: 60, unit: 'MINUTES'
     }
 
     environment {


### PR DESCRIPTION
If we set the build timeout before obtaining the lock used to limit
concurrent IIS builds the timeout includes waiting for the lock.
With the timeout 2-3 times longer than a typical build, this causes
jobs to be timeouted if more than a couple are queued at the same time.

So move the timeout option to after the locking.

Note: It does not seem to be documented that the relative order of
these options matters but testing shows that it does in practice.