### PR TITLE
Closes #1417: Introduce missing integration test for avro to protobuf workflow

### DIFF
--- a/iis-wf/iis-wf-documentssimilarity/pom.xml
+++ b/iis-wf/iis-wf-documentssimilarity/pom.xml
@@ -51,6 +51,18 @@
             <classifier>hadoop2</classifier>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.11</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- It seems that this dependency is needed, if it is not here,
         running Oozie tests of Avro-based map-reduce ends up with
         "java.lang.NoClassDefFoundError" exception and statement that
@@ -86,5 +98,48 @@
             <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-protobuf-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocVersion>2.5.0</protocVersion>
+                            <inputDirectories>
+                                <include>src/test/protobuf</include>
+                            </inputDirectories>
+                            <outputDirectory>${project.build.directory}/generated-test-sources/proto/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-protobuf-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-test-sources/proto/</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+		</plugins>
+    </build>
 
 </project>

--- a/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/AvroToProtobufWorkflowTest.java
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/AvroToProtobufWorkflowTest.java
@@ -1,0 +1,16 @@
+package eu.dnetlib.iis.wf.documentssimilarity.converter;
+
+import eu.dnetlib.iis.common.AbstractOozieWorkflowTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author mhorst
+ */
+public class AvroToProtobufWorkflowTest extends AbstractOozieWorkflowTestCase {
+
+    @Test
+    public void testDefaultWorkflow() throws Exception {
+        testWorkflow("eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/sampletest");
+    }
+
+}

--- a/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/PersonAvroToProtoBufConverter.java
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/PersonAvroToProtoBufConverter.java
@@ -1,0 +1,27 @@
+package eu.dnetlib.iis.wf.documentssimilarity.converter;
+
+import eu.dnetlib.iis.common.avro.Person;
+import eu.dnetlib.iis.common.protobuf.AvroToProtoBufConverter;
+import eu.dnetlib.iis.documentssimilarity.protobuf.PersonProtos;
+
+/**
+ * Simple converter class to be used for testing avro to protocol buffer converter workflow.
+ * @author mhorst
+ *
+ */
+public class PersonAvroToProtoBufConverter implements AvroToProtoBufConverter<Person, PersonProtos.Person> {
+    @Override
+    public String convertIntoKey(Person datum) {
+        return datum.getId().toString();
+    }
+
+    @Override
+    public PersonProtos.Person convertIntoValue(Person datum) {
+    	PersonProtos.Person.Builder builder = PersonProtos.Person.newBuilder();
+    	builder.setId(datum.getId());
+    	builder.setName(datum.getName());
+    	builder.setAge(datum.getAge());
+        return builder.build();
+    }
+
+}

