### PR TITLE
Closes #1415: Remove avro.schema.input.key redundant properties from map-reduce actions

### DIFF
--- a/iis-common/src/main/resources/eu/dnetlib/iis/common/protobuf/converter/avro_to_protobuf/oozie_app/workflow.xml
+++ b/iis-common/src/main/resources/eu/dnetlib/iis/common/protobuf/converter/avro_to_protobuf/oozie_app/workflow.xml
@@ -14,10 +14,6 @@
             <name>param_converter_class</name>
             <description>a class implementing AvroToProtoBufConverter</description>
         </property>
-        <property>
-            <name>param_avro_input_class</name>
-            <description>Avro input class</description>
-        </property>
 	</parameters>
     
     <global>
@@ -36,17 +32,7 @@
     </global>
     
     
-    <start to="generate-schema" />
-
-	<action name="generate-schema">
-	    <java>
-	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-	        <arg>${param_avro_input_class}</arg>
-	        <capture-output />
-	    </java>
-	    <ok to="converter" />
-	    <error to="fail" />
-	</action>
+    <start to="converter" />
 
     <action name="converter">
         <map-reduce>
@@ -115,12 +101,6 @@
                 <property>
                     <name>converter_class</name>
                     <value>${param_converter_class}</value>
-                </property>
-
-                <!-- ## Schemas -->
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')[wf:conf('param_avro_input_class')]}</value>
                 </property>
 
                 <!-- ## Specification of the input and output data store -->

--- a/iis-wf/iis-wf-collapsers/src/main/resources/eu/dnetlib/iis/wf/collapsers/basic_collapser/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-collapsers/src/main/resources/eu/dnetlib/iis/wf/collapsers/basic_collapser/oozie_app/workflow.xml
@@ -139,12 +139,6 @@
 
 				<!-- ## Schemas -->
 
-				<!-- ### Schema of the data ingested by the mapper. To be more precise, it's the schema of Avro data passed as template parameter of the AvroKey object passed to mapper -->
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')[wf:conf('schema')]}</value>
-				</property>
-
 				<!-- ### Schemas of the data produced by the mapper -->
 
 				<!-- #### Schema of the key produced by the mapper. To be more precise, it's the schema of Avro data produced by the mapper and passed forward as template parameter of AvroKey object. -->

--- a/iis-wf/iis-wf-collapsers/src/main/resources/eu/dnetlib/iis/wf/collapsers/citation/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-collapsers/src/main/resources/eu/dnetlib/iis/wf/collapsers/citation/oozie_app/workflow.xml
@@ -128,12 +128,6 @@
 
                 <!-- ## Schemas -->
 
-                <!-- ### Schema of the data ingested by the mapper. To be more precise, it's the schema of Avro data passed as template parameter of the AvroKey object passed to mapper -->
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.common.citations.schemas.Citation']}</value>
-                </property>
-
                 <!-- ### Schemas of the data produced by the mapper -->
 
                 <!-- #### Schema of the key produced by the mapper. To be more precise, it's the schema of Avro data produced by the mapper and passed forward as template parameter of AvroKey object. -->

--- a/iis-wf/iis-wf-documentssimilarity/src/main/resources/eu/dnetlib/iis/wf/documentssimilarity/chain/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-documentssimilarity/src/main/resources/eu/dnetlib/iis/wf/documentssimilarity/chain/oozie_app/workflow.xml
@@ -106,10 +106,6 @@
                     <name>param_converter_class</name>
                     <value>eu.dnetlib.iis.wf.documentssimilarity.converter.DocumentMetadataAvroToProtoBufConverter</value>
                 </property>
-                <property>
-                    <name>param_avro_input_class</name>
-                    <value>eu.dnetlib.iis.documentssimilarity.schemas.DocumentMetadata</value>
-                </property>
 			</configuration>
         </sub-workflow>
         <ok to="coansys" />

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -281,27 +281,7 @@
         </configuration>
     </global>
 
