### PR TITLE
Closes #1410: Introduce missing integration test cases for funders still not covered with tests

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/document_text.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/document_text.json
@@ -50,3 +50,9 @@
 {"text":"This work was partly supported by the Research Council of Norway through its Centers of Excellence funding scheme, project number 262644.", "id":"50|arXiv_______::006603fe0b5e0abfdc7fdc9b94c5ef16"}
 {"text":"Funding: European Research Council ERC Advanced Grant 101055088 (SP)", "id":"50|arXiv_______::4b95a6191ba40d97e7401edc1b5d44d0"}
 {"text":"To distinguish pattern-avoiding permutations from their consecutive counterpart, the former are sometimes referred to as classical pattern-avoiding permutations (PAPs).Supported by Australian Research Council grant DE170100186. ISSN 1365-8050", "id":"50|06cdd3ff4700::2ecc0ab7fe7b585190081d3623d34a30"}
+{"text":"This work was also supported by a project of the Portuguese Foundation for Science and Technology (PTDC/BIA-BEC/103158/2008).", "id":"50|pmid________::015e7e84b4dc77186dffa284f08b1ffe"}
+{"text":"Acknowledgment. The authors gratefully acknowledge financial support of this research by the Croatian Science Foundation (under the project number IP-1021).", "id":"50|57a035e5b1ae::28ca7507422e8791c7b034c316a126e1"}
+{"text":"The current study was supported by grants from: the Ministry of Agriculture (VIP/2012) and the Ministry of Science, Education and Sport of Croatia (053-0532265-2255).", "id":"50|od_______951::fe56c794571ea13ce3e9c93d56d90db3"}
+{"text":"Funding sources/sponsors: JL is funded by a National Health and Medical Research Council of Australia Partnership Project Grant (1056888).", "id":"50|sharebioRxiv::20773c458e7814d5b47c6c498b775d2b"}
+{"text":"This material is based upon work supported by the National Science Foundation under Grant No. ATM-0513463.", "id":"50|od_______212::0f31511cdbd148bf5446b52f49ba8544"}
+{"text":"Acknowledgements This work was partially supported by Science Foundation Ireland Grant 04/IN1/I478 and Science Foundation Ireland Grant 03/RPT1/I382.", "id":"50|doi_________::9c4ddd5d830294ab76d7e7919a379f3b"}

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/document_to_project.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/document_to_project.json
@@ -386,7 +386,7 @@
   "documentId": "50|core_ac_uk__::2fea53c390909c2640b2d1a94d53c0a7",
   "projectId": "40|inca________::1e5e62235d094afd01cd56e65112fc63",
   "confidenceLevel": 0.8,
-  "textsnippet": "This work was supported by INCA (plbio 2010-216 and INCa-DGOS-Inserm 6046)"
+  "textsnippet": "This work was supported by INCA (plbio 2010-216 and INCa-DGOS-Inserm 6046) "
 }
 {
   "documentId": "50|arXiv_______::a343cdcd534d696dd93c7ee9d78b9be7",
@@ -413,4 +413,39 @@
   "confidenceLevel": 0.8,
   "textsnippet": "former are sometimes referred to as classical pattern-avoiding permutations (PAPs).Supported by Australian Research Council grant <<< DE170100186. >>> ISSN 1365-8050"
 }
-
+{
+  "documentId": "50|pmid________::015e7e84b4dc77186dffa284f08b1ffe",
+  "projectId": "40|fct_________::48d8d7bb785bebf253ff9d73939ce865",
+  "confidenceLevel": 0.8,
+  "textsnippet": "work was also supported by a project of the Portuguese Foundation for Science and Technology <<< (PTDC/BIA-BEC/103158/2008). >>> "
+}
+{
+  "documentId": "50|57a035e5b1ae::28ca7507422e8791c7b034c316a126e1",
+  "projectId": "40|irb_hr______::37ca9ece55928656726557c7c0a36a1a",
+  "confidenceLevel": 0.8,
+  "textsnippet": "acknowledge financial support of this research by the Croatian Science Foundation (under the project number <<< IP-1021). >>> "
+}
+{
+  "documentId": "50|od_______951::fe56c794571ea13ce3e9c93d56d90db3",
+  "projectId": "40|irb_hr______::0a480b267a9c5f652a8cc607bda9fe1c",
+  "confidenceLevel": 0.8,
+  "textsnippet": "the Ministry of Agriculture (VIP/2012) and the Ministry of Science, Education and Sport of Croatia <<< (053-0532265-2255). >>> "
+}
+{
+  "documentId": "50|sharebioRxiv::20773c458e7814d5b47c6c498b775d2b",
+  "projectId": "40|nhmrc_______::019492919738381cbee98a17ae1dae25",
+  "confidenceLevel": 0.8,
+  "textsnippet": "is funded by a National Health and Medical Research Council of Australia Partnership Project Grant <<< (1056888). >>> "
+}
+{
+  "documentId": "50|od_______212::0f31511cdbd148bf5446b52f49ba8544",
+  "projectId": "40|nsf_________::0077daebf2041633be32e5915998fbf4",
+  "confidenceLevel": 0.99666107,
+  "textsnippet": "      material based upon work supported national science foundation grant <<< atm_0513463 >>>   "
+}
+{
+  "documentId": "50|doi_________::9c4ddd5d830294ab76d7e7919a379f3b",
+  "projectId": "40|sfi_________::05395fd69f5aa3ba5e9e75dcf527d8ac",
+  "confidenceLevel": 0.8,
+  "textsnippet": "Acknowledgements This work was partially supported by Science Foundation Ireland Grant <<< 04/IN1/I478 >>> and Science Foundation Ireland Grant"
+}

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/project.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/project.json
@@ -66,3 +66,9 @@
 {"id": "40|rcn_________::41236853b37a589c0c0c6ca9d178236a", "projectGrantId": "262644", "projectAcronym": null, "fundingClass": "RCN::SFF", "jsonextrainfo": "{}"}
 {"id": "40|corda_____he::ea43b41b48b3e7358e9da49bc3ba4ca6", "projectGrantId": "101055088", "projectAcronym": "CorMeTop", "fundingClass": "EC::HE", "jsonextrainfo": "{}"}
 {"id": "40|arc_________::820103bb21728d624a1836e5134e5712", "projectGrantId": "DE170100186", "projectAcronym": "CorMeTop", "fundingClass": "ARC::Discovery Early Career Researcher Award", "jsonextrainfo": "{}"}
