### PR TITLE
Marekhorst 1464 fix the jats ingester module responsible for authors and affiliations parsing

### DIFF
--- a/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandler.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandler.java
@@ -2,16 +2,21 @@ package eu.dnetlib.iis.wf.ingest.pmc.metadata;
 
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_AFFILIATION_ID;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_AFFILIATION_XREF;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_CONTENT_TYPE;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_CONTRIBUTOR_TYPE;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_COUNTRY;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_VALUE_AUTHOR;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_XREF_ID;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ATTR_XREF_TYPE;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_ADDR_LINE;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_AFFILIATION;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_ARTICLE_ID;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_CONTRIBUTOR;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_CONTRIBUTOR_GROUP;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_COUNTRY;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_FPAGE;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_GIVEN_NAMES;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_INSTITUTION;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_LABEL;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_LPAGE;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.JatsXmlConstants.ELEM_NAME;
@@ -57,6 +62,12 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
      */
     private static final int MAX_AFF_LENGTH = 3000;
     
+    private static final String INSTITUTION_CONTENT_TYPE_ORG_DIVISION_ATTR_VALUE = "org-division";
+    private static final String INSTITUTION_CONTENT_TYPE_ORG_NAME_ATTR_VALUE = "org-name";
+    private static final String INSTITUTION_ADDR_LINE_CONTENT_TYPE_STREET_ATTR_VALUE = "street";
+    private static final String INSTITUTION_ADDR_LINE_CONTENT_TYPE_POSTCODE_ATTR_VALUE = "postcode";
+    private static final String INSTITUTION_ADDR_LINE_CONTENT_TYPE_CITY_ATTR_VALUE = "city";
+    
     private Stack<String> parents;
     
     private final ExtractedDocumentMetadata.Builder builder;
@@ -69,7 +80,9 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
     private String currentArticleIdType;
     
     private final StringBuilder affiliationText = new StringBuilder();
+    private final JatsExtendedAffiliation currentExtendedAffiliation = new JatsExtendedAffiliation();
     private String currentAffiliationId;
+    private String currentAffFieldContentType;
     
     private final StringBuilder authorText = new StringBuilder();
     private JatsAuthor currentAuthor;
@@ -101,6 +114,11 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
         
         if (isElement(qName, ELEM_AFFILIATION)) {
             currentAffiliationId = attributes.getValue(ATTR_AFFILIATION_ID);
+        } else if (hasAmongParents(qName, ELEM_INSTITUTION, parents, ELEM_AFFILIATION) ||
+                isWithinElement(qName, ELEM_ADDR_LINE, parents, ELEM_AFFILIATION)) {
+            currentAffFieldContentType = attributes.getValue(ATTR_CONTENT_TYPE);
+        } else if (isWithinElement(qName, ELEM_COUNTRY, parents, ELEM_AFFILIATION)) {
+            currentExtendedAffiliation.setCountryCode(attributes.getValue(ATTR_COUNTRY));
         } else if (isElement(qName, ELEM_ARTICLE_ID)) {
             currentArticleIdType = attributes.getValue(PUB_ID_TYPE);
         } else if (isElement(qName, ELEM_CONTRIBUTOR)) {
@@ -116,7 +134,6 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
             }
         }
         
-        
         this.parents.push(qName);
     }
     