-    <start to="generate-schema" />
-
-    <!-- watch out for oozie.action.max.output.data limit set in oozie-site.xml it cannot be exceeded when capturing output of schemas generated as properties. When exceeded: either limit can be raised 
-        or multiple schema generating actions defined. -->
-    <action name="generate-schema">
-        <java>
-            <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator
-            </main-class>
-            <arg>eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject</arg>
-            <arg>eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet</arg>
-            <arg>eu.dnetlib.iis.referenceextraction.service.schemas.DocumentToService</arg>
-            <arg>eu.dnetlib.iis.export.schemas.DocumentToConceptIds</arg>
-            <arg>eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses</arg>
-            <arg>eu.dnetlib.iis.export.schemas.Citations</arg>
-            <arg>eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity</arg>
-            <arg>eu.dnetlib.iis.wf.affmatching.model.MatchedOrganizationWithProvenance</arg>
-            <capture-output />
-        </java>
-        <ok to="prepare" />
-        <error to="fail" />
-    </action>
+    <start to="prepare" />
 
     <action name="prepare">
         <fs>
@@ -423,10 +403,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToProjectActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_document_to_project}</value>
                 </property>
@@ -456,10 +432,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToDataSetActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_document_to_dataset}</value>
                 </property>
@@ -487,10 +459,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToServiceActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.referenceextraction.service.schemas.DocumentToService']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -523,10 +491,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToProjectConceptsActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_document_to_project_concepts}</value>
                 </property>
@@ -549,10 +513,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToConceptIdsActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -579,10 +539,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToCommunityActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_document_to_community}</value>
                 </property>
@@ -605,10 +561,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToPdbActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -639,10 +591,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToCovid19ActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.DocumentToConceptIds']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_document_to_covid19}</value>
                 </property>
@@ -665,10 +613,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentToDocumentClassesActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentsclassification.schemas.DocumentToDocumentClasses']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -700,10 +644,6 @@
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.CitationsActionBuilderModuleFactory</value>
                 </property>
                 <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.export.schemas.Citations']}</value>
-                </property>
-                <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
                     <value>${input_citations}</value>
                 </property>
@@ -726,10 +666,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.DocumentSimilarityActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>
@@ -758,10 +694,6 @@
                 <property>
                     <name>export.action.builder.factory.classname</name>
                     <value>eu.dnetlib.iis.wf.export.actionmanager.module.MatchedOrganizationActionBuilderModuleFactory</value>
-                </property>
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.wf.affmatching.model.MatchedOrganizationWithProvenance']}</value>
                 </property>
                 <property>
                     <name>mapreduce.input.fileinputformat.inputdir</name>

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content/oozie_app/workflow.xml
@@ -73,7 +73,6 @@
 	<action name="generate-schema">
 	    <java>
 	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-	        <arg>eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl</arg>
 	        <arg>eu.dnetlib.iis.importer.schemas.DocumentContent</arg>
 	        <arg>org.apache.avro.Schema.Type.NULL</arg>
 	        <capture-output />
@@ -160,11 +159,6 @@
                     <name>mapreduce.input.fileinputformat.split.maxsize</name>
                     <value>${mapred_max_split_size}</value>
                 </property>
-
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl']}</value>
-				</property>
 
 				<property>
                     <name>avro.serialization.key.reader.schema</name>

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/chain/oozie_app/workflow.xml
@@ -447,10 +447,6 @@
 					<value>eu.dnetlib.iis.wf.importer.content.DocumentContentUrlDispatcher</value>
 				</property>
 				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl']}</value>
-				</property>
-				<property>
 					<name>mapreduce.input.fileinputformat.inputdir</name>
 					<value>${workingDir}/document_content_url_deduped/output</value>
 				</property>

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/core/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/content_url/core/oozie_app/workflow.xml
@@ -72,7 +72,6 @@
 	<action name="generate-schema">
 	    <java>
 	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-            <arg>eu.dnetlib.iis.common.schemas.Identifier</arg>
 	        <arg>eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl</arg>
 	        <arg>org.apache.avro.Schema.Type.NULL</arg>
 	        <arg>org.apache.avro.Schema.Type.STRING</arg>
@@ -170,11 +169,6 @@
                 </property>
             
                 <!-- Standard stuff for our framework -->
-
-                <property>
-                    <name>avro.schema.input.key</name>
-                    <value>${wf:actionData('generate-schema')['eu.dnetlib.iis.common.schemas.Identifier']}</value>
-                </property>
 
                 <property>
                     <name>avro.serialization.key.reader.schema</name>

--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/plaintext/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/plaintext/oozie_app/workflow.xml
@@ -78,7 +78,6 @@
 	<action name="generate-schema">
 		<java>
 			<main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-			<arg>eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl</arg>
 			<arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
 			<arg>org.apache.avro.Schema.Type.NULL</arg>
 			<capture-output />