+{"id": "40|nsf_________::0077daebf2041633be32e5915998fbf4", "projectGrantId": "0513463", "projectAcronym": null, "fundingClass": "NSF::Directorate for Geosciences", "jsonextrainfo": "{}"}
+{"id": "40|sfi_________::05395fd69f5aa3ba5e9e75dcf527d8ac", "projectGrantId": "04/IN1/I478", "projectAcronym": null, "fundingClass": "SFI::SFI Principal Investigator Programme", "jsonextrainfo": "{}"}
+{"id": "40|fct_________::48d8d7bb785bebf253ff9d73939ce865", "projectGrantId": "PTDC/BIA-BEC/103158/2008", "projectAcronym": "PTDC/BIA-BEC/103158/2008", "fundingClass": "FCT::5876-PPCDTI", "jsonextrainfo": "{}"}
+{"id": "40|irb_hr______::0a480b267a9c5f652a8cc607bda9fe1c", "projectGrantId": "053-0532265-2255", "projectAcronym": null, "fundingClass": "MZOS::", "jsonextrainfo": "{}"}
+{"id": "40|irb_hr______::37ca9ece55928656726557c7c0a36a1a", "projectGrantId": "IP-2013-11-1021", "projectAcronym": null, "fundingClass": "HRZZ::", "jsonextrainfo": "{}"}
+{"id": "40|nhmrc_______::019492919738381cbee98a17ae1dae25", "projectGrantId": "1056888", "projectAcronym": null, "fundingClass": "NHMRC::NHMRC Partnerships", "jsonextrainfo": "{}"}

--- a/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/report_funder.json
+++ b/iis-wf/iis-wf-referenceextraction/src/test/resources/eu/dnetlib/iis/wf/referenceextraction/project/data/report_funder.json
@@ -39,6 +39,11 @@
   "value": "23"
 }
 {
+  "key": "processing.referenceExtraction.project.references.byfunder.fct",
+  "type": "COUNTER",
+  "value": "1"
+}
+{
   "key": "processing.referenceExtraction.project.references.byfunder.fwf",
   "type": "COUNTER",
   "value": "1"
@@ -47,6 +52,16 @@
   "key": "processing.referenceExtraction.project.references.byfunder.gsri",
   "type": "COUNTER",
   "value": "2"
+}
+{
+  "key": "processing.referenceExtraction.project.references.byfunder.hrzz",
+  "type": "COUNTER",
+  "value": "1"
+}
+{
+  "key": "processing.referenceExtraction.project.references.byfunder.nhmrc",
+  "type": "COUNTER",
+  "value": "1"
 }
 {
   "key": "processing.referenceExtraction.project.references.byfunder.inca",
@@ -69,6 +84,11 @@
   "value": "1"
 }
 {
+  "key": "processing.referenceExtraction.project.references.byfunder.mzos",
+  "type": "COUNTER",
+  "value": "1"
+}
+{
   "key": "processing.referenceExtraction.project.references.byfunder.nih",
   "type": "COUNTER",
   "value": "1"
@@ -80,6 +100,11 @@
 }
 {
   "key": "processing.referenceExtraction.project.references.byfunder.nserc",
+  "type": "COUNTER",
+  "value": "1"
+}
+{
+  "key": "processing.referenceExtraction.project.references.byfunder.nsf",
   "type": "COUNTER",
   "value": "1"
 }
@@ -100,6 +125,11 @@
 }
 {
   "key": "processing.referenceExtraction.project.references.byfunder.rsf",
+  "type": "COUNTER",
+  "value": "1"
+}
+{
+  "key": "processing.referenceExtraction.project.references.byfunder.sfi",
   "type": "COUNTER",
   "value": "1"
 }
@@ -141,5 +171,5 @@
 {
    "key": "processing.referenceExtraction.project.references.total",
    "type": "COUNTER",
-   "value": "69"
+   "value": "75"
 }


### PR DESCRIPTION
The projects mining integration tests suite was supplemented with the following 6 missing funder cases: FCT, HRZZ, MZOS, NHMRC, NSF, SFI.