### PR TITLE
Run tests in a fully pseudo-random order

### DIFF
--- a/Jenkinsfile.dockerized
+++ b/Jenkinsfile.dockerized
@@ -28,7 +28,12 @@ pipeline {
                 }
             }
             steps {
-		sh 'mvn -B clean install -DskipITs -DotherExcludedGroups=SlowTest -Dmaven.test.failure.ignore'
+		sh '''
+                    mvn -B clean install -DskipITs -DotherExcludedGroups=SlowTest \
+                        -Djunit.jupiter.testmethod.order.default=org.junit.jupiter.api.MethodOrderer\\$Random \
+                        -Djunit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer\\$Random \
+                        -Dmaven.test.failure.ignore
+                    '''
             }
 	    post {
 		always {

--- a/pom.xml
+++ b/pom.xml
@@ -960,7 +960,7 @@
         <iis.spark.version>2.4.0.cloudera2</iis.spark.version>
         <iis.coansys.version>1.10</iis.coansys.version>
 
-        <junit.version>5.4.2</junit.version>
+        <junit.version>5.8.2</junit.version>
         <mockito.version>3.5.13</mockito.version>
 
         <otherExcludedGroups/>


### PR DESCRIPTION
We discovered several cases of unexpected test interdependencies
recently by tests failing in new environments.
Try running tests in a fully pseudo-random oder to detect other such
cases earlier.

Use test class and method ordering options provided by JUnit 5.
Bump JUnit version to the latest one since the one we used before did
not support test class reordering.