@@ -126,9 +143,33 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
         this.currentValue = new String(ch, start, length);
         
         if (hasAmongParents(parents, ELEM_AFFILIATION)) {
-            
+            // if one of the elements: ELEM_INSTITUTION, ELEM_ADDR_LINE, ELEM_COUNTRY was defined then processing extended affiliation coming from Springer
+            // otherwise processing raw affiliation text coming from PubMed or any other provider
+            if (hasAmongParents(parents, ELEM_INSTITUTION)) {
+                if (INSTITUTION_CONTENT_TYPE_ORG_DIVISION_ATTR_VALUE.equals(currentAffFieldContentType)) {
+                    this.currentExtendedAffiliation.appendToInstitutionOrgDivision(currentValue);
+                } else if (INSTITUTION_CONTENT_TYPE_ORG_NAME_ATTR_VALUE.equals(currentAffFieldContentType)) {
+                    this.currentExtendedAffiliation.appendToInstitutionOrgName(currentValue);
+                } else {
+                    // adding as an orgName if unknown/unspecified content type
+                    this.currentExtendedAffiliation.appendToInstitutionOrgName(currentValue);
+                }
+            } else if (hasAmongParents(parents, ELEM_ADDR_LINE)) {
+                if (INSTITUTION_ADDR_LINE_CONTENT_TYPE_STREET_ATTR_VALUE.equals(currentAffFieldContentType)) {
+                    this.currentExtendedAffiliation.appendToAddrLineStreet(currentValue);
+                } else if (INSTITUTION_ADDR_LINE_CONTENT_TYPE_POSTCODE_ATTR_VALUE.equals(currentAffFieldContentType)) {
+                    this.currentExtendedAffiliation.appendToAddrLinePostCode(currentValue);
+                }  else if (INSTITUTION_ADDR_LINE_CONTENT_TYPE_CITY_ATTR_VALUE.equals(currentAffFieldContentType)) {
+                    this.currentExtendedAffiliation.appendToAddrLineCity(currentValue);
+                } else {
+                 // adding as a city if unknown/unspecified content type
+                    this.currentExtendedAffiliation.appendToAddrLineCity(currentValue);
+                }
+            } else if (hasAmongParents(parents, ELEM_COUNTRY)) {
+                this.currentExtendedAffiliation.appendToCountryName(currentValue);
+            } else if (!hasAmongParents(parents, ELEM_LABEL) && !hasAmongParents(parents, ELEM_SUP)) {
+            // processing affiliation string as defined in PubMed (simple aff text, no structured elements
             // skipping affiliation position element
-            if (!hasAmongParents(parents, ELEM_LABEL) && !hasAmongParents(parents, ELEM_SUP)) {
                 this.affiliationText.append(currentValue);
             }
             
@@ -201,7 +242,10 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
     
     private void handleAffiliation() throws SAXException {
         
-        Affiliation currentAffiliation = buildAffiliation();
+        Affiliation currentAffiliation = currentExtendedAffiliation.getNumberOfFieldsSet() > 0
+                ? buildAffiliation(currentExtendedAffiliation)
+                : buildAffiliationFromText(affiliationText.toString());
+
         if (currentAffiliation != null) {
             int currentAffiliationPosition = builder.getAffiliations().size();
             builder.getAffiliations().add(currentAffiliation);
@@ -209,15 +253,59 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
         }
         
         affiliationText.setLength(0);
+        currentExtendedAffiliation.clear();
+        currentAffFieldContentType = null;
     }
     
-    private Affiliation buildAffiliation() throws SAXException {
+    private Affiliation buildAffiliation(JatsExtendedAffiliation extendedAffiliation) throws SAXException {
+        if (StringUtils.isNotBlank(extendedAffiliation.getInstitutionOrgName())) {
+            if (shouldBePostprocessed(extendedAffiliation)) {
+                //  getting through CERMINE parsing with the raw text to improve the coverage of recognized affiliation fields
+                return buildAffiliationFromText(extendedAffiliation.generateRawText());
+            } else {
+                Affiliation.Builder affBuilder = Affiliation.newBuilder();
+                String fullOrgName = extendedAffiliation.generateFullOrganizationName();
+                if (StringUtils.isNotBlank(fullOrgName)) {
+                    affBuilder.setOrganization(fullOrgName);
+                }
+                String fullAddress = extendedAffiliation.generateFullAddress();
+                if (StringUtils.isNotBlank(fullAddress)) {
+                    affBuilder.setAddress(fullAddress);
+                }
+                String countryCode = extendedAffiliation.getCountryCode();
+                if (StringUtils.isNotBlank(countryCode)) {
+                    affBuilder.setCountryCode(countryCode);
+                }
+                String countryName = extendedAffiliation.getCountryName();
+                if (StringUtils.isNotBlank(countryName)) {
+                    affBuilder.setCountryName(countryName);
+                }
+                String rawText = extendedAffiliation.generateRawText();
+                if (StringUtils.isNotBlank(rawText)) {
+                    affBuilder.setRawText(rawText);
+                }
+                return affBuilder.build();
+            }
+            
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+     * Checks if given affiliation should be supplemented with missing metadata. It is usually required when
+     * an affiliation was defined as organization name and address pair without any specifics regarding the country.
+     */
+    private static boolean shouldBePostprocessed(JatsExtendedAffiliation extendedAffiliation) {
+        return extendedAffiliation.getNumberOfFieldsSet() <= 2;
+    }
+
+    private Affiliation buildAffiliationFromText(String affiliationText) throws SAXException {
         
         try {
-            String affStr = this.affiliationText.toString();
-            if (StringUtils.isNotBlank(affStr) && affStr.length() <= MAX_AFF_LENGTH) {
+            if (StringUtils.isNotBlank(affiliationText) && affiliationText.length() <= MAX_AFF_LENGTH) {
                 CRFAffiliationParser affiliationParser = new CRFAffiliationParser();
-                Element parsedAffiliation = affiliationParser.parse(affStr);
+                Element parsedAffiliation = affiliationParser.parse(affiliationText);
                 if (parsedAffiliation!=null) {
                     CermineAffiliation cAff = cermineAffiliationBuilder.build(parsedAffiliation);
                     return cermineToIngestAffConverter.convert(cAff);

--- a/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandler.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandler.java
@@ -156,9 +156,13 @@ public class ArticleMetaXmlHandler extends DefaultHandler implements ProcessingF
                 } else {
                     // adding as an orgName if unknown/unspecified content type
                     // might need to add separator if wasInstitutionTagAlreadyClosedForAff and if separator is not already involved
-                    if (wasInstitutionTagAlreadyClosedForAff && isSeparatorNeeded(
-                            this.currentExtendedAffiliation.getInstitutionOrgName(), currentValue)) {
-                        this.currentExtendedAffiliation.appendToInstitutionOrgName(TOKEN_SEPARATOR);
+                    if (wasInstitutionTagAlreadyClosedForAff) {
+                        if (isSeparatorNeeded(this.currentExtendedAffiliation.getInstitutionOrgName(), currentValue)) {
+                            this.currentExtendedAffiliation.appendToInstitutionOrgName(TOKEN_SEPARATOR);
+                        }
+                        // need to unmark closed institution tag because of potentially long name
+                        // incoming in multiple subsequent characters() calls
+                        this.wasInstitutionTagAlreadyClosedForAff = false;
                     }
                     this.currentExtendedAffiliation.appendToInstitutionOrgName(currentValue);
                 }

--- a/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliation.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliation.java
@@ -138,7 +138,7 @@ public class JatsExtendedAffiliation {
         addrLinePostCode = new StringBuilder();
         addrLineCity = new StringBuilder();
         countryName = new StringBuilder();
-        countryCode = null;
+        countryCode = "";
     }
     
     //------------------------ GETTERS --------------------------

--- a/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliation.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliation.java
@@ -1,0 +1,217 @@
+package eu.dnetlib.iis.wf.ingest.pmc.metadata;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This is an extended affiliation conveying structured affiliation details instead of a single raw text line.
+ * It reflects the affiliations encoded in JATS records coming from Springer, in contrary to the ones coming from PubMed
+ * where an affiliation is a simple raw string which has to be parsed in order to obtain affiliation metadata. 
+ * 
+ * @author mhorst
+ */
+public class JatsExtendedAffiliation {
+    
+    private StringBuilder institutionOrgDivision;
+    
+    private StringBuilder institutionOrgName;
+    
+    private StringBuilder addrLineStreet;
+    
+    private StringBuilder addrLinePostCode;
+    
+    private StringBuilder addrLineCity;
+    
+    private StringBuilder countryName;
+    
+    private String countryCode;
+    
+    
+    //-----------------------CONSTRUCTOR-------------------------
+    
+    
+    public JatsExtendedAffiliation() {
+        initialize();
+    }
+    
+    //--------------------------PUBLIC --------------------------
+    
+    /**
+     * Checks the number of fields set.
+     */
+    public int getNumberOfFieldsSet() {
+        int count = 0;
+        if (institutionOrgDivision.length() > 0) count++;
+        if (institutionOrgName.length() > 0) count++;
+        if (addrLineStreet.length() > 0) count++;
+        if (addrLinePostCode.length() > 0) count++;
+        if (addrLineCity.length() > 0) count++;
+        if (countryName.length() > 0) count++;
+        if (StringUtils.isNotBlank(countryCode)) count++;
+        return count;
+    }
+    
+    /**
+     * Clears the values of all the affiliation fields.
+     */
+    public void clear() {
+        initialize();
+    }
+    
+    /**
+     * Generates raw text representation of the affiliation relying on the structured metadata.
+     */
+    public String generateRawText() {
+        StringBuilder strBuilder = new StringBuilder();
+        
+        strBuilder = generateFullOrganizationName(strBuilder);
+        strBuilder = generateFullAddress(strBuilder);
+        appendWithCheckAndLeadingComma(strBuilder, countryName);
+        
+        return strBuilder.toString();
+        
+    }
+    
+    public String generateFullOrganizationName() {
+        StringBuilder strBuilder = new StringBuilder();
+        appendWithCheckAndLeadingComma(strBuilder, institutionOrgDivision);
+        appendWithCheckAndLeadingComma(strBuilder, institutionOrgName);
+        return strBuilder.toString();
+    }
+    
+    public String generateFullAddress() {
+        StringBuilder strBuilder = new StringBuilder();
+        appendWithCheckAndLeadingComma(strBuilder, addrLineStreet);
+        appendWithCheckAndLeadingComma(strBuilder, addrLinePostCode);
+        if (StringUtils.isNotBlank(addrLinePostCode)) {
+            appendWithCheckAndLeadingSpace(strBuilder, addrLineCity);
+        } else {
+            appendWithCheckAndLeadingComma(strBuilder, addrLineCity);    
+        }
+        
+        return strBuilder.toString();
+    }
+    
+    //--------------------------PRIVATE --------------------------
+    
+    private StringBuilder generateFullOrganizationName(StringBuilder strBuilder) {
+        appendWithCheckAndLeadingComma(strBuilder, institutionOrgDivision);
+        appendWithCheckAndLeadingComma(strBuilder, institutionOrgName);
+        return strBuilder;
+    }
+    
+    private StringBuilder generateFullAddress(StringBuilder strBuilder) {
+        appendWithCheckAndLeadingComma(strBuilder, addrLineStreet);
+        appendWithCheckAndLeadingComma(strBuilder, addrLinePostCode);
+        if (StringUtils.isNotBlank(addrLinePostCode)) {
+            appendWithCheckAndLeadingSpace(strBuilder, addrLineCity);
+        } else {
+            appendWithCheckAndLeadingComma(strBuilder, addrLineCity);    
+        }
+        
+        return strBuilder;
+    }
+    
+    private static void appendWithCheckAndLeadingComma(StringBuilder strBuilder, CharSequence phrase) {
+        appendWithCheckAndLeadingSeparator(strBuilder, phrase, ", ");
+    }
+    
+    private static void appendWithCheckAndLeadingSpace(StringBuilder strBuilder, CharSequence phrase) {
+        appendWithCheckAndLeadingSeparator(strBuilder, phrase, " ");
+    }
+    
+    private static void appendWithCheckAndLeadingSeparator(StringBuilder strBuilder, CharSequence phrase, String separator) {
+        if (StringUtils.isNotBlank(phrase)) {
+            if (strBuilder.length()>0) {
+                strBuilder.append(separator);
+            }
+            strBuilder.append(phrase);
+        }
+    }
+
+    /**
+     * Clears the values of all the affiliation fields.
+     */
+    private void initialize() {
+        institutionOrgDivision = new StringBuilder();
+        institutionOrgName = new StringBuilder();
+        addrLineStreet = new StringBuilder();
+        addrLinePostCode = new StringBuilder();
+        addrLineCity = new StringBuilder();
+        countryName = new StringBuilder();
+        countryCode = null;
+    }
+    
+    //------------------------ GETTERS --------------------------
+    
+    public String getInstitutionOrgDivision() {
+        return institutionOrgDivision.toString();
+    }
+
+    public String getInstitutionOrgName() {
+        return institutionOrgName.toString();
+    }
+
+    public String getAddrLineStreet() {
+        return addrLineStreet.toString();
+    }
+
+    public String getAddrLinePostCode() {
+        return addrLinePostCode.toString();
+    }
+
+    public String getAddrLineCity() {
+        return addrLineCity.toString();
+    }
+
+    public String getCountryName() {
+        return countryName.toString();
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+    
+    
+    //------------------------ APPENDERS/SETTERS --------------------------
+    
+    public void appendToInstitutionOrgDivision(String institutionOrgDivision) {
+        if (institutionOrgDivision != null) {
+            this.institutionOrgDivision.append(institutionOrgDivision);    
+        }
+    }
+
+    public void appendToInstitutionOrgName(String institutionOrgName) {
+        if (institutionOrgName != null) {
+            this.institutionOrgName.append(institutionOrgName);    
+        }
+    }
+
+    public void appendToAddrLineStreet(String addrLineStreet) {
+        if (addrLineStreet != null) {
+            this.addrLineStreet.append(addrLineStreet);    
+        }
+    }
+
+    public void appendToAddrLinePostCode(String addrLinePostCode) {
+        if (addrLinePostCode != null) {
+            this.addrLinePostCode.append(addrLinePostCode);    
+        }
+    }
+
+    public void appendToAddrLineCity(String addrLineCity) {
+        if (addrLineCity != null) {
+            this.addrLineCity.append(addrLineCity);    
+        }
+    }
+
+    public void appendToCountryName(String countryName) {
+        if (countryName != null) {
+            this.countryName.append(countryName);    
+        }
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+    
+}

--- a/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsXmlConstants.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/main/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsXmlConstants.java
@@ -24,7 +24,9 @@ public final class JatsXmlConstants {
     protected static final String ELEM_SUP = "sup";
     protected static final String ELEM_COUNTRY = "country";
     protected static final String ELEM_INSTITUTION = "institution";
-    
+    protected static final String ELEM_ADDR_LINE = "addr-line";
+    protected static final String ATTR_CONTENT_TYPE = "content-type";
+    protected static final String ATTR_COUNTRY = "country";
     
 //  back citations
     protected static final String ELEM_REF_LIST = "ref-list";

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandlerTest.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandlerTest.java
@@ -1,22 +1,25 @@
 package eu.dnetlib.iis.wf.ingest.pmc.metadata;
 
-import com.google.common.collect.Maps;
-import eu.dnetlib.iis.common.ClassPathResourceProvider;
-import eu.dnetlib.iis.ingest.pmc.metadata.schemas.Affiliation;
-import eu.dnetlib.iis.ingest.pmc.metadata.schemas.Author;
-import eu.dnetlib.iis.ingest.pmc.metadata.schemas.ExtractedDocumentMetadata;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAffiliation;
+import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAuthor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.List;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.XMLReader;
 
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.File;
-import java.util.List;
+import com.google.common.collect.Maps;
 
-import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAffiliation;
-import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAuthor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import eu.dnetlib.iis.common.ClassPathResourceProvider;
+import eu.dnetlib.iis.ingest.pmc.metadata.schemas.Affiliation;
+import eu.dnetlib.iis.ingest.pmc.metadata.schemas.Author;
+import eu.dnetlib.iis.ingest.pmc.metadata.schemas.ExtractedDocumentMetadata;
 
 /**
  * @author madryk
@@ -189,6 +192,24 @@ public class ArticleMetaXmlHandlerTest {
         assertAuthor(authors.get(1), "González, Víctor");
         assertAuthor(authors.get(2), "Dávila, Guillermo");
         
+    }
+
+    @Test
+    public void testNestedContributorsFromSpringer() throws Exception {
+        // given
+        File xmlFile = new File(XML_BASE_PATH + "/nested_contributors_from_springer.xml");
+        
+        // execute
+        saxParser.parse(xmlFile, articleMetaXmlHandler);
+        ExtractedDocumentMetadata metadata = metaBuilder.build();
+        
+        // assert
+        
+        List<Author> authors = metadata.getAuthors();
+        assertEquals(2, authors.size());
+        
+        assertAuthor(authors.get(0), "Niemi, Mari E. K.", 0);
+        assertAuthor(authors.get(1), "Karjalainen, Juha", 1);
     }
     
 }

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandlerTest.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/ArticleMetaXmlHandlerTest.java
@@ -3,6 +3,7 @@ package eu.dnetlib.iis.wf.ingest.pmc.metadata;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAffiliation;
 import static eu.dnetlib.iis.wf.ingest.pmc.metadata.AssertExtractedDocumentMetadata.assertAuthor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.util.List;
@@ -210,6 +211,60 @@ public class ArticleMetaXmlHandlerTest {
         
         assertAuthor(authors.get(0), "Niemi, Mari E. K.", 0);
         assertAuthor(authors.get(1), "Karjalainen, Juha", 1);
+    }
+    
+    @Test
+    public void testComplexAffiliationsFromSpringer() throws Exception {
+        // given
+        File xmlFile = new File(XML_BASE_PATH + "/complex_affiliations_from_springer.xml");
+        
+        // execute
+        saxParser.parse(xmlFile, articleMetaXmlHandler);
+        ExtractedDocumentMetadata metadata = metaBuilder.build();
+        
+        // assert
+        
+        List<Affiliation> affs = metadata.getAffiliations();
+        
+        assertEquals(6, affs.size());
+        
+        assertEquals("DE", affs.get(0).getCountryCode());
+        assertEquals("Germany", affs.get(0).getCountryName());
+        assertEquals("Max-Planck-Institute for Immunobiology", affs.get(0).getOrganization());
+        assertEquals("Schillhof 5, 79110 Freiburg", affs.get(0).getAddress());
+        assertEquals("Max-Planck-Institute for Immunobiology, Schillhof 5, 79110 Freiburg, Germany", affs.get(0).getRawText());
+        
+        assertNull(affs.get(1).getCountryCode());
+        assertNull(affs.get(1).getCountryName());
+        assertEquals("Laboratory of Toxicology, Department of Pharmacological Sciences, University of Milan", affs.get(1).getOrganization());
+        assertEquals("Milan", affs.get(1).getAddress());
+        assertEquals("Laboratory of Toxicology, Department of Pharmacological Sciences, University of Milan, Milan", affs.get(1).getRawText());
+        
+        assertEquals("DE", affs.get(2).getCountryCode());
+        assertEquals("Germany", affs.get(2).getCountryName());
+        assertEquals("Proteome Sciences R&D GmbH & Co. KG", affs.get(2).getOrganization());
+        assertEquals("Frankfurt", affs.get(2).getAddress());
+        assertEquals("Proteome Sciences R&D GmbH & Co. KG, Frankfurt, Germany", affs.get(2).getRawText());
+        
+        assertEquals("DE", affs.get(3).getCountryCode());
+        assertEquals("Germany", affs.get(3).getCountryName());
+        assertEquals("Department of Dermatology, University Medical Centre", affs.get(3).getOrganization());
+        assertEquals("Mannheim", affs.get(3).getAddress());
+        assertEquals("Department of Dermatology, University Medical Centre, Mannheim, Germany", affs.get(3).getRawText());
+        
+        assertEquals("DK", affs.get(4).getCountryCode());
+        assertEquals("Denmark", affs.get(4).getCountryName());
+        assertEquals("Novozymes AS", affs.get(4).getOrganization());
+        assertEquals("Bagsvaerd", affs.get(4).getAddress());
+        assertEquals("Novozymes AS, Bagsvaerd, Denmark", affs.get(4).getRawText());
+        
+        // this is a mixed case: having institution and addr-line elements but without any specific content-type, also country needs to be discovered
+        assertEquals("MX", affs.get(5).getCountryCode());
+        assertEquals("México", affs.get(5).getCountryName());
+        assertEquals("Programa de Genómica Evolutiva, Centro de Ciencias Genómicas, Universidad Nacional Autónoma de México", affs.get(5).getOrganization());
+        assertEquals("Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos", affs.get(5).getAddress());
+        assertEquals("Programa de Genómica Evolutiva, Centro de Ciencias Genómicas, Universidad Nacional Autónoma de México, Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos, México", affs.get(5).getRawText());
+
     }
     
 }

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliationTest.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliationTest.java
@@ -1,7 +1,6 @@
 package eu.dnetlib.iis.wf.ingest.pmc.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ public class JatsExtendedAffiliationTest {
         assertEquals("", aff.getAddrLinePostCode());
         assertEquals("", aff.getAddrLineCity());
         assertEquals("", aff.getCountryName());
-        assertNull(aff.getCountryCode());
+        assertEquals("", aff.getCountryCode());
         assertEquals(0, aff.getNumberOfFieldsSet());
     }
     

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliationTest.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsExtendedAffiliationTest.java
@@ -1,0 +1,185 @@
+package eu.dnetlib.iis.wf.ingest.pmc.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link JatsExtendedAffiliation} test class. 
+ * @author mhorst
+ */
+public class JatsExtendedAffiliationTest {
+    
+    private final String institutionOrgDivision = "ICM"; 
+    private final String institutionOrgName = "University of Warsaw"; 
+    private final String addrLineStreet = "Tyniecka 15/17";
+    private final String addrLinePostCode = "02-630"; 
+    private final String addrLineCity = "Warsaw"; 
+    private final String countryName = "Poland";
+    private final String countryCode = "PL";
+
+    // -------------------------------TEST------------------------------
+    
+    @Test
+    public void testClear() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), institutionOrgDivision, institutionOrgName, 
+                addrLineStreet, addrLinePostCode, addrLineCity, 
+                countryName, countryCode);
+        
+        // execute
+        aff.clear();
+        
+        // assert
+        assertEquals("", aff.getInstitutionOrgDivision());
+        assertEquals("", aff.getInstitutionOrgName());
+        assertEquals("", aff.getAddrLineStreet());
+        assertEquals("", aff.getAddrLinePostCode());
+        assertEquals("", aff.getAddrLineCity());
+        assertEquals("", aff.getCountryName());
+        assertNull(aff.getCountryCode());
+        assertEquals(0, aff.getNumberOfFieldsSet());
+    }
+    
+    
+    @Test
+    public void testGenerateFullOrganizationName() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), institutionOrgDivision, institutionOrgName, 
+                null, null, null, null, null);
+        
+        // execute & assert
+        assertEquals("ICM, University of Warsaw", aff.generateFullOrganizationName());
+        assertEquals(2, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateFullOrganizationNameWithoutDivision() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), null, institutionOrgName, 
+                null, null, null, null, null);
+        
+        // execute & assert
+        assertEquals("University of Warsaw", aff.generateFullOrganizationName());
+        assertEquals(1, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateFullOrganizationNameWithoutName() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), institutionOrgDivision, null, 
+                null, null, null, null, null);
+        
+        // execute & assert
+        assertEquals("ICM", aff.generateFullOrganizationName());
+        assertEquals(1, aff.getNumberOfFieldsSet());
+    }
+     
+    @Test
+    public void testGenerateFullAddress() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), null, null, 
+                addrLineStreet, addrLinePostCode, addrLineCity, null, null);
+        
+        // execute & assert
+        assertEquals("Tyniecka 15/17, 02-630 Warsaw", aff.generateFullAddress());
+        assertEquals(3, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateFullAddressWithoutPostCode() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), null, null, 
+                addrLineStreet, null, addrLineCity, null, null);
+        
+        // execute & assert
+        assertEquals("Tyniecka 15/17, Warsaw", aff.generateFullAddress());
+        assertEquals(2, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateFullAddressWithoutStreet() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), null, null, 
+                null, addrLinePostCode, addrLineCity, null, null);
+        
+        // execute & assert
+        assertEquals("02-630 Warsaw", aff.generateFullAddress());
+        assertEquals(2, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateFullAddressWithoutCity() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), null, null, 
+                addrLineStreet, addrLinePostCode, null, null, null);
+        
+        // execute & assert
+        assertEquals("Tyniecka 15/17, 02-630", aff.generateFullAddress());
+        assertEquals(2, aff.getNumberOfFieldsSet());
+    }
+
+    @Test
+    public void testGenerateRawText() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), institutionOrgDivision, institutionOrgName, 
+                addrLineStreet, addrLinePostCode, addrLineCity, 
+                countryName, countryCode);
+        
+        // execute & assert
+        assertEquals("ICM, University of Warsaw, Tyniecka 15/17, 02-630 Warsaw, Poland", aff.generateRawText());
+        assertEquals(7, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testGenerateRawTextNoCountryName() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(
+                new JatsExtendedAffiliation(), institutionOrgDivision, institutionOrgName, 
+                addrLineStreet, addrLinePostCode, addrLineCity, 
+                null, countryCode);
+        
+        // execute & assert
+        assertEquals("ICM, University of Warsaw, Tyniecka 15/17, 02-630 Warsaw", aff.generateRawText());
+        assertEquals(6, aff.getNumberOfFieldsSet());
+    }
+    
+    @Test
+    public void testNoFieldSet() throws Exception {
+        // given
+        JatsExtendedAffiliation aff = fillJatsExtendedAffiliationWithMetadata(new JatsExtendedAffiliation(), null, null,
+                null, null, null, null, null);
+        
+        // execute & assert
+        assertEquals(0, aff.getNumberOfFieldsSet());
+    }
+
+    // ------------------------------ PRIVATE --------------------------------
+    
+    private static JatsExtendedAffiliation fillJatsExtendedAffiliationWithMetadata(JatsExtendedAffiliation aff,
+            String institutionOrgDivision, String institutionOrgName, 
+            String addrLineStreet, String addrLinePostCode, String addrLineCity, 
+            String countryName, String countryCode) {
+        aff.appendToInstitutionOrgDivision(institutionOrgDivision);
+        aff.appendToInstitutionOrgName(institutionOrgName);
+
+        aff.appendToAddrLineStreet(addrLineStreet);
+        aff.appendToAddrLinePostCode(addrLinePostCode);
+        aff.appendToAddrLineCity(addrLineCity);
+
+        aff.appendToCountryName(countryName);
+        aff.setCountryCode(countryCode);
+        return aff;
+    }
+    
+}

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsXmlHandlerTest.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/JatsXmlHandlerTest.java
@@ -117,16 +117,66 @@ public class JatsXmlHandlerTest {
 
 		assertNotNull(meta.getAffiliations());
 		assertEquals(6, meta.getAffiliations().size());
-		// checking first affiliation
+		// checking all affiliations
 		assertEquals(
-				"Auditory Neuroscience Laboratory, www.brainvolts.northwestern.edu, Northwestern University Evanston, IL, USA",
+				"Auditory Neuroscience Laboratory, Northwestern University, Evanston, IL, USA",
 				meta.getAffiliations().get(0).getRawText());
 		assertEquals(
-				"Auditory Neuroscience Laboratory, www.brainvolts.northwestern.edu, Northwestern University Evanston",
+				"Auditory Neuroscience Laboratory, Northwestern University",
 				meta.getAffiliations().get(0).getOrganization());
 		assertEquals("USA", meta.getAffiliations().get(0).getCountryName());
 		assertEquals("US", meta.getAffiliations().get(0).getCountryCode());
-		assertEquals("IL", meta.getAffiliations().get(0).getAddress());
+		assertEquals("Evanston, IL", meta.getAffiliations().get(0).getAddress());
+		
+		assertEquals(
+                "Department of Communication Sciences, Northwestern University, Evanston, IL, USA",
+                meta.getAffiliations().get(1).getRawText());
+        assertEquals(
+                "Department of Communication Sciences, Northwestern University",
+                meta.getAffiliations().get(1).getOrganization());
+        assertEquals("USA", meta.getAffiliations().get(1).getCountryName());
+        assertEquals("US", meta.getAffiliations().get(1).getCountryCode());
+        assertEquals("Evanston, IL", meta.getAffiliations().get(1).getAddress());
+        
+        assertEquals(
+                "Neuroscience Program, Northwestern University, Evanston, IL, USA",
+                meta.getAffiliations().get(2).getRawText());
+        assertEquals(
+                "Neuroscience Program, Northwestern University",
+                meta.getAffiliations().get(2).getOrganization());
+        assertEquals("USA", meta.getAffiliations().get(2).getCountryName());
+        assertEquals("US", meta.getAffiliations().get(2).getCountryCode());
+        assertEquals("Evanston, IL", meta.getAffiliations().get(2).getAddress());
+        
+        assertEquals(
+                "Department of Neurobiology and Physiology, Northwestern University, Evanston, IL, USA",
+                meta.getAffiliations().get(3).getRawText());
+        assertEquals(
+                "Department of Neurobiology and Physiology, Northwestern University",
+                meta.getAffiliations().get(3).getOrganization());
+        assertEquals("USA", meta.getAffiliations().get(3).getCountryName());
+        assertEquals("US", meta.getAffiliations().get(3).getCountryCode());
+        assertEquals("Evanston, IL", meta.getAffiliations().get(3).getAddress());
+        
+        assertEquals(
+                "Department of Otolaryngology, Northwestern University, Chicago, IL, USA",
+                meta.getAffiliations().get(4).getRawText());
+        assertEquals(
+                "Department of Otolaryngology, Northwestern University",
+                meta.getAffiliations().get(4).getOrganization());
+        assertEquals("USA", meta.getAffiliations().get(4).getCountryName());
+        assertEquals("US", meta.getAffiliations().get(4).getCountryCode());
+        assertEquals("Chicago, IL", meta.getAffiliations().get(4).getAddress());
+        
+        assertEquals(
+                "Data Sense LLC, Chicago, IL, USA",
+                meta.getAffiliations().get(5).getRawText());
+        assertEquals(
+                "Data Sense LLC",
+                meta.getAffiliations().get(5).getOrganization());
+        assertEquals("USA", meta.getAffiliations().get(5).getCountryName());
+        assertEquals("US", meta.getAffiliations().get(5).getCountryCode());
+        assertEquals("Chicago, IL", meta.getAffiliations().get(5).getAddress());
 	}
 
 	@Test

