### PR TITLE
Closes #1363: Fix jackson library mismatch causing class incompatibility fatal error while importing the graph

### DIFF
--- a/iis-common/pom.xml
+++ b/iis-common/pom.xml
@@ -35,6 +35,23 @@
         <dependency>
             <groupId>eu.dnetlib.dhp</groupId>
             <artifactId>dhp-schemas</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- conflicting versions -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- conflicting versions -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- conflicting versions -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is quite important PR because if fixes fatal error in InfoSpace graph importer phase.

Excluding conflicting jackson dependencies from dhp-schemas.