### PR TITLE
Do not run SlowTest tests during regular Jenkins builds

### DIFF
--- a/Jenkinsfile.dockerized
+++ b/Jenkinsfile.dockerized
@@ -28,7 +28,7 @@ pipeline {
                 }
             }
             steps {
-		sh 'mvn -B clean install -DskipITs -Dmaven.test.failure.ignore'
+		sh 'mvn -B clean install -DskipITs -DotherExcludedGroups=SlowTest -Dmaven.test.failure.ignore'
             }
 	    post {
 		always {
@@ -49,7 +49,7 @@ pipeline {
 	    //NOTE: sonar scan is only done for master branch because current Sonar instance does not support branching
 	    when { branch 'master' }
             steps {
-		sh 'mvn -B sonar:sonar -DskipTests -DskipITs -Dsonar.host.url=http://sonar.ceon.pl -Dsonar.login=${SONAR_TOKEN}'
+		sh 'mvn -B sonar:sonar -DskipTests -Dsonar.host.url=http://sonar.ceon.pl -Dsonar.login=${SONAR_TOKEN}'
             }
         }
     }


### PR DESCRIPTION
As discussed in issue #1329 we do not want to run tests marked as
slow, some of which take dozens of minutes to finish, during regular
IIS builds. It is enough that they are run together with integration
tests and during deployment builds.

So add -DotherExcludedGroups=SlowTest to the maven invocation.

Additional not strictly related small fix - skipTests implies skipITs
so do not define both in the maven invocation for sonar.