--- a/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/data/articlemeta/complex_affiliations_from_springer.xml
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/data/articlemeta/complex_affiliations_from_springer.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" article-type="research-article" dtd-version="1.2" xml:lang="en">
+  <?properties open_access?>
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">3</journal-id>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type="doi">10.1007/s00003-009-0510-5</article-id>
+      <title-group>
+        <article-title xml:lang="en">Safe cosmetics without animal testing? Contributions of the EU Project <italic toggle="yes">Sens-it-iv</italic></article-title>
+      </title-group>
+      <contrib-group>
+        <aff id="Aff1">
+          <label>Aff1</label>
+          <institution-wrap>
+            <institution-id institution-id-type="GRID">grid.429509.3</institution-id>
+            <institution-id institution-id-type="ISNI">0000000404914256</institution-id>
+            <institution content-type="org-name">Max-Planck-Institute for Immunobiology</institution>
+          </institution-wrap>
+          <addr-line content-type="street">Schillhof 5</addr-line>
+          <addr-line content-type="postcode">79110</addr-line>
+          <addr-line content-type="city">Freiburg</addr-line>
+          <country country="DE">Germany</country>
+        </aff>
+        <aff id="Aff2">
+          <label>Aff2</label>
+          <institution-wrap>
+            <institution-id institution-id-type="GRID">grid.4708.b</institution-id>
+            <institution-id institution-id-type="ISNI">0000000417572822</institution-id>
+            <institution content-type="org-division">Laboratory of Toxicology, Department of Pharmacological Sciences</institution>
+            <institution content-type="org-name">University of Milan</institution>
+          </institution-wrap>
+          <addr-line content-type="city">Milan</addr-line>
+        </aff>
+        <aff id="Aff4">
+          <label>Aff4</label>
+          <institution-wrap>
+            <institution-id institution-id-type="GRID">grid.4514.4</institution-id>
+            <institution-id institution-id-type="ISNI">0000000109302361</institution-id>
+          </institution-wrap>
+          <addr-line content-type="city">Lund</addr-line>
+          <country country="SE">Sweden</country>
+        </aff>
+        <aff id="Aff5">
+          <label>Aff5</label>
+          <institution-wrap>
+            <institution content-type="org-name">Proteome Sciences R&amp;D GmbH &amp; Co. KG</institution>
+          </institution-wrap>
+          <addr-line content-type="city">Frankfurt</addr-line>
+          <country country="DE">Germany</country>
+        </aff>
+        <aff id="Aff6">
+          <label>Aff6</label>
+          <institution-wrap>
+            <institution-id institution-id-type="GRID">grid.411778.c</institution-id>
+            <institution-id institution-id-type="ISNI">0000000121621728</institution-id>
+            <institution content-type="org-division">Department of Dermatology</institution>
+            <institution content-type="org-name">University Medical Centre</institution>
+          </institution-wrap>
+          <addr-line content-type="city">Mannheim</addr-line>
+          <country country="DE">Germany</country>
+        </aff>
+        <aff id="Aff8">
+          <label>Aff8</label>
+          <institution-wrap>
+            <institution-id institution-id-type="GRID">grid.10582.3e</institution-id>
+            <institution-id institution-id-type="ISNI">0000000403730797</institution-id>
+            <institution content-type="org-name">Novozymes AS</institution>
+          </institution-wrap>
+          <addr-line content-type="city">Bagsvaerd</addr-line>
+          <country country="DK">Denmark</country>
+        </aff>
+        <aff id="aff-taken-from-other-doc">
+            <institution>Programa de Gen&#x000f3;mica Evolutiva, Centro de Ciencias Gen&#x000f3;micas, Universidad Nacional Aut&#x000f3;noma de M&#x000e9;xico</institution>
+            <addr-line>Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos, M&#x000e9;xico</addr-line>    
+        </aff>
+      </contrib-group>
+    </article-meta>
+  </front>
+  <body>
+  </body>
+  <back>
+  </back>
+</article>

