### PR TITLE
Closes #1412: Prevent metadata extraction phase from failing when dealing with an encrypted PDF file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,13 @@
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>1.50</version>
             </dependency>
+            
+            <!-- #1412 fix, required when dealing with encrypted PDF files -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>1.50</version>
+            </dependency>
 
             <!-- Needed to run Avro-based map-reduce -->
             <dependency>


### PR DESCRIPTION
Introducing `bcpkix-jdk15on` dependency.