### PR TITLE
workaround for bug with UDF strsplit

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/sqlite_builder/oozie_app/lib/scripts/buildprojectdb.sql
+++ b/iis-wf/iis-wf-referenceextraction/src/main/resources/eu/dnetlib/iis/wf/referenceextraction/project/sqlite_builder/oozie_app/lib/scripts/buildprojectdb.sql
@@ -37,7 +37,7 @@ create table grants as select acronym,
           (setschema 'acronym,normalizedacro,grantid,fundingclass1,fundingclass2,id,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10' 
           select case when c1 is null then "UNKNOWN" else c1 end as acronym, 
                  case when c1 is not null then regexpr("[_\s]",normalizetext(lower(c1)),"[_\s]") else "unknown" end as normalizedacro, 
-                 c3 as grantid,strsplit(c4,"delimiter:::") as fundingClass,c2 as id, 
+                 c3 as grantid,jsplit(t2j(regexpr("::", c4, "\t"))) as fundingclass,c2 as id, 
                  jsonpath(c5,'$.NWOgebied','$.dossiernr','$.orgname', '$.activity', '$.administeringic', '$.serialnumber', '$.coreprojectnum','$.alias','$.keywords','$.settore') 
                        from 
                           (select * from (setschema 'c1,c2,c3,c4,c5' select jsonpath(c1, '$.projectAcronym', '$.id' , '$.projectGrantId','$.fundingClass','$.jsonextrainfo') from jsoninp) 


### PR DESCRIPTION
strsplit is based on an external lib (python dsv) which was integrated with madis. In this commit, we replace strsplit function call with an equivalent workaround. Debugging of strsplit is more complex since the bug is in third parties code (a csv reader which reads delimited input, this should be replaced with a python3 library).