@@ -160,11 +159,6 @@
 				</property>
 
 				<!-- Standard stuff for our framework -->
-
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl']}</value>
-				</property>
 
 				<property>
 					<name>avro.serialization.key.reader.schema</name>

--- a/iis-wf/iis-wf-ingest-pmc/src/main/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/oozie_app/workflow.xml
@@ -60,7 +60,6 @@
 	<action name="generate-schema">
 		<java>
 			<main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-			<arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
 			<arg>eu.dnetlib.iis.ingest.pmc.metadata.schemas.ExtractedDocumentMetadata</arg>
 			<arg>eu.dnetlib.iis.audit.schemas.Fault</arg>
 			<capture-output />
@@ -125,10 +124,6 @@
 				</property>
 
 				<!-- Standard stuff for our framework -->
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.metadataextraction.schemas.DocumentText']}</value>
-				</property>
 				<property>
 					<name>avro.mapreduce.multipleoutputs</name>
 					<value>${output_name_meta} ${output_name_fault}</value>

--- a/iis-wf/iis-wf-ingest/src/main/resources/eu/dnetlib/iis/wf/ingest/html/plaintext/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-ingest/src/main/resources/eu/dnetlib/iis/wf/ingest/html/plaintext/oozie_app/workflow.xml
@@ -105,11 +105,6 @@
                 </property>
             
                 <!-- Standard stuff for our framework -->
-
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.metadataextraction.schemas.DocumentText']}</value>
-				</property>
 				
                 <property>
                     <name>avro.serialization.key.reader.schema</name>

--- a/iis-wf/iis-wf-ingest/src/main/resources/eu/dnetlib/iis/wf/ingest/webcrawl/fundings/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-ingest/src/main/resources/eu/dnetlib/iis/wf/ingest/webcrawl/fundings/oozie_app/workflow.xml
@@ -105,11 +105,6 @@
                 </property>
             
                 <!-- Standard stuff for our framework -->
-
-                <property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.metadataextraction.schemas.DocumentText']}</value>
-				</property>
 				
                 <property>
                     <name>avro.serialization.key.reader.schema</name>

--- a/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/core/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/core/oozie_app/workflow.xml
@@ -81,7 +81,6 @@
 	<action name="generate-schema">
 	    <java>
 	        <main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-	        <arg>eu.dnetlib.iis.importer.schemas.DocumentContent</arg>
 	        <arg>eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata</arg>
 	        <arg>eu.dnetlib.iis.audit.schemas.Fault</arg>
 	        <capture-output />
@@ -154,11 +153,6 @@
                 </property>
             
                 <!-- Standard stuff for our framework -->
-			    <property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.importer.schemas.DocumentContent']}</value>
-				</property>
-                
                 <property>
 					<name>avro.mapreduce.multipleoutputs</name>
 					<value>${output_name_meta} ${output_name_fault}</value>

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -16,7 +16,6 @@
 	<action name="generate-schema">
 		<java>
 			<main-class>eu.dnetlib.iis.common.javamapreduce.hack.AvroSchemaGenerator</main-class>
-			<arg>eu.dnetlib.iis.common.schemas.DocumentContentClasspath</arg>
 			<arg>eu.dnetlib.iis.metadataextraction.schemas.DocumentText</arg>
 			<arg>org.apache.avro.Schema.Type.NULL</arg>
 			<capture-output />
@@ -190,10 +189,6 @@
 					<value>eu.dnetlib.iis.common.utils.DocumentClasspathToTextConverter</value>
 				</property>
 
-				<property>
-					<name>avro.schema.input.key</name>
-					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.common.schemas.DocumentContentClasspath']}</value>
-				</property>
 				<property>
 					<name>avro.serialization.key.reader.schema</name>
 					<value>${wf:actionData('generate-schema')['eu.dnetlib.iis.metadataextraction.schemas.DocumentText']}</value>


### PR DESCRIPTION
Removing all `avro.schema.input.key` references in all workflows where it was defined. 

Dropping `generate-schema` action whenever the class defined as a value of removed `avro.schema.input.key` property was the only one covered with schema generation action.

For almost all of the cases integration tests proved the introduced changes did not affect the job in any way. The only case not covered with test was checked by the manual run of the documents similarity workflow (which involved `avro_to_protobuf` conversion).

I have created another task #1417 on creating missing integration test for `avro_to_protobuf` which due to some strange reason was not covered with integration test yet.