--- a/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/PersonProtoConsumer.java
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/java/eu/dnetlib/iis/wf/documentssimilarity/converter/PersonProtoConsumer.java
@@ -1,0 +1,84 @@
+package eu.dnetlib.iis.wf.documentssimilarity.converter;
+
+import java.io.IOException;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Preconditions;
+
+import eu.dnetlib.iis.common.spark.JavaSparkContextFactory;
+import eu.dnetlib.iis.documentssimilarity.protobuf.PersonProtos.Person;
+
+/**
+ * Person consumer expecting single person record at input with the field values defined as parameters.
+ * 
+ * @author mhorst
+ *
+ */
+public class PersonProtoConsumer {
+
+    //------------------------ LOGIC --------------------------
+    
+    public static void main(String[] args) throws IOException {
+        AvroToRdbTransformerJobParameters params = new AvroToRdbTransformerJobParameters();
+        JCommander jcommander = new JCommander(params);
+        jcommander.parse(args);
+        
+        final int id = params.personId;
+        final String name = params.personName;
+        final int age = params.personAge;
+        
+        try (JavaSparkContext sc = JavaSparkContextFactory.withConfAndKryo(new SparkConf())) {
+
+            JavaPairRDD<BytesWritable, BytesWritable> rdd = sc.sequenceFile(params.input, BytesWritable.class, BytesWritable.class);
+            JavaRDD<Person> protoRDD = rdd.values().map(bytesWritable -> {
+            	Person.Builder builder = Person.newBuilder();
+                try {
+                    builder.mergeFrom(bytesWritable.getBytes(), 0, bytesWritable.getLength());
+                    return builder.build();
+                } catch (Exception e) {
+                    throw new IOException("unable to read protocol buffer object from bytes", e);
+                }
+            
+            });
+
+            Preconditions.checkArgument(protoRDD.count() == 1, "unexpected number of person records: %d, expected 1", protoRDD.count());
+            checkPerson(protoRDD.first(), id, name, age);
+        }
+    }
+    
+    //------------------------ PRIVATE --------------------------
+
+    private static void checkPerson(Person person, int id, String name, int age) throws IOException{
+    	Preconditions.checkArgument(id == person.getId(), 
+    			String.format("person id does not match! expected: %d, got: %d", id, person.getId()));
+    	Preconditions.checkArgument(name.equals(person.getName()), 
+    			String.format("person name does not match! expected: %s, got: %s", name, person.getName()));
+    	Preconditions.checkArgument(age == person.getAge(), 
+    			String.format("person age does not match! expected: %d, got: %d", age, person.getAge()));
+    }
+    
+    @Parameters(separators = "=")
+    private static class AvroToRdbTransformerJobParameters {
+        
+        @Parameter(names = "-input", required = true)
+        private String input;
+        
+        @Parameter(names = "-personId", required = true)
+        private int personId;
+        
+        @Parameter(names = "-personName", required = true)
+        private String personName;
+        
+        @Parameter(names = "-personAge", required = true)
+        private int personAge;
+    }
+
+}

--- a/iis-wf/iis-wf-documentssimilarity/src/test/protobuf/eu/dnetlib/iis/documentssimilarity/protobuf/Person.proto
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/protobuf/eu/dnetlib/iis/documentssimilarity/protobuf/Person.proto
@@ -1,0 +1,9 @@
+option java_package = "eu.dnetlib.iis.documentssimilarity.protobuf";
+option java_outer_classname = "PersonProtos";
+
+
+message Person {
+  required int32 id = 1;
+  required string name = 2;
+  required int32 age = 3;
+}

--- a/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/data/person.json
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/data/person.json
@@ -1,0 +1,1 @@
+{"id":1,"name":"John Doe","age":30}

--- a/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/sampletest/oozie_app/import.txt
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/sampletest/oozie_app/import.txt
@@ -1,0 +1,2 @@
+## This is a classpath-based import file (this header is required)
+avro_to_protobuf classpath eu/dnetlib/iis/common/protobuf/converter/avro_to_protobuf/oozie_app

