### PR TITLE
Introduce two citation matching related fixes for issues discovered during the last provision round on BETA

### DIFF
--- a/iis-wf/iis-wf-citationmatching-direct/src/main/resources/eu/dnetlib/iis/wf/citationmatching/direct/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-citationmatching-direct/src/main/resources/eu/dnetlib/iis/wf/citationmatching/direct/oozie_app/workflow.xml
@@ -36,6 +36,10 @@
             <description>number of cores used by single executor</description>
         </property>
         <property>
+            <name>sparkExecutorOverhead</name>
+            <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
+        </property>
+        <property>
             <name>oozieActionShareLibForSpark2</name>
             <description>oozie action sharelib for spark 2.*</description>
         </property>
@@ -93,6 +97,7 @@
                 --executor-memory=${sparkExecutorMemory}
                 --executor-cores=${sparkExecutorCores}
                 --driver-memory=${sparkDriverMemory}
+                --conf spark.yarn.executor.memoryOverhead=${sparkExecutorOverhead}
                 --conf spark.extraListeners=${spark2ExtraListeners}
                 --conf spark.sql.queryExecutionListeners=${spark2SqlQueryExecutionListeners}
                 --conf spark.yarn.historyServer.address=${spark2YarnHistoryServerAddress}

--- a/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/input/CitationMatchingInputTransformerJob.java
+++ b/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/input/CitationMatchingInputTransformerJob.java
@@ -1,5 +1,6 @@
 package eu.dnetlib.iis.wf.citationmatching.input;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import org.apache.commons.lang3.StringUtils;
@@ -17,6 +18,7 @@ import com.google.common.collect.Sets;
 import eu.dnetlib.iis.citationmatching.schemas.DocumentMetadata;
 import eu.dnetlib.iis.common.WorkflowRuntimeParameters;
 import eu.dnetlib.iis.common.citations.schemas.Citation;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import eu.dnetlib.iis.transformers.metadatamerger.schemas.ExtractedDocumentMetadataMergedWithOriginal;
 import pl.edu.icm.sparkutils.avro.SparkAvroLoader;
 import pl.edu.icm.sparkutils.avro.SparkAvroSaver;
@@ -37,7 +39,7 @@ public class CitationMatchingInputTransformerJob {
     
     //------------------------ LOGIC --------------------------
     
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, IOException {
         
         CitationMatchingInputTransformerJobParameters params = new CitationMatchingInputTransformerJobParameters();
         JCommander jcommander = new JCommander(params);
@@ -48,6 +50,8 @@ public class CitationMatchingInputTransformerJob {
         conf.set("spark.kryo.registrator", "pl.edu.icm.sparkutils.avro.AvroCompatibleKryoRegistrator");
         
         try (JavaSparkContext sc = new JavaSparkContext(conf)) {
+        	
+        	HdfsUtils.remove(sc.hadoopConfiguration(), params.output);
             
             JavaRDD<ExtractedDocumentMetadataMergedWithOriginal> inputDocuments = avroLoader.loadJavaRDD(sc, params.inputMetadata, ExtractedDocumentMetadataMergedWithOriginal.class);
             

--- a/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/output/CitationMatchingOutputTransformerJob.java
+++ b/iis-wf/iis-wf-citationmatching/src/main/java/eu/dnetlib/iis/wf/citationmatching/output/CitationMatchingOutputTransformerJob.java
@@ -1,5 +1,7 @@
 package eu.dnetlib.iis.wf.citationmatching.output;
 
+import java.io.IOException;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -9,6 +11,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
 import eu.dnetlib.iis.citationmatching.schemas.Citation;
+import eu.dnetlib.iis.common.java.io.HdfsUtils;
 import pl.edu.icm.sparkutils.avro.SparkAvroLoader;
 import pl.edu.icm.sparkutils.avro.SparkAvroSaver;
 
@@ -30,7 +33,7 @@ public class CitationMatchingOutputTransformerJob {
     
     //------------------------ LOGIC --------------------------
     
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         
         CitationMatchingOutputTransformerJobParameters params = new CitationMatchingOutputTransformerJobParameters();
         JCommander jcommander = new JCommander(params);
@@ -41,6 +44,8 @@ public class CitationMatchingOutputTransformerJob {
         
         try (JavaSparkContext sc = new JavaSparkContext(conf)) {
             
+        	HdfsUtils.remove(sc.hadoopConfiguration(), params.output);
+        	
             JavaRDD<Citation> inputCitations = avroLoader.loadJavaRDD(sc, params.input, Citation.class);
             
             

--- a/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
@@ -115,6 +115,7 @@
                 --executor-memory=${sparkExecutorMemory}
                 --executor-cores=${sparkExecutorCores}
                 --driver-memory=${sparkDriverMemory}
+                --conf spark.yarn.executor.memoryOverhead=${sparkExecutorOverhead}
                 --conf spark.extraListeners=${spark1ExtraListeners}
                 --conf spark.sql.queryExecutionListeners=${spark1SqlQueryExecutionListeners}
                 --conf spark.yarn.historyServer.address=${spark1YarnHistoryServerAddress}

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -277,6 +277,11 @@
             <description>memory for individual executor</description>
         </property>
         <property>
+            <name>citationmatchingDirectSparkExecutorOverhead</name>
+            <value>2048</value>
+            <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
+        </property>
+        <property>
             <name>citationmatchingDirectSparkExecutorCores</name>
             <value>${sparkExecutorCores}</value>
             <description>number of cores used by single executor</description>
@@ -1656,6 +1661,10 @@
                 <property>
                     <name>sparkExecutorMemory</name>
                     <value>${citationmatchingDirectSparkExecutorMemory}</value>
+                </property>
+                <property>
+                    <name>sparkExecutorOverhead</name>
+                    <value>${citationmatchingDirectSparkExecutorOverhead}</value>
                 </property>
                 <property>
                     <name>sparkExecutorCores</name>


### PR DESCRIPTION
Namely:
* #1427 extending executor memory overhead by declaring an explicit value (default value to be set in an env config file addressed [here](https://git.icm.edu.pl/openaire/iis-deployment/-/merge_requests/15))
* #1428 removing input directory in transformer modules (this is the default approach for all spark modules somehow omitted in fuzzy citation matching module what causes issues when rerunning citationmatching in isolation)

Usually I will create two separate PRs but those are pretty small fixes so we could cover them with a single PR (will be merged with the master branch with separate commits though).