### PR TITLE
Closes #1478: Make the process responsible for importing SoftwareHeritage origins immune to timeout failures

### DIFF
--- a/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporter.java
+++ b/iis-wf/iis-wf-import/src/main/java/eu/dnetlib/iis/wf/importer/software/origins/SoftwareHeritageOriginsImporter.java
@@ -149,7 +149,7 @@ public class SoftwareHeritageOriginsImporter implements eu.dnetlib.iis.common.ja
                                     Thread.sleep(params.getDelayMillis());
                                     continue;
                                 } else {
-                                    log.error("exceeding the allowed number of retries: " + params.getMaxRetryCount() + "interrupting...");
+                                    log.error("exceeding the allowed number of retries: " + params.getMaxRetryCount() + ", interrupting...");
                                     throw new RuntimeException(errMessage);    
                                 }
                             }
@@ -181,13 +181,13 @@ public class SoftwareHeritageOriginsImporter implements eu.dnetlib.iis.common.ja
                     } catch (SocketTimeoutException e) {
                         if (retryCount < params.getMaxRetryCount()) {
                             retryCount++;
-                            log.error("got timeout exception while accessing SH endpoint, number of retries left: "
+                            log.warn("got timeout exception while accessing SH endpoint, number of retries left: "
                                     + (params.getMaxRetryCount() - retryCount), e);
                             Thread.sleep(params.getDelayMillis());
                             continue;
                         } else {
                             log.error("exceeding the allowed number of retries: " + params.getMaxRetryCount()
-                                    + "interrupting...");
+                                    + ", interrupting...");
                             throw e;
                         }
                     }


### PR DESCRIPTION
Apart from handling `SocketTimeoutException` in a proper way by allowing retry mechanism to kick-in I added two unit tests proving this mechanism works as expected.

Adding one error log line to indicate the number of retries was reached also when handling throttling and unsupported HTTP error codes. 