--- a/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/sampletest/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-documentssimilarity/src/test/resources/eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/sampletest/oozie_app/workflow.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="test-documentssimilarity_avro_to_protobuf_sampletest">
+
+	<parameters>
+        <property>
+            <name>sparkExecutorMemory</name>
+            <description>memory for individual executor</description>
+        </property>
+        <property>
+            <name>sparkExecutorCores</name>
+            <description>number of cores used by single executor</description>
+        </property>
+        <property>
+            <name>sparkDriverMemory</name>
+            <description>memory for driver process</description>
+        </property>
+        <property>
+            <name>oozieActionShareLibForSpark2</name>
+            <description>oozie action sharelib for spark 2.*</description>
+        </property>
+        <property>
+            <name>spark2ExtraListeners</name>
+            <value>com.cloudera.spark.lineage.NavigatorAppListener</value>
+            <description>spark 2.* extra listeners classname</description>
+        </property>
+        <property>
+            <name>spark2SqlQueryExecutionListeners</name>
+            <value>com.cloudera.spark.lineage.NavigatorQueryListener</value>
+            <description>spark 2.* sql query execution listeners classname</description>
+        </property>
+        <property>
+            <name>spark2YarnHistoryServerAddress</name>
+            <description>spark 2.* yarn history server address</description>
+        </property>
+        <property>
+            <name>spark2EventLogDir</name>
+            <description>spark 2.* event log dir location</description>
+        </property>
+	</parameters>
+
+    <global>
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <configuration>
+            <property>
+                <name>mapreduce.job.queuename</name>
+                <value>${queueName}</value>
+            </property>
+            <property>
+                <name>oozie.launcher.mapred.job.queue.name</name>
+                <value>${oozieLauncherQueueName}</value>
+            </property>
+            <property>
+                <name>oozie.action.sharelib.for.spark</name>
+                <value>${oozieActionShareLibForSpark2}</value>
+            </property>
+        </configuration>
+    </global>
+    
+    <start to="producer"/>
+
+    <action name="producer">
+        <java>
+			<prepare>
+				<delete path="${nameNode}${workingDir}/producer" />
+				<mkdir path="${nameNode}${workingDir}/producer" />
+			</prepare>
+			<main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+			<arg>eu.dnetlib.iis.common.java.jsonworkflownodes.Producer</arg>
+            <arg>-C{person,
+            eu.dnetlib.iis.common.avro.Person,
+            eu/dnetlib/iis/wf/documentssimilarity/avro_to_protobuf/data/person.json}</arg>
+            <arg>-Operson=${workingDir}/producer/person</arg>
+        </java>
+        <ok to="avro_to_protobuf"/>
+        <error to="fail"/>
+    </action>
+    
+    <action name="avro_to_protobuf">
+        <sub-workflow>
+            <app-path>${wf:appPath()}/avro_to_protobuf</app-path>
+            <propagate-configuration/>
+            <configuration>
+                <property>
+					<name>input</name>
+					<value>${workingDir}/producer/person</value>
+                </property>
+                <property>
+					<name>output</name>
+					<value>${workingDir}/avro_to_protobuf/out</value>
+                </property>
+                <property>
+                    <name>param_converter_class</name>
+                    <value>eu.dnetlib.iis.wf.documentssimilarity.converter.PersonAvroToProtoBufConverter</value>
+                </property>
+			</configuration>            
+        </sub-workflow>
+		<ok to="proto-consumer"/>
+        <error to="fail"/>
+    </action>
+    
+    <action name="proto-consumer">
+        <spark xmlns="uri:oozie:spark-action:0.2">
+            <master>yarn-cluster</master>
+            <mode>cluster</mode>
+            <name>person_proto_consumer</name>
+            <class>eu.dnetlib.iis.wf.documentssimilarity.converter.PersonProtoConsumer</class>
+            <jar>${oozieTopWfApplicationPath}/lib/iis-wf-documentssimilarity-${projectVersion}.jar</jar>
+            <spark-opts>
+                --executor-memory=${sparkExecutorMemory}
+                --executor-cores=${sparkExecutorCores}
+                --driver-memory=${sparkDriverMemory}
+                --conf spark.extraListeners=${spark2ExtraListeners}
+                --conf spark.sql.queryExecutionListeners=${spark2SqlQueryExecutionListeners}
+                --conf spark.yarn.historyServer.address=${spark2YarnHistoryServerAddress}
+                --conf spark.eventLog.dir=${nameNode}${spark2EventLogDir}
+            </spark-opts>
+            <arg>-input=${workingDir}/avro_to_protobuf/out</arg>
+            <arg>-personId=1</arg>
+            <arg>-personName=John Doe</arg>
+            <arg>-personAge=30</arg>
+        </spark>
+        
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+
+    <kill name="fail">
+		<message>Unfortunately, the workflow failed -- error message:
+			[${wf:errorMessage(wf:lastErrorNode())}]</message>
+    </kill>
+    <end name="end"/>
+    
+</workflow-app>

--- a/pom.xml
+++ b/pom.xml
@@ -832,6 +832,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>com.github.os72</groupId>
+                    <artifactId>protoc-jar-maven-plugin</artifactId>
+                    <version>3.11.4</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>1.12</version>


### PR DESCRIPTION
This PR introduces missing test verifying correctness of agro -> protobuf transformation workflow.

The major difficulty was to implement a testing consumer verifying whether produced protobuf outcome is built according to predefined expectations. Usually we rely on a simple java class (`Process` in the IIS nomenclature) but it turned out to be rather cumbersome to veriify protocol buffer record this way because a lot of new protobuf related code seemed to be required to be written in order to introduce protobuf-compatible `TestingConsumer`. So I decided to implement less generic, spark based but very simple `PersonProtoConsumer` which does the job.