### PR TITLE
Closes #1404: Refine the way EOSC services mining outcome is exported

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/OafConstants.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/OafConstants.java
@@ -7,7 +7,7 @@ public class OafConstants {
     public static final String REL_TYPE_RESULT_RESULT = ModelConstants.RESULT_RESULT;
     public static final String REL_TYPE_RESULT_PROJECT = ModelConstants.RESULT_PROJECT;
     public static final String REL_TYPE_RESULT_ORGANIZATION = ModelConstants.RESULT_ORGANIZATION;
-    public static final String REL_TYPE_RESULT_DATASOURCE = "resultDatasource";
+    public static final String REL_TYPE_RESULT_SERVICE = "resultService";
     
     public static final String SUBREL_TYPE_RELATIONSHIP = ModelConstants.RELATIONSHIP;
     public static final String SUBREL_TYPE_OUTCOME = ModelConstants.OUTCOME;

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AlgorithmName.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AlgorithmName.java
@@ -16,7 +16,7 @@ public enum AlgorithmName {
 	document_referencedProjects,
 	document_referencedDatasets,
 	document_referencedDocuments,
-	document_referencedDatasources,
+	document_eoscServices,
 	document_research_initiative,
 	document_pdb,
 	document_software_url,

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDatasourceActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDatasourceActionBuilderModuleFactory.java
@@ -22,7 +22,7 @@ public class DocumentToDatasourceActionBuilderModuleFactory extends AbstractActi
     // ------------------------ CONSTRUCTORS --------------------------
     
     public DocumentToDatasourceActionBuilderModuleFactory() {
-        super(AlgorithmName.document_referencedDatasources);
+        super(AlgorithmName.document_eoscServices);
     }
     
     // ------------------------ LOGIC ---------------------------------
@@ -52,9 +52,9 @@ public class DocumentToDatasourceActionBuilderModuleFactory extends AbstractActi
         public List<AtomicAction<Relation>> build(DocumentToDatasource object) throws TrustLevelThresholdExceededException {
             return Arrays.asList(
                     createAction(object.getDocumentId().toString(), object.getDatasourceId().toString(),
-                            object.getConfidenceLevel(), OafConstants.REL_CLASS_REFERENCES),
+                            object.getConfidenceLevel(), OafConstants.REL_CLASS_ISRELATEDTO),
                     createAction(object.getDatasourceId().toString(), object.getDocumentId().toString(),
-                            object.getConfidenceLevel(), OafConstants.REL_CLASS_IS_REFERENCED_BY));
+                            object.getConfidenceLevel(), OafConstants.REL_CLASS_ISRELATEDTO));
         }
 
         // ------------------------ PRIVATE --------------------------
@@ -70,7 +70,7 @@ public class DocumentToDatasourceActionBuilderModuleFactory extends AbstractActi
             Relation relation = new Relation();
             relation.setSource(source);
             relation.setTarget(target);
-            relation.setRelType(OafConstants.REL_TYPE_RESULT_DATASOURCE);
+            relation.setRelType(OafConstants.REL_TYPE_RESULT_SERVICE);
             relation.setSubRelType(OafConstants.SUBREL_TYPE_RELATIONSHIP);
             relation.setRelClass(relClass);
             relation.setDataInfo(buildInference(confidenceLevel));

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -84,9 +84,9 @@
             <description>document_referencedDatasets action-set identifier of exported data</description>
         </property>
         <property>
-            <name>action_set_id_document_referencedDatasources</name>
+            <name>action_set_id_document_eoscServices</name>
             <value>$UNDEFINED$</value>
-            <description>document_referencedDatasources action-set identifier of exported data</description>
+            <description>document_eoscServices action-set identifier of exported data</description>
         </property>
         <property>
             <name>action_set_id_document_referencedDocuments</name>
@@ -480,7 +480,7 @@
 	<action name="exporter-document-to-datasource">
         <map-reduce>
             <prepare>
-                <mkdir path="${nameNode}${output}/document_referencedDatasources" />
+                <mkdir path="${nameNode}${output}/document_eoscServices" />
             </prepare>
             <configuration>
                 <property>