--- a/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/data/articlemeta/nested_contributors_from_springer.xml
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/data/articlemeta/nested_contributors_from_springer.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<article
+    xmlns:mml="http://www.w3.org/1998/Math/MathML"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ali="http://www.niso.org/schemas/ali/1.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" dtd-version="1.2" article-type="research-article" xml:lang="en">
+    <?properties open_access?>
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">41586</journal-id>
+            <journal-id journal-id-type="doi">10.1038/41586.1476-4687</journal-id>
+            <journal-title-group>
+                <journal-title>Nature</journal-title>
+                <journal-subtitle>International weekly journal of science</journal-subtitle>
+                <abbrev-journal-title abbrev-type="publisher">Nature</abbrev-journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">0028-0836</issn>
+            <issn pub-type="epub">1476-4687</issn>
+            <publisher>
+                <publisher-name>Nature Publishing Group UK</publisher-name>
+                <publisher-loc>London</publisher-loc>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">s41586-021-03767-x</article-id>
+            <article-id pub-id-type="manuscript">3767</article-id>
+            <article-id pub-id-type="doi">10.1038/s41586-021-03767-x</article-id>
+            <article-categories>
+                <subj-group subj-group-type="heading">
+                    <subject>Article</subject>
+                </subj-group>
+                <subj-group subj-group-type="SubjectPath">
+                    <subject>/631/208</subject>
+                </subj-group>
+                <subj-group subj-group-type="SubjectPath">
+                    <subject>/631/208/205/2138</subject>
+                </subj-group>
+                <subj-group subj-group-type="SubjectPath">
+                    <subject>/631/326/596/4130</subject>
+                </subj-group>
+                <subj-group subj-group-type="SubjectPath">
+                    <subject>/692/699/255/2514</subject>
+                </subj-group>
+                <subj-group subj-group-type="TechniquePath">
+                    <subject>/45/43</subject>
+                </subj-group>
+                <subj-group subj-group-type="NatureArticleTypeID">
+                    <subject>article</subject>
+                </subj-group>
+            </article-categories>
+            <title-group>
+                <article-title xml:lang="en">Mapping the human genetic architecture of COVID-19</article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author" id="IAu1" corresp="yes">
+                    <xref ref-type="aff" rid="Aff4">4</xref>
+                    <collab>
+                        <institution>COVID-19 Host Genetics Initiative</institution>
+                        <contrib-group>
+                            <contrib contrib-type="author" id="IAu2">
+                                <collab>
+                                    <institution>COVID-19 Host Genetics InitiativeLeadership</institution>
+                                    <contrib-group>
+                                        <contrib contrib-type="author" id="Au1">
+                                            <name name-style="western">
+                                                <surname>Niemi</surname>
+                                                <given-names>Mari E. K.</given-names>
+                                            </name>
+                                            <xref ref-type="aff" rid="Aff1">1</xref>
+                                        </contrib>
+                                        <contrib contrib-type="author" id="Au2">
+                                            <name name-style="western">
+                                                <surname>Karjalainen</surname>
+                                                <given-names>Juha</given-names>
+                                            </name>
+                                            <xref ref-type="aff" rid="Aff2">2</xref>
+                                        </contrib>
+                                    </contrib-group>
+                                </collab>
+                            </contrib>
+                        </contrib-group>
+                    </collab>
+                </contrib>
+                <aff id="Aff1">
+                    <label>1</label>
+                    <institution-wrap>
+                        <institution-id institution-id-type="GRID">grid.452494.a</institution-id>
+                        <institution-id institution-id-type="ISNI">0000 0004 0409 5350</institution-id>
+                        <institution content-type="org-name">Institute for Molecular Medicine Finland (FIMM), University of Helsinki</institution>
+                    </institution-wrap>
+                    <addr-line content-type="city">Helsinki</addr-line>
+                    <country country="FI">Finland</country>
+                </aff>
+                <aff id="Aff2">
+                    <label>2</label>
+                    <institution-wrap>
+                        <institution-id institution-id-type="GRID">grid.66859.34</institution-id>
+                        <institution content-type="org-name">Broad Institute of MIT and Harvard</institution>
+                    </institution-wrap>
+                    <addr-line content-type="city">Cambridge</addr-line>
+                    <addr-line content-type="state">MA</addr-line>
+                    <country country="US">USA</country>
+                </aff>
+                <aff id="Aff4">
+                    <label>4</label>
+                    <institution-wrap>
+                        <institution-id institution-id-type="GRID">grid.66859.34</institution-id>
+                        <institution content-type="org-name">Massachusetts General Hospital, Broad Institute of MIT and Harvard</institution>
+                    </institution-wrap>
+                    <addr-line content-type="city">Cambridge</addr-line>
+                    <addr-line content-type="state">MA</addr-line>
+                    <country country="US">USA</country>
+                </aff>
+            </contrib-group>
+        </article-meta>
+    </front>
+</article>

