### PR TITLE
Deploy IIS snapshots to our Maven repository

### DIFF
--- a/Jenkinsfile.dockerized
+++ b/Jenkinsfile.dockerized
@@ -17,6 +17,7 @@ pipeline {
 
     environment {
 	SONAR_TOKEN=credentials('sonar-token')
+	ARTIFACTORY_DEPLOY=credentials('artifactory-deploy')
     }
     stages {
         stage('Build') {
@@ -38,7 +39,7 @@ pipeline {
 		}
 	    }
         }
-        stage('Sonar') {
+        stage('Sonar & Deploy') {
             agent {
                 docker {
                     image dockerImage
@@ -49,7 +50,7 @@ pipeline {
 	    //NOTE: sonar scan is only done for master branch because current Sonar instance does not support branching
 	    when { branch 'master' }
             steps {
-		sh 'mvn -B sonar:sonar -DskipTests -Dsonar.host.url=http://sonar.ceon.pl -Dsonar.login=${SONAR_TOKEN}'
+		sh 'mvn -B sonar:sonar deploy -s deploy-settings.xml -DskipTests -Dsonar.host.url=http://sonar.ceon.pl -Dsonar.login=${SONAR_TOKEN}'
             }
         }
     }

--- a/deploy-settings.xml
+++ b/deploy-settings.xml
@@ -1,0 +1,12 @@
+<settings  xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+<servers>
+  <server>
+   <id>iis-snapshots</id>
+   <username>${env.ARTIFACTORY_DEPLOY_USR}</username>
+   <password>${env.ARTIFACTORY_DEPLOY_PSW}</password>
+  </server>
+</servers>
+</settings>


### PR DESCRIPTION
Since other projects (in particular iis-examples) depend on some IIS
snapshot artifacts we need to upload them to the repository to allow for
independent builds.

Use the same approach as with MDE:
- Only upload from master branch, doing it in the same step that runs
the Sonar analysis.
- Pass the upload credentials using a maven settings file.