@@ -497,7 +497,7 @@
                 </property>
                 <property>
                     <name>mapreduce.output.fileoutputformat.outputdir</name>
-                    <value>${output}/document_referencedDatasources/${action_set_id_document_referencedDatasources}</value>
+                    <value>${output}/document_eoscServices/${action_set_id_document_eoscServices}</value>
                 </property>
                 <!-- reducing input with large number of small files -->
                 <property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDatasourceActionBuilderModuleFactoryTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDatasourceActionBuilderModuleFactoryTest.java
@@ -22,7 +22,7 @@ public class DocumentToDatasourceActionBuilderModuleFactoryTest extends Abstract
     // ----------------------- CONSTRUCTORS -------------------
     
     public DocumentToDatasourceActionBuilderModuleFactoryTest() throws Exception {
-        super(DocumentToDatasourceActionBuilderModuleFactory.class, AlgorithmName.document_referencedDatasources);
+        super(DocumentToDatasourceActionBuilderModuleFactory.class, AlgorithmName.document_eoscServices);
     }
 
     // ----------------------- TESTS --------------------------
@@ -57,8 +57,8 @@ public class DocumentToDatasourceActionBuilderModuleFactoryTest extends Abstract
         assertNotNull(action);
         assertEquals(Relation.class, action.getClazz());
         Expectations expectations = new Expectations(docId, datasourceId, matchStrength, 
-                OafConstants.REL_TYPE_RESULT_DATASOURCE, OafConstants.SUBREL_TYPE_RELATIONSHIP, 
-                OafConstants.REL_CLASS_REFERENCES);
+                OafConstants.REL_TYPE_RESULT_SERVICE, OafConstants.SUBREL_TYPE_RELATIONSHIP, 
+                OafConstants.REL_CLASS_ISRELATEDTO);
         assertOafRel(action.getPayload(), expectations);
         
 //      checking backward relation
@@ -67,7 +67,6 @@ public class DocumentToDatasourceActionBuilderModuleFactoryTest extends Abstract
         assertEquals(Relation.class, action.getClazz());
         expectations.setSource(datasourceId);
         expectations.setTarget(docId);
-        expectations.setRelationClass(OafConstants.REL_CLASS_IS_REFERENCED_BY);
         assertOafRel(action.getPayload(), expectations);
     }
     

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
@@ -171,7 +171,7 @@
                     <value>actionset-id</value>
                 </property>
                 <property>
-                    <name>action_set_id_document_referencedDatasources</name>
+                    <name>action_set_id_document_eoscServices</name>
                     <value>actionset-id</value>
                 </property>
                 <property>
@@ -303,7 +303,7 @@
         <java>
             <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
             <arg>eu.dnetlib.iis.wf.export.actionmanager.sequencefile.TestingConsumer</arg>
-            <arg>-Iseqfile=${workingDir}/output/document_referencedDatasources/actionset-id</arg>
+            <arg>-Iseqfile=${workingDir}/output/document_eoscServices/actionset-id</arg>
             <arg>-Pexpectation_file_paths=/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_1.properties,/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_2.properties
             </arg>
         </java>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_1.properties
@@ -1,14 +1,14 @@
 clazz.canonicalName=eu.dnetlib.dhp.schema.oaf.Relation
 
-payload.relType=resultDatasource
+payload.relType=resultService
 payload.subRelType=relationship
-payload.relClass=References
+payload.relClass=IsRelatedTo
 payload.source=id-10
 payload.target=dsid-1
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348
-payload.dataInfo.inferenceprovenance=iis::document_referencedDatasources
+payload.dataInfo.inferenceprovenance=iis::document_eoscServices
 payload.dataInfo.provenanceaction.classid=iis
 payload.dataInfo.provenanceaction.classname=iis
 payload.dataInfo.provenanceaction.schemeid=dnet:provenanceActions

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_datasource_2.properties
@@ -1,14 +1,14 @@
 clazz.canonicalName=eu.dnetlib.dhp.schema.oaf.Relation
 
-payload.relType=resultDatasource
+payload.relType=resultService
 payload.subRelType=relationship