--- a/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/sampledataproducer/data/metadata.json
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/resources/eu/dnetlib/iis/wf/ingest/pmc/metadata/sampledataproducer/data/metadata.json
@@ -1187,11 +1187,11 @@
   ],
   "affiliations": [
     {
-      "organization": "Programa de Geno\u0301mica Evolutiva, Centro de Ciencias Geno\u0301micas, Universidad Nacional Auto\u0301noma de Me\u0301xicoApartado Postal 565-A, C.",
-      "countryName": "Me\u0301xico",
+      "organization": "Programa de Genómica Evolutiva, Centro de Ciencias Genómicas, Universidad Nacional Autónoma de México",
+      "countryName": "México",
       "countryCode": "MX",
-      "address": "P 62210, Cuernavaca, Morelos",
-      "rawText": "Programa de Geno\u0301mica Evolutiva, Centro de Ciencias Geno\u0301micas, Universidad Nacional Auto\u0301noma de Me\u0301xicoApartado Postal 565-A, C.P 62210, Cuernavaca, Morelos, Me\u0301xico"
+      "address": "Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos",
+      "rawText": "Programa de Genómica Evolutiva, Centro de Ciencias Genómicas, Universidad Nacional Autónoma de México, Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos, México"
     }
   ],
   "authors": [


### PR DESCRIPTION
This PR covers two fixes related to affiliations parsing. The first one, #1464, deals with author names and an improper linking them to affiliations while the second one, #1466, addresses the complex affiliations parsing.

It turned out even though Springer and PubMed share the same XML JATS format it is flexible enough to allow encoding affiliations in multiple ways and only one way of such encoding was covered so far, the simplified one (coming from PubMed):

```
<aff id="I1"><label>1</label>Graduate School of Bioscience and Biotechnology, Tokyo Institute of Technology, Nagatsuta-cho, Midori-ku, Yokohama 226-8501, Japan</aff>
```

while the complex one coming from Springer:
```
        <aff id="Aff1">
          <label>Aff1</label>
          <institution-wrap>
            <institution-id institution-id-type="GRID">grid.429509.3</institution-id>
            <institution-id institution-id-type="ISNI">0000000404914256</institution-id>
            <institution content-type="org-name">Max-Planck-Institute for Immunobiology</institution>
          </institution-wrap>
          <addr-line content-type="street">Schillhof 5</addr-line>
          <addr-line content-type="postcode">79110</addr-line>
          <addr-line content-type="city">Freiburg</addr-line>
        </aff>    
```

with XML tags indicating affiliations metadata explicitly, was improperly handled resulting in all the contents of those XML tags being glued together without any delimiter.

From now on the complex affiliation is properly handled. 

Semi-structured affiliations provided by some of the repositories:
```
<aff id="aff-taken-from-other-doc">
            <institution>Programa de Gen&#x000f3;mica Evolutiva, Centro de Ciencias Gen&#x000f3;micas, Universidad Nacional Aut&#x000f3;noma de M&#x000e9;xico</institution>
            <addr-line>Apartado Postal 565-A, C.P 62210, Cuernavaca, Morelos, M&#x000e9;xico</addr-line>    
        </aff>
```
so having `institution` and `addr-line` tags without the `content-type` attribute indicating the type of such elements are also handled by putting them together to for the raw text of an affiliation and then sending them to CERMINE affiliation tokenization module in order to identify the affiliation metadata fields (so organization name, address, country name and country code).