-payload.relClass=IsReferencedBy
+payload.relClass=IsRelatedTo
 payload.source=dsid-1
 payload.target=id-10
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348
-payload.dataInfo.inferenceprovenance=iis::document_referencedDatasources
+payload.dataInfo.inferenceprovenance=iis::document_eoscServices
 payload.dataInfo.provenanceaction.classid=iis
 payload.dataInfo.provenanceaction.classname=iis
 payload.dataInfo.provenanceaction.schemeid=dnet:provenanceActions

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
@@ -119,9 +119,9 @@
             <description>document_referencedDocuments action-set identifier of exported data</description>
         </property>
         <property>
-            <name>action_set_id_document_referencedDatasources</name>
+            <name>action_set_id_document_eoscServices</name>
             <value>$UNDEFINED$</value>
-            <description>document_referencedDatasources action-set identifier of exported data</description>
+            <description>document_eoscServices action-set identifier of exported data</description>
         </property>
         <property>
             <name>action_set_id_document_research_initiative</name>
@@ -190,9 +190,9 @@
             <description>document_referencedDatasets trust level threshold</description>
         </property>
         <property>
-            <name>trust_level_threshold_document_referencedDatasources</name>
+            <name>trust_level_threshold_document_eoscServices</name>
             <value>$UNDEFINED$</value>
-            <description>document_referencedDatasources trust level threshold</description>
+            <description>document_eoscServices trust level threshold</description>
         </property>
         <property>
             <name>trust_level_threshold_document_pdb</name>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -263,9 +263,9 @@
             <description>document_referencedDocuments action-set identifier of exported data</description>
         </property>
         <property>
-            <name>export_action_set_id_document_referencedDatasources</name>
+            <name>export_action_set_id_document_eoscServices</name>
             <value>$UNDEFINED$</value>
-            <description>document_referencedDatasources action-set identifier of exported data</description>
+            <description>document_eoscServices action-set identifier of exported data</description>
         </property>
         <property>
             <name>export_action_set_id_document_research_initiative</name>
@@ -355,9 +355,9 @@
             <description>document_referencedDocuments trust level threshold</description>
         </property>
         <property>
-            <name>export_trust_level_threshold_document_referencedDatasources</name>
+            <name>export_trust_level_threshold_document_eoscServices</name>
             <value>$UNDEFINED$</value>
-            <description>document_referencedDatasources trust level threshold</description>
+            <description>document_eoscServices trust level threshold</description>
         </property>
         <!-- -->
         <property>
@@ -908,8 +908,8 @@
                     <value>${export_action_set_id_document_referencedDocuments}</value>
                 </property>
                 <property>
-                    <name>action_set_id_document_referencedDatasources</name>
-                    <value>${export_action_set_id_document_referencedDatasources}</value>
+                    <name>action_set_id_document_eoscServices</name>
+                    <value>${export_action_set_id_document_eoscServices}</value>
                 </property>
                 <property>
                     <name>action_set_id_document_research_initiative</name>
@@ -985,8 +985,8 @@
                     <value>${export_trust_level_threshold_document_referencedDocuments}</value>
                 </property>
                 <property>
-                    <name>trust_level_threshold_document_referencedDatasources</name>
-                    <value>${export_trust_level_threshold_document_referencedDatasources}</value>
+                    <name>trust_level_threshold_document_eoscServices</name>
+                    <value>${export_trust_level_threshold_document_eoscServices}</value>
                 </property>
                 <property>
                     <name>documentssimilarity_threshold</name>


### PR DESCRIPTION
Renaming the following fields/parameters:
* setting `relClass` field value to `IsRelatedTo` instead of `References`/`IsReferencedBy`
* setting `relType` field value to `resultService` instead of `resultDatasource`
* setting `inferenceprovenance` field value to `iis::document_eoscServices` instead of `iis::document_referencedDatasources`
* renaming `AlgorithnName#document_referencedDatasources` to `AlgorithnName#document_eoscServices`
* renaming `export_action_set_id_document_referencedDatasources` input parameter to `export_action_set_id_document_eoscServices`