### PR TITLE
Closes #1483: Set collectedfrom to OpenAIRE in all the relations exported by the IIS

### DIFF
--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/ExportWorkflowRuntimeParameters.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/ExportWorkflowRuntimeParameters.java
@@ -10,5 +10,7 @@ public final class ExportWorkflowRuntimeParameters {
 	
 	public static final String EXPORT_DOCUMENTSSIMILARITY_THRESHOLD = "export.documentssimilarity.threshold";
 	
+	public static final String EXPORT_RELATION_COLLECTEDFROM_VALUE = "export.relation.collectedfrom.value";
+	
 	private ExportWorkflowRuntimeParameters() {}
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/ExportWorkflowRuntimeParameters.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/ExportWorkflowRuntimeParameters.java
@@ -10,7 +10,7 @@ public final class ExportWorkflowRuntimeParameters {
 	
 	public static final String EXPORT_DOCUMENTSSIMILARITY_THRESHOLD = "export.documentssimilarity.threshold";
 	
-	public static final String EXPORT_RELATION_COLLECTEDFROM_VALUE = "export.relation.collectedfrom.value";
+	public static final String EXPORT_RELATION_COLLECTEDFROM_KEY = "export.relation.collectedfrom.key";
 	
 	private ExportWorkflowRuntimeParameters() {}
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/cfg/StaticConfigurationProvider.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/cfg/StaticConfigurationProvider.java
@@ -9,7 +9,7 @@ public final class StaticConfigurationProvider {
 	
 	public static final String ACTION_TRUST_0_9 = "0.9";
 	
-	public static final String COLLECTED_FROM_KEY = "OpenAIRE";
+	public static final String COLLECTED_FROM_VALUE = "OpenAIRE";
 	
 	private StaticConfigurationProvider() {}
 	

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/cfg/StaticConfigurationProvider.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/cfg/StaticConfigurationProvider.java
@@ -9,6 +9,8 @@ public final class StaticConfigurationProvider {
 	
 	public static final String ACTION_TRUST_0_9 = "0.9";
 	
+	public static final String COLLECTED_FROM_KEY = "OpenAIRE";
+	
 	private StaticConfigurationProvider() {}
 	
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -181,6 +181,7 @@ public class PatentExporterJob {
 
             final Float confidenceLevelThreshold = ConfidenceLevelUtils
                     .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
+            final String collectedFromValue = params.collectedFromValue;
 
             JavaRDD<DocumentToPatent> relMetaRDD = avroLoader
                     .loadJavaRDD(sc, params.inputDocumentToPatentPath, DocumentToPatent.class);
@@ -213,7 +214,7 @@ public class PatentExporterJob {
             configuration.set(FileOutputFormat.COMPRESS, Boolean.TRUE.toString());
             configuration.set(FileOutputFormat.COMPRESS_TYPE, SequenceFile.CompressionType.BLOCK.name());
 
-            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(patentExportMetaDedupRDD);
+            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(patentExportMetaDedupRDD, collectedFromValue);
             RDDUtils.saveTextPairRDD(relationsToExportRDD, numberOfOutputFiles, params.outputRelationPath, configuration);
 
             String patentDateOfCollection = DateTimeUtils.format(
@@ -256,43 +257,35 @@ public class PatentExporterJob {
         return x.getDocumentToPatent().getConfidenceLevel() > y.getDocumentToPatent().getConfidenceLevel() ? x : y;
     }
 
-    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<PatentExportMetadata> rdd) {
+    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<PatentExportMetadata> rdd, String collectedFromValue) {
         return AtomicActionSerializationUtils
                 .mapActionToText(rdd
                         .flatMap(x -> {
                             String documentId = x.getDocumentId();
                             String patentId = x.getPatentId();
                             Float confidenceLevel = x.getDocumentToPatent().getConfidenceLevel();
-                            return buildRelationActions(documentId, patentId, confidenceLevel).iterator();
+                            return buildRelationActions(documentId, patentId, confidenceLevel, collectedFromValue).iterator();
                         })
                 );
     }
 
-    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String patentId, Float confidenceLevel) {
+    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String patentId, Float confidenceLevel, String collectedFromValue) {
         AtomicAction<Relation> forwardAction = new AtomicAction<>();
         forwardAction.setClazz(Relation.class);
-        forwardAction.setPayload(buildRelation(documentId, patentId, confidenceLevel));
+        forwardAction.setPayload(buildRelation(documentId, patentId, confidenceLevel, collectedFromValue));
 
         AtomicAction<Relation> reverseAction = new AtomicAction<>();
         reverseAction.setClazz(Relation.class);
-        reverseAction.setPayload(buildRelation(patentId, documentId, confidenceLevel));
+        reverseAction.setPayload(buildRelation(patentId, documentId, confidenceLevel, collectedFromValue));
 
         return Arrays.asList(forwardAction, reverseAction);
     }
 
-    private static Relation buildRelation(String source, String target, Float confidenceLevel) {
-        Relation relation = new Relation();
-        relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-        relation.setSubRelType(OafConstants.SUBREL_TYPE_RELATIONSHIP);
-        relation.setRelClass(OafConstants.REL_CLASS_ISRELATEDTO);
-
-        relation.setSource(source);
-        relation.setTarget(target);
-
-        relation.setDataInfo(BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE));
-        relation.setLastupdatetimestamp(System.currentTimeMillis());
-
-        return relation;
+    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromValue) {
+        return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                OafConstants.SUBREL_TYPE_RELATIONSHIP, OafConstants.REL_CLASS_ISRELATEDTO, 
+                BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE),
+                collectedFromValue);
     }
 
     private static JavaPairRDD<Text, Text> entitiesToExport(JavaRDD<PatentExportMetadata> rdd,
@@ -480,6 +473,9 @@ public class PatentExporterJob {
 
         @Parameter(names = "-trustLevelThreshold")
         private String trustLevelThreshold;
+        
+        @Parameter(names = "-collectedFromValue", required = true)
+        private String collectedFromValue;
 
         @Parameter(names = "-patentDateOfCollection", required = true)
         private String patentDateOfCollection;

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJob.java
@@ -181,7 +181,7 @@ public class PatentExporterJob {
 
             final Float confidenceLevelThreshold = ConfidenceLevelUtils
                     .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
-            final String collectedFromValue = params.collectedFromValue;
+            final String collectedFromKey = params.collectedFromKey;
 
             JavaRDD<DocumentToPatent> relMetaRDD = avroLoader
                     .loadJavaRDD(sc, params.inputDocumentToPatentPath, DocumentToPatent.class);
@@ -214,7 +214,7 @@ public class PatentExporterJob {
             configuration.set(FileOutputFormat.COMPRESS, Boolean.TRUE.toString());
             configuration.set(FileOutputFormat.COMPRESS_TYPE, SequenceFile.CompressionType.BLOCK.name());
 
-            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(patentExportMetaDedupRDD, collectedFromValue);
+            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(patentExportMetaDedupRDD, collectedFromKey);
             RDDUtils.saveTextPairRDD(relationsToExportRDD, numberOfOutputFiles, params.outputRelationPath, configuration);
 
             String patentDateOfCollection = DateTimeUtils.format(
@@ -257,35 +257,35 @@ public class PatentExporterJob {
         return x.getDocumentToPatent().getConfidenceLevel() > y.getDocumentToPatent().getConfidenceLevel() ? x : y;
     }
 
-    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<PatentExportMetadata> rdd, String collectedFromValue) {
+    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<PatentExportMetadata> rdd, String collectedFromKey) {
         return AtomicActionSerializationUtils
                 .mapActionToText(rdd
                         .flatMap(x -> {
                             String documentId = x.getDocumentId();
                             String patentId = x.getPatentId();
                             Float confidenceLevel = x.getDocumentToPatent().getConfidenceLevel();
-                            return buildRelationActions(documentId, patentId, confidenceLevel, collectedFromValue).iterator();
+                            return buildRelationActions(documentId, patentId, confidenceLevel, collectedFromKey).iterator();
                         })
                 );
     }
 
-    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String patentId, Float confidenceLevel, String collectedFromValue) {
+    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String patentId, Float confidenceLevel, String collectedFromKey) {
         AtomicAction<Relation> forwardAction = new AtomicAction<>();
         forwardAction.setClazz(Relation.class);
-        forwardAction.setPayload(buildRelation(documentId, patentId, confidenceLevel, collectedFromValue));
+        forwardAction.setPayload(buildRelation(documentId, patentId, confidenceLevel, collectedFromKey));
 
         AtomicAction<Relation> reverseAction = new AtomicAction<>();
         reverseAction.setClazz(Relation.class);
-        reverseAction.setPayload(buildRelation(patentId, documentId, confidenceLevel, collectedFromValue));
+        reverseAction.setPayload(buildRelation(patentId, documentId, confidenceLevel, collectedFromKey));
 
         return Arrays.asList(forwardAction, reverseAction);
     }
 
-    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromValue) {
+    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromKey) {
         return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
                 OafConstants.SUBREL_TYPE_RELATIONSHIP, OafConstants.REL_CLASS_ISRELATEDTO, 
                 BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE),
-                collectedFromValue);
+                collectedFromKey);
     }
 
     private static JavaPairRDD<Text, Text> entitiesToExport(JavaRDD<PatentExportMetadata> rdd,
@@ -474,8 +474,8 @@ public class PatentExporterJob {
         @Parameter(names = "-trustLevelThreshold")
         private String trustLevelThreshold;
         
-        @Parameter(names = "-collectedFromValue", required = true)
-        private String collectedFromValue;
+        @Parameter(names = "-collectedFromKey", required = true)
+        private String collectedFromKey;
 
         @Parameter(names = "-patentDateOfCollection", required = true)
         private String patentDateOfCollection;

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJob.java
@@ -123,6 +123,7 @@ public class SoftwareExporterJob {
 
             final Float confidenceLevelThreshold = ConfidenceLevelUtils
                     .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
+            final String collectedFromValue = params.collectedFromValue;
 
             JavaRDD<DocumentToSoftwareUrlWithMeta> relMetaRDD = avroLoader
                     .loadJavaRDD(sc, params.inputDocumentToSoftwareUrlPath, DocumentToSoftwareUrlWithMeta.class);
@@ -157,7 +158,7 @@ public class SoftwareExporterJob {
             configuration.set(FileOutputFormat.COMPRESS, Boolean.TRUE.toString());
             configuration.set(FileOutputFormat.COMPRESS_TYPE, SequenceFile.CompressionType.BLOCK.name());
 
-            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(softwareExportMetaDedupRDD);
+            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(softwareExportMetaDedupRDD, collectedFromValue);
             RDDUtils.saveTextPairRDD(relationsToExportRDD, NUMBER_OF_OUTPUT_FILES, params.outputRelationPath, configuration);
 
             JavaPairRDD<Text, Text> entitiesToExportRDD = entitiesToExport(softwareExportMetaDedupRDD);
@@ -215,43 +216,36 @@ public class SoftwareExporterJob {
                 y.getDocumentToSoftwareUrlWithMeta().getConfidenceLevel() ? x : y;
     }
 
-    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<SoftwareExportMetadata> rdd) {
+    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<SoftwareExportMetadata> rdd, String collectedFromValue) {
         return AtomicActionSerializationUtils
                 .mapActionToText(rdd
                         .flatMap(x -> {
                             String documentId = x.getDocumentId();
                             String softwareId = x.getSoftwareId();
                             Float confidenceLevel = x.getDocumentToSoftwareUrlWithMeta().getConfidenceLevel();
-                            return buildRelationActions(documentId, softwareId, confidenceLevel).iterator();
+                            return buildRelationActions(documentId, softwareId, confidenceLevel, collectedFromValue).iterator();
                         })
                 );
     }
 
-    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String softwareId, Float confidenceLevel) {
+    private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String softwareId,
+            Float confidenceLevel, String collectedFromValue) {
         AtomicAction<Relation> forwardAction = new AtomicAction<>();
         forwardAction.setClazz(Relation.class);
-        forwardAction.setPayload(buildRelation(documentId, softwareId, confidenceLevel));
+        forwardAction.setPayload(buildRelation(documentId, softwareId, confidenceLevel, collectedFromValue));
 
         AtomicAction<Relation> reverseAction = new AtomicAction<>();
         reverseAction.setClazz(Relation.class);
-        reverseAction.setPayload(buildRelation(softwareId, documentId, confidenceLevel));
+        reverseAction.setPayload(buildRelation(softwareId, documentId, confidenceLevel, collectedFromValue));
 
         return Arrays.asList(forwardAction, reverseAction);
     }
 
-    private static Relation buildRelation(String source, String target, Float confidenceLevel) {
-        Relation relation = new Relation();
-        relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-        relation.setSubRelType(OafConstants.SUBREL_TYPE_RELATIONSHIP);
-        relation.setRelClass(OafConstants.REL_CLASS_ISRELATEDTO);
-
-        relation.setSource(source);
-        relation.setTarget(target);
-
-        relation.setDataInfo(BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE));
-        relation.setLastupdatetimestamp(System.currentTimeMillis());
-
-        return relation;
+    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromValue) {
+        return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                OafConstants.SUBREL_TYPE_RELATIONSHIP, OafConstants.REL_CLASS_ISRELATEDTO, 
+                BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE),
+                collectedFromValue);
     }
 
     private static JavaPairRDD<Text, Text> entitiesToExport(JavaRDD<SoftwareExportMetadata> rdd) {
@@ -448,5 +442,8 @@ public class SoftwareExporterJob {
 
         @Parameter(names = "-trustLevelThreshold", required = false)
         private String trustLevelThreshold;
+        
+        @Parameter(names = "-collectedFromValue", required = true)
+        private String collectedFromValue;
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJob.java
@@ -123,7 +123,7 @@ public class SoftwareExporterJob {
 
             final Float confidenceLevelThreshold = ConfidenceLevelUtils
                     .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
-            final String collectedFromValue = params.collectedFromValue;
+            final String collectedFromKey = params.collectedFromKey;
 
             JavaRDD<DocumentToSoftwareUrlWithMeta> relMetaRDD = avroLoader
                     .loadJavaRDD(sc, params.inputDocumentToSoftwareUrlPath, DocumentToSoftwareUrlWithMeta.class);
@@ -158,7 +158,7 @@ public class SoftwareExporterJob {
             configuration.set(FileOutputFormat.COMPRESS, Boolean.TRUE.toString());
             configuration.set(FileOutputFormat.COMPRESS_TYPE, SequenceFile.CompressionType.BLOCK.name());
 
-            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(softwareExportMetaDedupRDD, collectedFromValue);
+            JavaPairRDD<Text, Text> relationsToExportRDD = relationsToExport(softwareExportMetaDedupRDD, collectedFromKey);
             RDDUtils.saveTextPairRDD(relationsToExportRDD, NUMBER_OF_OUTPUT_FILES, params.outputRelationPath, configuration);
 
             JavaPairRDD<Text, Text> entitiesToExportRDD = entitiesToExport(softwareExportMetaDedupRDD);
@@ -216,36 +216,36 @@ public class SoftwareExporterJob {
                 y.getDocumentToSoftwareUrlWithMeta().getConfidenceLevel() ? x : y;
     }
 
-    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<SoftwareExportMetadata> rdd, String collectedFromValue) {
+    private static JavaPairRDD<Text, Text> relationsToExport(JavaRDD<SoftwareExportMetadata> rdd, String collectedFromKey) {
         return AtomicActionSerializationUtils
                 .mapActionToText(rdd
                         .flatMap(x -> {
                             String documentId = x.getDocumentId();
                             String softwareId = x.getSoftwareId();
                             Float confidenceLevel = x.getDocumentToSoftwareUrlWithMeta().getConfidenceLevel();
-                            return buildRelationActions(documentId, softwareId, confidenceLevel, collectedFromValue).iterator();
+                            return buildRelationActions(documentId, softwareId, confidenceLevel, collectedFromKey).iterator();
                         })
                 );
     }
 
     private static List<AtomicAction<Relation>> buildRelationActions(String documentId, String softwareId,
-            Float confidenceLevel, String collectedFromValue) {
+            Float confidenceLevel, String collectedFromKey) {
         AtomicAction<Relation> forwardAction = new AtomicAction<>();
         forwardAction.setClazz(Relation.class);
-        forwardAction.setPayload(buildRelation(documentId, softwareId, confidenceLevel, collectedFromValue));
+        forwardAction.setPayload(buildRelation(documentId, softwareId, confidenceLevel, collectedFromKey));
 
         AtomicAction<Relation> reverseAction = new AtomicAction<>();
         reverseAction.setClazz(Relation.class);
-        reverseAction.setPayload(buildRelation(softwareId, documentId, confidenceLevel, collectedFromValue));
+        reverseAction.setPayload(buildRelation(softwareId, documentId, confidenceLevel, collectedFromKey));
 
         return Arrays.asList(forwardAction, reverseAction);
     }
 
-    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromValue) {
+    private static Relation buildRelation(String source, String target, Float confidenceLevel, String collectedFromKey) {
         return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
                 OafConstants.SUBREL_TYPE_RELATIONSHIP, OafConstants.REL_CLASS_ISRELATEDTO, 
                 BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE),
-                collectedFromValue);
+                collectedFromKey);
     }
 
     private static JavaPairRDD<Text, Text> entitiesToExport(JavaRDD<SoftwareExportMetadata> rdd) {
@@ -443,7 +443,7 @@ public class SoftwareExporterJob {
         @Parameter(names = "-trustLevelThreshold", required = false)
         private String trustLevelThreshold;
         
-        @Parameter(names = "-collectedFromValue", required = true)
-        private String collectedFromValue;
+        @Parameter(names = "-collectedFromKey", required = true)
+        private String collectedFromKey;
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractBuilderModule.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractBuilderModule.java
@@ -1,11 +1,12 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
+import org.apache.avro.specific.SpecificRecord;
+
 import com.google.common.base.Preconditions;
+
 import eu.dnetlib.dhp.schema.oaf.DataInfo;
 import eu.dnetlib.dhp.schema.oaf.Oaf;
 import eu.dnetlib.iis.common.model.conversion.ConfidenceAndTrustLevelConversionUtils;
-import org.apache.avro.specific.SpecificRecord;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Abstract builder module.
@@ -58,24 +59,9 @@ public abstract class AbstractBuilderModule<S extends SpecificRecord, T extends 
      * @throws TrustLevelThresholdExceededException thrown when trust level threshold was exceeded
      */
     protected DataInfo buildInference(float confidenceLevel) throws TrustLevelThresholdExceededException {
-        return buildInference(confidenceLevel, null);
-    }
-    
-    /**
-     * Returns {@link DataInfo} with inference details. Confidence level will be normalized to trust level.
-     * 
-     * @param confidenceLevel confidence level which will be normalized to trust level
-     * @throws TrustLevelThresholdExceededException thrown when trust level threshold was exceeded
-     */
-    protected DataInfo buildInference(float confidenceLevel, String inferenceProvenance) throws TrustLevelThresholdExceededException {
         float currentTrustLevel = ConfidenceAndTrustLevelConversionUtils.confidenceLevelToTrustLevel(confidenceLevel);
         if (trustLevelThreshold == null || currentTrustLevel >= trustLevelThreshold) {
-            if (StringUtils.isNotBlank(inferenceProvenance)) {
-                return buildInferenceForTrustLevel(BuilderModuleHelper.getDecimalFormat().format(currentTrustLevel), 
-                        inferenceProvenance);
-            } else {
-                return buildInferenceForTrustLevel(BuilderModuleHelper.getDecimalFormat().format(currentTrustLevel));    
-            }
+            return buildInferenceForTrustLevel(BuilderModuleHelper.getDecimalFormat().format(currentTrustLevel));    
         } else {
             throw new TrustLevelThresholdExceededException();
         }
@@ -86,14 +72,6 @@ public abstract class AbstractBuilderModule<S extends SpecificRecord, T extends 
      * 
      */
     protected DataInfo buildInferenceForTrustLevel(String trustLevel) {
-        return buildInferenceForTrustLevel(trustLevel, inferenceProvenance);
-    }
-
-    /**
-     * Returns {@link DataInfo} with inference details.
-     * 
-     */
-    protected DataInfo buildInferenceForTrustLevel(String trustLevel, String inferenceProvenance) {
         return BuilderModuleHelper.buildInferenceForTrustLevel(trustLevel, inferenceProvenance);
     }
     

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
@@ -19,15 +19,15 @@ import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
 public abstract class AbstractRelationBuilderModule <S extends SpecificRecord> extends AbstractBuilderModule<S, Relation> {
 
     /**
-     * Value to be exported in {@link Relation}{@link #collectedFromValue}.
+     * Value to be exported in {@link Relation}{@link #collectedFromKey}.
      */
-    private final String collectedFromValue;
+    private final String collectedFromKey;
  
     // ------------------------ CONSTRUCTORS --------------------------
     
-    public AbstractRelationBuilderModule(Float trustLevelThreshold, String inferenceProvenance, String collectedFromValue) {
+    public AbstractRelationBuilderModule(Float trustLevelThreshold, String inferenceProvenance, String collectedFromKey) {
         super(trustLevelThreshold, inferenceProvenance);
-        this.collectedFromValue = collectedFromValue;
+        this.collectedFromKey = collectedFromKey;
     }
     
     // ----------------------------- LOGIC --------------------------------
@@ -51,7 +51,7 @@ public abstract class AbstractRelationBuilderModule <S extends SpecificRecord> e
         DataInfo dataInfo = confidenceLevel != null ? buildInference(confidenceLevel)
                 : buildInferenceForTrustLevel(StaticConfigurationProvider.ACTION_TRUST_0_9);
         return BuilderModuleHelper.createRelation(source, target, relType, subRelType, relClass,
-                properties, dataInfo, collectedFromValue);
+                properties, dataInfo, collectedFromKey);
     }
     
     /**

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
@@ -1,0 +1,113 @@
+package eu.dnetlib.iis.wf.export.actionmanager.module;
+
+import java.util.List;
+
+import org.apache.avro.specific.SpecificRecord;
+
+import eu.dnetlib.dhp.schema.action.AtomicAction;
+import eu.dnetlib.dhp.schema.oaf.DataInfo;
+import eu.dnetlib.dhp.schema.oaf.KeyValue;
+import eu.dnetlib.dhp.schema.oaf.Relation;
+import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
+
+/**
+ * Abstract {@link Relation} builder module.
+ * 
+ * @author mhorst
+ *
+ */
+public abstract class AbstractRelationBuilderModule <S extends SpecificRecord> extends AbstractBuilderModule<S, Relation> {
+
+    /**
+     * Value to be exported in {@link Relation}{@link #collectedFromValue}.
+     */
+    private final String collectedFromValue;
+ 
+    // ------------------------ CONSTRUCTORS --------------------------
+    
+    public AbstractRelationBuilderModule(Float trustLevelThreshold, String inferenceProvenance, String collectedFromValue) {
+        super(trustLevelThreshold, inferenceProvenance);
+        this.collectedFromValue = collectedFromValue;
+    }
+    
+    // ----------------------------- LOGIC --------------------------------
+    
+    /**
+     * Creates {@link Relation} initialized with basic metadata.
+     * 
+     * @param source          relation source
+     * @param target          relation target
+     * @param relType         relation type
+     * @param subRelType      relation sub-type
+     * @param relClass        relation class
+     * @param confidenceLevel an input for trust level calculation, trust level set
+     *                        to {@link StaticConfigurationProvider#ACTION_TRUST_0_9}
+     *                        when confidence level is null
+     * @param properties      relation properties
+     * @throws TrustLevelThresholdExceededException when trust level threshold exceeded
+     */
+    protected Relation createRelation(String source, String target, String relType, String subRelType, String relClass,
+            Float confidenceLevel, List<KeyValue> properties) throws TrustLevelThresholdExceededException {
+        DataInfo dataInfo = confidenceLevel != null ? buildInference(confidenceLevel)
+                : buildInferenceForTrustLevel(StaticConfigurationProvider.ACTION_TRUST_0_9);
+        return BuilderModuleHelper.createRelation(source, target, relType, subRelType, relClass,
+                properties, dataInfo, collectedFromValue);
+    }
+    
+    /**
+     * Creates an {@link AtomicAction} with {@link Relation} payload.
+     * @param source relation source
+     * @param target relation target
+     * @param relType relation type
+     * @param subRelType relation sub-type
+     * @param relClass relation class
+     * @param confidenceLevel confidence level to be used when calculating trust level
+     * @throws TrustLevelThresholdExceededException when trust level threshold exceeded
+     */
+    protected AtomicAction<Relation> createAtomicActionWithRelation(String source, String target, String relType,
+            String subRelType, String relClass, Float confidenceLevel) throws TrustLevelThresholdExceededException {
+        return createAtomicActionWithRelation(source, target, relType, subRelType, relClass, confidenceLevel, null);
+    }
+    
+    /**
+     * Creates an {@link AtomicAction} with {@link Relation} payload.
+     * @param source relation source
+     * @param target relation target
+     * @param relType relation type
+     * @param subRelType relation sub-type
+     * @param relClass relation class
+     * @param confidenceLevel confidence level to be used when calculating trust level
+     * @param properties relation properties
+     */
+    protected AtomicAction<Relation> createAtomicActionWithRelation(String source, String target, String relType,
+            String subRelType, String relClass, List<KeyValue> properties) {
+        AtomicAction<Relation> action = new AtomicAction<>();
+        action.setClazz(Relation.class);
+        try {
+            action.setPayload(createRelation(source, target, relType, subRelType, relClass, null, properties));
+        } catch (TrustLevelThresholdExceededException e) {
+            throw new RuntimeException(e);
+        }
+        return action;
+    }
+    
+    /**
+     * Creates an {@link AtomicAction} with {@link Relation} payload.
+     * @param source relation source
+     * @param target relation target
+     * @param relType relation type
+     * @param subRelType relation sub-type
+     * @param relClass relation class
+     * @param properties relation properties
+     * @throws TrustLevelThresholdExceededException when trust level threshold exceeded
+     */
+    protected AtomicAction<Relation> createAtomicActionWithRelation(String source, String target, String relType,
+            String subRelType, String relClass, Float confidenceLevel, List<KeyValue> properties) throws TrustLevelThresholdExceededException {
+        AtomicAction<Relation> action = new AtomicAction<>();
+        action.setClazz(Relation.class);
+        action.setPayload(createRelation(source, target, relType, subRelType, relClass, confidenceLevel, properties));
+        return action;
+    }
+
+    
+}

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/AbstractRelationBuilderModule.java
@@ -34,6 +34,23 @@ public abstract class AbstractRelationBuilderModule <S extends SpecificRecord> e
     
     /**
      * Creates {@link Relation} initialized with basic metadata.
+     *
+     * @param source          relation source
+     * @param target          relation target
+     * @param relType         relation type
+     * @param subRelType      relation sub-type
+     * @param relClass        relation class
+     * @param properties      relation properties
+     */
+    protected Relation createRelation(String source, String target, String relType, String subRelType, String relClass,
+            List<KeyValue> properties)  {
+        DataInfo dataInfo = buildInferenceForTrustLevel(StaticConfigurationProvider.ACTION_TRUST_0_9);
+        return BuilderModuleHelper.createRelation(source, target, relType, subRelType, relClass,
+                properties, dataInfo, collectedFromKey);
+    }
+
+    /**
+     * Creates {@link Relation} initialized with basic metadata.
      * 
      * @param source          relation source
      * @param target          relation target
@@ -76,30 +93,31 @@ public abstract class AbstractRelationBuilderModule <S extends SpecificRecord> e
      * @param relType relation type
      * @param subRelType relation sub-type
      * @param relClass relation class
-     * @param confidenceLevel confidence level to be used when calculating trust level
      * @param properties relation properties
      */
     protected AtomicAction<Relation> createAtomicActionWithRelation(String source, String target, String relType,
             String subRelType, String relClass, List<KeyValue> properties) {
         AtomicAction<Relation> action = new AtomicAction<>();
         action.setClazz(Relation.class);
-        try {
-            action.setPayload(createRelation(source, target, relType, subRelType, relClass, null, properties));
-        } catch (TrustLevelThresholdExceededException e) {
-            throw new RuntimeException(e);
-        }
+        action.setPayload(createRelation(source, target, relType, subRelType, relClass, properties));
         return action;
     }
     
     /**
      * Creates an {@link AtomicAction} with {@link Relation} payload.
-     * @param source relation source
-     * @param target relation target
-     * @param relType relation type
-     * @param subRelType relation sub-type
-     * @param relClass relation class
-     * @param properties relation properties
-     * @throws TrustLevelThresholdExceededException when trust level threshold exceeded
+     * 
+     * @param source          relation source
+     * @param target          relation target
+     * @param relType         relation type
+     * @param subRelType      relation sub-type
+     * @param relClass        relation class
+     * @param confidenceLevel an input for trust level calculation, trust level set
+     *                        to
+     *                        {@link StaticConfigurationProvider#ACTION_TRUST_0_9}
+     *                        when confidence level is null
+     * @param properties      relation properties
+     * @throws TrustLevelThresholdExceededException when trust level threshold
+     *                                              exceeded
      */
     protected AtomicAction<Relation> createAtomicActionWithRelation(String source, String target, String relType,
             String subRelType, String relClass, Float confidenceLevel, List<KeyValue> properties) throws TrustLevelThresholdExceededException {

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelper.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelper.java
@@ -37,11 +37,11 @@ public class BuilderModuleHelper {
      * @param subRelType      relation sub-type
      * @param relClass        relation class
      * @param dataInfo        {@link DataInfo} describing relation
-     * @param collectedFromValue relation collectedfrom value
+     * @param collectedFromKey relation collectedfrom key
      */
     public static Relation createRelation(String source, String target, String relType, String subRelType,
-            String relClass, DataInfo dataInfo, String collectedFromValue) {
-        return createRelation(source, target, relType, subRelType, relClass, null, dataInfo, collectedFromValue);
+            String relClass, DataInfo dataInfo, String collectedFromKey) {
+        return createRelation(source, target, relType, subRelType, relClass, null, dataInfo, collectedFromKey);
     }
     
     /**
@@ -54,10 +54,10 @@ public class BuilderModuleHelper {
      * @param relClass        relation class
      * @param properties      relation properties
      * @param dataInfo        {@link DataInfo} describing relation
-     * @param collectedFromValue relation collectedfrom value
+     * @param collectedFromKey relation collectedfrom key
      */
     public static Relation createRelation(String source, String target, String relType, String subRelType,
-            String relClass, List<KeyValue> properties, DataInfo dataInfo, String collectedFromValue) {
+            String relClass, List<KeyValue> properties, DataInfo dataInfo, String collectedFromKey) {
         Relation relation = new Relation();
         relation.setSource(source);
         relation.setTarget(target);
@@ -67,18 +67,18 @@ public class BuilderModuleHelper {
         relation.setProperties(properties);
         relation.setDataInfo(dataInfo);
         relation.setLastupdatetimestamp(System.currentTimeMillis());
-        relation.setCollectedfrom(Collections.singletonList(buildCollectedFromKeyValue(collectedFromValue)));
+        relation.setCollectedfrom(Collections.singletonList(buildCollectedFromKeyValue(collectedFromKey)));
         return relation;
     }
     
     /**
      * Returns {@link KeyValue} object with the predefined key and value provided as parameter.
-     * @param collectedFromValue value of {@link KeyValue} object
+     * @param collectedFromKey key of {@link KeyValue} object
      */
-    public static KeyValue buildCollectedFromKeyValue(String collectedFromValue) {
+    public static KeyValue buildCollectedFromKeyValue(String collectedFromKey) {
         KeyValue keyValue = new KeyValue();
-        keyValue.setKey(StaticConfigurationProvider.COLLECTED_FROM_KEY);
-        keyValue.setValue(collectedFromValue);
+        keyValue.setKey(collectedFromKey);
+        keyValue.setValue(StaticConfigurationProvider.COLLECTED_FROM_VALUE);
         return keyValue;
     }
     

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelper.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelper.java
@@ -2,13 +2,18 @@ package eu.dnetlib.iis.wf.export.actionmanager.module;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import eu.dnetlib.dhp.schema.oaf.DataInfo;
+import eu.dnetlib.dhp.schema.oaf.KeyValue;
 import eu.dnetlib.dhp.schema.oaf.Oaf;
 import eu.dnetlib.dhp.schema.oaf.Qualifier;
+import eu.dnetlib.dhp.schema.oaf.Relation;
 import eu.dnetlib.iis.common.InfoSpaceConstants;
 import eu.dnetlib.iis.common.model.conversion.ConfidenceAndTrustLevelConversionUtils;
+import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
 
 /**
  * {@link Oaf} builder helper.
@@ -23,6 +28,59 @@ public class BuilderModuleHelper {
      */
     private static final DecimalFormat decimalFormat = initailizeDecimalFormat();
     
+    /**
+     * Creates {@link Relation} initialized with basic metadata.
+     * 
+     * @param source          relation source
+     * @param target          relation target
+     * @param relType         relation type
+     * @param subRelType      relation sub-type
+     * @param relClass        relation class
+     * @param dataInfo        {@link DataInfo} describing relation
+     * @param collectedFromValue relation collectedfrom value
+     */
+    public static Relation createRelation(String source, String target, String relType, String subRelType,
+            String relClass, DataInfo dataInfo, String collectedFromValue) {
+        return createRelation(source, target, relType, subRelType, relClass, null, dataInfo, collectedFromValue);
+    }
+    
+    /**
+     * Creates {@link Relation} initialized with basic metadata.
+     * 
+     * @param source          relation source
+     * @param target          relation target
+     * @param relType         relation type
+     * @param subRelType      relation sub-type
+     * @param relClass        relation class
+     * @param properties      relation properties
+     * @param dataInfo        {@link DataInfo} describing relation
+     * @param collectedFromValue relation collectedfrom value
+     */
+    public static Relation createRelation(String source, String target, String relType, String subRelType,
+            String relClass, List<KeyValue> properties, DataInfo dataInfo, String collectedFromValue) {
+        Relation relation = new Relation();
+        relation.setSource(source);
+        relation.setTarget(target);
+        relation.setRelType(relType);
+        relation.setSubRelType(subRelType);
+        relation.setRelClass(relClass);
+        relation.setProperties(properties);
+        relation.setDataInfo(dataInfo);
+        relation.setLastupdatetimestamp(System.currentTimeMillis());
+        relation.setCollectedfrom(Collections.singletonList(buildCollectedFromKeyValue(collectedFromValue)));
+        return relation;
+    }
+    
+    /**
+     * Returns {@link KeyValue} object with the predefined key and value provided as parameter.
+     * @param collectedFromValue value of {@link KeyValue} object
+     */
+    public static KeyValue buildCollectedFromKeyValue(String collectedFromValue) {
+        KeyValue keyValue = new KeyValue();
+        keyValue.setKey(StaticConfigurationProvider.COLLECTED_FROM_KEY);
+        keyValue.setValue(collectedFromValue);
+        return keyValue;
+    }
     
     /**
      * Returns {@link DataInfo} with inference details including inferred flag set to true.

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentSimilarityActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentSimilarityActionBuilderModuleFactory.java
@@ -1,7 +1,7 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
 import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_DOCUMENTSSIMILARITY_THRESHOLD;
-import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_KEY;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,7 +48,7 @@ public class DocumentSimilarityActionBuilderModuleFactory extends AbstractAction
             log.info("setting documents similarity exporter threshold to: " + similarityThreshold);
         }
         return new DocumentSimilarityActionBuilderModule(provideTrustLevelThreshold(config), similarityThreshold, 
-                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_KEY, config));
     }
     
     // ------------------------ INNER CLASS --------------------------
@@ -64,10 +64,10 @@ public class DocumentSimilarityActionBuilderModuleFactory extends AbstractAction
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
          * @param similarityThreshold similarity threshold, skipped when null
-         * @param collectedFromValue collectedFrom value to be set for relation
+         * @param collectedFromKey collectedFrom key to be set for relation
          */
-        public DocumentSimilarityActionBuilderModule(Float trustLevelThreshold, Float similarityThreshold, String collectedFromValue) {
-            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
+        public DocumentSimilarityActionBuilderModule(Float trustLevelThreshold, Float similarityThreshold, String collectedFromKey) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromKey);
             this.similarityThreshold = similarityThreshold;
         }
 

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentSimilarityActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentSimilarityActionBuilderModuleFactory.java
@@ -1,6 +1,7 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
 import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_DOCUMENTSSIMILARITY_THRESHOLD;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,7 +16,6 @@ import eu.dnetlib.dhp.schema.oaf.Relation;
 import eu.dnetlib.iis.common.WorkflowRuntimeParameters;
 import eu.dnetlib.iis.documentssimilarity.schemas.DocumentSimilarity;
 import eu.dnetlib.iis.wf.export.actionmanager.OafConstants;
-import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
 
 /**
  * {@link DocumentSimilarity} based action builder module.
@@ -47,24 +47,27 @@ public class DocumentSimilarityActionBuilderModuleFactory extends AbstractAction
             similarityThreshold = Float.valueOf(thresholdStr);
             log.info("setting documents similarity exporter threshold to: " + similarityThreshold);
         }
-        return new DocumentSimilarityActionBuilderModule(provideTrustLevelThreshold(config), similarityThreshold);
+        return new DocumentSimilarityActionBuilderModule(provideTrustLevelThreshold(config), similarityThreshold, 
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
     }
     
     // ------------------------ INNER CLASS --------------------------
 
-    class DocumentSimilarityActionBuilderModule extends AbstractBuilderModule<DocumentSimilarity, Relation> {
+    class DocumentSimilarityActionBuilderModule extends AbstractRelationBuilderModule<DocumentSimilarity> {
 
         
         private final Float similarityThreshold;
+
 
         // ------------------------ CONSTRUCTORS --------------------------
 
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
          * @param similarityThreshold similarity threshold, skipped when null
+         * @param collectedFromValue collectedFrom value to be set for relation
          */
-        public DocumentSimilarityActionBuilderModule(Float trustLevelThreshold, Float similarityThreshold) {
-            super(trustLevelThreshold, buildInferenceProvenance());
+        public DocumentSimilarityActionBuilderModule(Float trustLevelThreshold, Float similarityThreshold, String collectedFromValue) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
             this.similarityThreshold = similarityThreshold;
         }
 
@@ -90,20 +93,9 @@ public class DocumentSimilarityActionBuilderModuleFactory extends AbstractAction
          * Creates similarity related actions.
          */
         private AtomicAction<Relation> createAction(String source, String target, float score, String relClass) {
-            AtomicAction<Relation> action = new AtomicAction<>();
-            action.setClazz(Relation.class);
-            
-            Relation relation = new Relation();
-            relation.setSource(source);
-            relation.setTarget(target);
-            relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-            relation.setSubRelType(OafConstants.SUBREL_TYPE_SIMILARITY);
-            relation.setRelClass(relClass);
-            relation.setDataInfo(buildInferenceForTrustLevel(StaticConfigurationProvider.ACTION_TRUST_0_9));
-            relation.setLastupdatetimestamp(System.currentTimeMillis());
-            relation.setProperties(Collections.singletonList(buildSimilarityLevel(score)));
-            action.setPayload(relation);
-            return action;
+            return createAtomicActionWithRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                    OafConstants.SUBREL_TYPE_SIMILARITY, relClass, 
+                    Collections.singletonList(buildSimilarityLevel(score)));
         }
 
         private KeyValue buildSimilarityLevel(float score) {

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDataSetActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDataSetActionBuilderModuleFactory.java
@@ -1,5 +1,7 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -7,6 +9,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import eu.dnetlib.dhp.schema.action.AtomicAction;
 import eu.dnetlib.dhp.schema.oaf.Relation;
+import eu.dnetlib.iis.common.WorkflowRuntimeParameters;
 import eu.dnetlib.iis.referenceextraction.dataset.schemas.DocumentToDataSet;
 import eu.dnetlib.iis.wf.export.actionmanager.OafConstants;
 
@@ -29,21 +32,23 @@ public class DocumentToDataSetActionBuilderModuleFactory extends AbstractActionB
 
     @Override
     public ActionBuilderModule<DocumentToDataSet, Relation> instantiate(Configuration config) {
-        return new DocumentToDataSetActionBuilderModule(provideTrustLevelThreshold(config));
+        return new DocumentToDataSetActionBuilderModule(provideTrustLevelThreshold(config), 
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
     }
 
     // ------------------------ INNER CLASS --------------------------
     
-    class DocumentToDataSetActionBuilderModule extends AbstractBuilderModule<DocumentToDataSet, Relation> {
+    class DocumentToDataSetActionBuilderModule extends AbstractRelationBuilderModule<DocumentToDataSet> {
 
         
         // ------------------------ CONSTRUCTORS --------------------------
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
+         * @param collectedFromValue collectedFrom value to be set for relation
          */
-        public DocumentToDataSetActionBuilderModule(Float trustLevelThreshold) {
-            super(trustLevelThreshold, buildInferenceProvenance());
+        public DocumentToDataSetActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
         }
 
         // ------------------------ LOGIC --------------------------
@@ -64,21 +69,8 @@ public class DocumentToDataSetActionBuilderModuleFactory extends AbstractActionB
          */
         private AtomicAction<Relation> createAction(String source, String target, float confidenceLevel,
                 String relClass) throws TrustLevelThresholdExceededException {
-            AtomicAction<Relation> action = new AtomicAction<>();
-            action.setClazz(Relation.class);
-
-            Relation relation = new Relation();
-            relation.setSource(source);
-            relation.setTarget(target);
-            relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-            relation.setSubRelType(OafConstants.SUBREL_TYPE_RELATIONSHIP);
-            relation.setRelClass(relClass);
-            relation.setDataInfo(buildInference(confidenceLevel));
-            relation.setLastupdatetimestamp(System.currentTimeMillis());
-            
-            action.setPayload(relation);
-            
-            return action;
+            return createAtomicActionWithRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                    OafConstants.SUBREL_TYPE_RELATIONSHIP, relClass, confidenceLevel);
         }
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDataSetActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToDataSetActionBuilderModuleFactory.java
@@ -1,6 +1,6 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_KEY;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +33,7 @@ public class DocumentToDataSetActionBuilderModuleFactory extends AbstractActionB
     @Override
     public ActionBuilderModule<DocumentToDataSet, Relation> instantiate(Configuration config) {
         return new DocumentToDataSetActionBuilderModule(provideTrustLevelThreshold(config), 
-                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_KEY, config));
     }
 
     // ------------------------ INNER CLASS --------------------------
@@ -45,10 +45,10 @@ public class DocumentToDataSetActionBuilderModuleFactory extends AbstractActionB
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param collectedFromValue collectedFrom value to be set for relation
+         * @param collectedFromKey collectedFrom key to be set for relation
          */
-        public DocumentToDataSetActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
-            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
+        public DocumentToDataSetActionBuilderModule(Float trustLevelThreshold, String collectedFromKey) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromKey);
         }
 
         // ------------------------ LOGIC --------------------------

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToProjectActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToProjectActionBuilderModuleFactory.java
@@ -1,6 +1,6 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_KEY;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +33,7 @@ public class DocumentToProjectActionBuilderModuleFactory extends AbstractActionB
     @Override
     public ActionBuilderModule<DocumentToProject, Relation> instantiate(Configuration config) {
         return new DocumentToProjectActionBuilderModule(provideTrustLevelThreshold(config),
-                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_KEY, config));
     }
     
     // ------------------------ INNER CLASS ----------------------------
@@ -45,10 +45,10 @@ public class DocumentToProjectActionBuilderModuleFactory extends AbstractActionB
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param collectedFromValue collectedFrom value to be set for relation
+         * @param collectedFromKey collectedFrom key to be set for relation
          */
-        public DocumentToProjectActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
-            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
+        public DocumentToProjectActionBuilderModule(Float trustLevelThreshold, String collectedFromKey) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromKey);
         }
         
         // ------------------------ LOGIC ----------------------------------

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToProjectActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToProjectActionBuilderModuleFactory.java
@@ -1,5 +1,7 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -7,6 +9,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import eu.dnetlib.dhp.schema.action.AtomicAction;
 import eu.dnetlib.dhp.schema.oaf.Relation;
+import eu.dnetlib.iis.common.WorkflowRuntimeParameters;
 import eu.dnetlib.iis.referenceextraction.project.schemas.DocumentToProject;
 import eu.dnetlib.iis.wf.export.actionmanager.OafConstants;
 
@@ -29,23 +32,23 @@ public class DocumentToProjectActionBuilderModuleFactory extends AbstractActionB
     
     @Override
     public ActionBuilderModule<DocumentToProject, Relation> instantiate(Configuration config) {
-        return new DocumentToProjectActionBuilderModule(provideTrustLevelThreshold(config));
+        return new DocumentToProjectActionBuilderModule(provideTrustLevelThreshold(config),
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
     }
     
     // ------------------------ INNER CLASS ----------------------------
     
-    class DocumentToProjectActionBuilderModule extends AbstractBuilderModule<DocumentToProject, Relation> {
+    class DocumentToProjectActionBuilderModule extends AbstractRelationBuilderModule<DocumentToProject> {
 
 
         // ------------------------ CONSTRUCTORS --------------------------
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param agent action manager agent details
-         * @param actionSetId action set identifier
+         * @param collectedFromValue collectedFrom value to be set for relation
          */
-        public DocumentToProjectActionBuilderModule(Float trustLevelThreshold) {
-            super(trustLevelThreshold, buildInferenceProvenance());
+        public DocumentToProjectActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
         }
         
         // ------------------------ LOGIC ----------------------------------
@@ -65,20 +68,8 @@ public class DocumentToProjectActionBuilderModuleFactory extends AbstractActionB
          * Creates similarity related actions.
          */
         private AtomicAction<Relation> createAction(String source, String target, float confidenceLevel, String relClass) throws TrustLevelThresholdExceededException {
-            AtomicAction<Relation> action = new AtomicAction<>();
-            action.setClazz(Relation.class);
-            
-            Relation relation = new Relation();
-            relation.setSource(source);
-            relation.setTarget(target);
-            relation.setRelType(OafConstants.REL_TYPE_RESULT_PROJECT);
-            relation.setSubRelType(OafConstants.SUBREL_TYPE_OUTCOME);
-            relation.setRelClass(relClass);
-            relation.setDataInfo(buildInference(confidenceLevel, getInferenceProvenance()));
-            relation.setLastupdatetimestamp(System.currentTimeMillis());
-            
-            action.setPayload(relation);
-            return action;
+            return createAtomicActionWithRelation(source, target, OafConstants.REL_TYPE_RESULT_PROJECT,
+                    OafConstants.SUBREL_TYPE_OUTCOME, relClass, confidenceLevel);
         }
         
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToServiceActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/DocumentToServiceActionBuilderModuleFactory.java
@@ -1,6 +1,6 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_KEY;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +33,7 @@ public class DocumentToServiceActionBuilderModuleFactory extends AbstractActionB
     @Override
     public ActionBuilderModule<DocumentToService, Relation> instantiate(Configuration config) {
         return new DocumentToServiceActionBuilderModule(provideTrustLevelThreshold(config),
-                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_KEY, config));
     }
 
     // ------------------------ INNER CLASS --------------------------
@@ -45,10 +45,10 @@ public class DocumentToServiceActionBuilderModuleFactory extends AbstractActionB
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param collectedFromValue collectedFrom value to be set for relation
+         * @param collectedFromKey collectedFrom key to be set for relation
          */
-        public DocumentToServiceActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
-            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
+        public DocumentToServiceActionBuilderModule(Float trustLevelThreshold, String collectedFromKey) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromKey);
         }
 
         // ------------------------ LOGIC --------------------------

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/MatchedOrganizationActionBuilderModuleFactory.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/module/MatchedOrganizationActionBuilderModuleFactory.java
@@ -1,6 +1,6 @@
 package eu.dnetlib.iis.wf.export.actionmanager.module;
 
-import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_VALUE;
+import static eu.dnetlib.iis.wf.export.actionmanager.ExportWorkflowRuntimeParameters.EXPORT_RELATION_COLLECTEDFROM_KEY;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public class MatchedOrganizationActionBuilderModuleFactory extends AbstractActio
     @Override
     public ActionBuilderModule<MatchedOrganizationWithProvenance, Relation> instantiate(Configuration config) {
         return new MatchedOrganizationActionBuilderModule(provideTrustLevelThreshold(config),
-                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_VALUE, config));
+                WorkflowRuntimeParameters.getParamValue(EXPORT_RELATION_COLLECTEDFROM_KEY, config));
     }
     
     // ------------------------ INNER CLASS ---------------------------------
@@ -50,10 +50,10 @@ public class MatchedOrganizationActionBuilderModuleFactory extends AbstractActio
         
         /**
          * @param trustLevelThreshold trust level threshold or null when all records should be exported
-         * @param collectedFromValue collectedFrom value to be set for relation
+         * @param collectedFromKey collectedFrom key to be set for relation
          */
-        public MatchedOrganizationActionBuilderModule(Float trustLevelThreshold, String collectedFromValue) {
-            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromValue);
+        public MatchedOrganizationActionBuilderModule(Float trustLevelThreshold, String collectedFromKey) {
+            super(trustLevelThreshold, buildInferenceProvenance(), collectedFromKey);
         }
 
         // ------------------------ LOGIC ---------------------------------

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
@@ -36,6 +36,8 @@ public class CitationRelationExporterJob {
         Float confidenceLevelThreshold = ConfidenceLevelUtils
                 .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
         logger.info("Confidence level threshold to be used: {}.", confidenceLevelThreshold);
+        
+        final String collectedFromValue = params.collectedFromValue;
 
         runWithSparkSession(new SparkConf(), params.isSparkSessionShared, spark -> {
             clearOutput(spark, params.outputRelationPath, params.outputReportPath);
@@ -45,7 +47,7 @@ public class CitationRelationExporterJob {
             UserDefinedFunction isValidConfidenceLevel = udf((UDF1<Float, Boolean>) confidenceLevel ->
                             ConfidenceLevelUtils.isValidConfidenceLevel(confidenceLevel, confidenceLevelThreshold),
                     DataTypes.BooleanType);
-            Dataset<Relation> relations = processCitations(citations, isValidConfidenceLevel);
+            Dataset<Relation> relations = processCitations(citations, isValidConfidenceLevel, collectedFromValue);
             relations.cache();
 
             Dataset<Text> serializedActions = relationsToSerializedActions(relations);
@@ -72,5 +74,8 @@ public class CitationRelationExporterJob {
 
         @Parameter(names = "-trustLevelThreshold", required = true)
         private String trustLevelThreshold;
+        
+        @Parameter(names = "-collectedFromValue", required = true)
+        private String collectedFromValue;
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJob.java
@@ -37,7 +37,7 @@ public class CitationRelationExporterJob {
                 .evaluateConfidenceLevelThreshold(params.trustLevelThreshold);
         logger.info("Confidence level threshold to be used: {}.", confidenceLevelThreshold);
         
-        final String collectedFromValue = params.collectedFromValue;
+        final String collectedFromKey = params.collectedFromKey;
 
         runWithSparkSession(new SparkConf(), params.isSparkSessionShared, spark -> {
             clearOutput(spark, params.outputRelationPath, params.outputReportPath);
@@ -47,7 +47,7 @@ public class CitationRelationExporterJob {
             UserDefinedFunction isValidConfidenceLevel = udf((UDF1<Float, Boolean>) confidenceLevel ->
                             ConfidenceLevelUtils.isValidConfidenceLevel(confidenceLevel, confidenceLevelThreshold),
                     DataTypes.BooleanType);
-            Dataset<Relation> relations = processCitations(citations, isValidConfidenceLevel, collectedFromValue);
+            Dataset<Relation> relations = processCitations(citations, isValidConfidenceLevel, collectedFromKey);
             relations.cache();
 
             Dataset<Text> serializedActions = relationsToSerializedActions(relations);
@@ -75,7 +75,7 @@ public class CitationRelationExporterJob {
         @Parameter(names = "-trustLevelThreshold", required = true)
         private String trustLevelThreshold;
         
-        @Parameter(names = "-collectedFromValue", required = true)
-        private String collectedFromValue;
+        @Parameter(names = "-collectedFromKey", required = true)
+        private String collectedFromKey;
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtils.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtils.java
@@ -37,8 +37,8 @@ public class CitationRelationExporterUtils {
     private CitationRelationExporterUtils() {
     }
 
-    public static Dataset<Relation> processCitations(Dataset<Row> citations,
-                                                     UserDefinedFunction isValidConfidenceLevel) {
+    public static Dataset<Relation> processCitations(Dataset<Row> citations, UserDefinedFunction isValidConfidenceLevel,
+            final String collectedFromValue) {
         return documentIdAndCitationEntry(citations)
                 .select(
                         col("documentId"),
@@ -51,7 +51,7 @@ public class CitationRelationExporterUtils {
                 .groupBy(col("documentId"), col("destinationDocumentId"))
                 .agg(max(col("confidenceLevel")).as("confidenceLevel"))
                 .as(Encoders.bean(DocumentRelation.class))
-                .flatMap(toRelationFlatMapFn(), Encoders.kryo(Relation.class));
+                .flatMap(toRelationFlatMapFn(collectedFromValue), Encoders.kryo(Relation.class));
     }
 
     private static Dataset<Row> documentIdAndCitationEntry(Dataset<Row> citations) {
@@ -60,30 +60,27 @@ public class CitationRelationExporterUtils {
                         explode(col("citations")).as("citationEntry"));
     }
 
-    private static FlatMapFunction<DocumentRelation, Relation> toRelationFlatMapFn() {
+    private static FlatMapFunction<DocumentRelation, Relation> toRelationFlatMapFn(final String collectedFromValue) {
         return (FlatMapFunction<DocumentRelation, Relation>) documentRelation -> {
             Relation forwardRelation = buildRelation(documentRelation.documentId,
                     documentRelation.destinationDocumentId,
                     OafConstants.REL_CLASS_CITES,
-                    documentRelation.confidenceLevel);
+                    documentRelation.confidenceLevel,
+                    collectedFromValue);
             Relation backwardRelation = buildRelation(documentRelation.destinationDocumentId,
                     documentRelation.documentId,
                     OafConstants.REL_CLASS_ISCITEDBY,
-                    documentRelation.confidenceLevel);
+                    documentRelation.confidenceLevel,
+                    collectedFromValue);
             return Stream.of(forwardRelation, backwardRelation).iterator();
         };
     }
 
-    private static Relation buildRelation(String source, String target, String relClass, Float confidenceLevel) {
-        Relation relation = new Relation();
-        relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-        relation.setSubRelType(OafConstants.SUBREL_TYPE_CITATION);
-        relation.setRelClass(relClass);
-        relation.setSource(source);
-        relation.setTarget(target);
-        relation.setDataInfo(BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE));
-        relation.setLastupdatetimestamp(System.currentTimeMillis());
-        return relation;
+    private static Relation buildRelation(String source, String target, String relClass, Float confidenceLevel, String collectedFromValue) {
+        return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                OafConstants.SUBREL_TYPE_CITATION, relClass,
+                BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, INFERENCE_PROVENANCE),
+                collectedFromValue);
     }
 
     public static class DocumentRelation {

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/oozie_app/workflow.xml
@@ -32,9 +32,9 @@
             </description>
         </property>
         <property>
-            <name>collectedfrom_value</name>
+            <name>collectedfrom_key</name>
             <description>
-                datasource identifier to be stored in Relation#collectedfrom[].value
+                datasource identifier to be stored in Relation#collectedfrom[].key
             </description>
         </property>
         <property>
@@ -156,7 +156,7 @@
             <arg>-inputDocumentToPatentPath=${input_document_to_patent}</arg>
             <arg>-inputPatentPath=${input_patent}</arg>
             <arg>-trustLevelThreshold=${trust_level_threshold_document_patent}</arg>
-            <arg>-collectedFromValue=${collectedfrom_value}</arg>
+            <arg>-collectedFromKey=${collectedfrom_key}</arg>
             <arg>-patentDateOfCollection=${patent_date_of_collection}</arg>
             <arg>-patentEpoUrlRoot=${patent_epo_url_root}</arg>
             <arg>-outputRelationPath=${output_root_relations}/${action_set_id_document_patent}</arg>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/oozie_app/workflow.xml
@@ -32,6 +32,12 @@
             </description>
         </property>
         <property>
+            <name>collectedfrom_value</name>
+            <description>
+                datasource identifier to be stored in Relation#collectedfrom[].value
+            </description>
+        </property>
+        <property>
             <name>patent_date_of_collection</name>
             <description>
                 date of collection of patent file formatted as yyyy-MM-dd'T'HH:mm
@@ -150,6 +156,7 @@
             <arg>-inputDocumentToPatentPath=${input_document_to_patent}</arg>
             <arg>-inputPatentPath=${input_patent}</arg>
             <arg>-trustLevelThreshold=${trust_level_threshold_document_patent}</arg>
+            <arg>-collectedFromValue=${collectedfrom_value}</arg>
             <arg>-patentDateOfCollection=${patent_date_of_collection}</arg>
             <arg>-patentEpoUrlRoot=${patent_epo_url_root}</arg>
             <arg>-outputRelationPath=${output_root_relations}/${action_set_id_document_patent}</arg>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/oozie_app/workflow.xml
@@ -27,6 +27,10 @@
             <description>document_software_url trust level threshold</description>
         </property>
         <property>
+            <name>collectedfrom_value</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+        </property>
+        <property>
             <name>output_root_entities</name>
             <description>root directory for storing ${action_set_id_entity_software} subdirectories with exported actionset</description>
         </property>
@@ -120,6 +124,7 @@
             </spark-opts>
 
             <arg>-trustLevelThreshold=${trust_level_threshold_document_software_url}</arg>
+            <arg>-collectedFromValue=${collectedfrom_value}</arg>
 
             <arg>-inputDocumentToSoftwareUrlPath=${input_document_to_software_url}</arg>
             <arg>-inputDocumentMetadataPath=${input_document_metadata}</arg>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/oozie_app/workflow.xml
@@ -27,8 +27,8 @@
             <description>document_software_url trust level threshold</description>
         </property>
         <property>
-            <name>collectedfrom_value</name>
-            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+            <name>collectedfrom_key</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].key</description>
         </property>
         <property>
             <name>output_root_entities</name>
@@ -124,7 +124,7 @@
             </spark-opts>
 
             <arg>-trustLevelThreshold=${trust_level_threshold_document_software_url}</arg>
-            <arg>-collectedFromValue=${collectedfrom_value}</arg>
+            <arg>-collectedFromKey=${collectedfrom_key}</arg>
 
             <arg>-inputDocumentToSoftwareUrlPath=${input_document_to_software_url}</arg>
             <arg>-inputDocumentMetadataPath=${input_document_metadata}</arg>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/oozie_app/workflow.xml
@@ -26,8 +26,8 @@
             <description>trust level threshold of exported data</description>
         </property>
         <property>
-            <name>collectedfrom_value</name>
-            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+            <name>collectedfrom_key</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].key</description>
         </property>
 
         <property>
@@ -107,7 +107,7 @@
             <arg>-outputRelationPath=${output_root_relations}/${action_set_id_citation_relations}</arg>
             <arg>-outputReportPath=${output_report_root_path}/${output_report_relative_path}</arg>
             <arg>-trustLevelThreshold=${trust_level_threshold_document_referencedDocuments}</arg>
-            <arg>-collectedFromValue=${collectedfrom_value}</arg>
+            <arg>-collectedFromKey=${collectedfrom_key}</arg>
         </spark>
         <ok to="end"/>
         <error to="fail"/>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/oozie_app/workflow.xml
@@ -25,6 +25,10 @@
             <name>trust_level_threshold_document_referencedDocuments</name>
             <description>trust level threshold of exported data</description>
         </property>
+        <property>
+            <name>collectedfrom_value</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+        </property>
 
         <property>
             <name>sparkDriverMemory</name>
@@ -103,6 +107,7 @@
             <arg>-outputRelationPath=${output_root_relations}/${action_set_id_citation_relations}</arg>
             <arg>-outputReportPath=${output_report_root_path}/${output_report_relative_path}</arg>
             <arg>-trustLevelThreshold=${trust_level_threshold_document_referencedDocuments}</arg>
+            <arg>-collectedFromValue=${collectedfrom_value}</arg>
         </spark>
         <ok to="end"/>
         <error to="fail"/>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -152,7 +152,7 @@
             <description>document to organization trust level threshold</description>
         </property>
         <property>
-            <name>collectedfrom_value</name>
+            <name>collectedfrom_key</name>
             <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
         </property>
         <property>
@@ -279,8 +279,8 @@
                 <value>${trust_level_threshold_matched_doc_organizations}</value>
             </property>
             <property>
-                <name>export.relation.collectedfrom.value</name>
-                <value>${collectedfrom_value}</value>
+                <name>export.relation.collectedfrom.key</name>
+                <value>${collectedfrom_key}</value>
             </property>
         </configuration>
     </global>

--- a/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/main/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/oozie_app/workflow.xml
@@ -152,6 +152,10 @@
             <description>document to organization trust level threshold</description>
         </property>
         <property>
+            <name>collectedfrom_value</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+        </property>
+        <property>
             <name>documentssimilarity_threshold</name>
             <value>$UNDEFINED$</value>
             <description>documents similarity threshold value below which similarity export is omitted</description>
@@ -273,6 +277,10 @@
             <property>
                 <name>export.trust.level.threshold.document_affiliations</name>
                 <value>${trust_level_threshold_matched_doc_organizations}</value>
+            </property>
+            <property>
+                <name>export.relation.collectedfrom.value</name>
+                <value>${collectedfrom_value}</value>
             </property>
         </configuration>
     </global>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
@@ -55,7 +55,7 @@ public class PatentExporterJobTest {
     private static final String PATENT_DATE_OF_COLLECTION = "2019-11-20T23:59";
     private static final String PATENT_EPO_URL_ROOT = "https://register.epo.org/application?number=";
     
-    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
+    private static final String RELATION_COLLECTED_FROM_KEY = "someRepo";
 
     @BeforeEach
     public void before() {
@@ -155,7 +155,7 @@ public class PatentExporterJobTest {
                 .addArg("-inputDocumentToPatentPath", inputDocumentToPatentPath)
                 .addArg("-inputPatentPath", inputPatentPath)
                 .addArg("-trustLevelThreshold", trustLevelThreshold)
-                .addArg("-collectedFromValue", RELATION_COLLECTED_FROM_VALUE)
+                .addArg("-collectedFromKey", RELATION_COLLECTED_FROM_KEY)
                 .addArg("-patentDateOfCollection", PATENT_DATE_OF_COLLECTION)
                 .addArg("-patentEpoUrlRoot", PATENT_EPO_URL_ROOT)
                 .addArg("-outputRelationPath", outputRelationPath)

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/PatentExporterJobTest.java
@@ -54,6 +54,8 @@ public class PatentExporterJobTest {
 
     private static final String PATENT_DATE_OF_COLLECTION = "2019-11-20T23:59";
     private static final String PATENT_EPO_URL_ROOT = "https://register.epo.org/application?number=";
+    
+    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
 
     @BeforeEach
     public void before() {
@@ -153,6 +155,7 @@ public class PatentExporterJobTest {
                 .addArg("-inputDocumentToPatentPath", inputDocumentToPatentPath)
                 .addArg("-inputPatentPath", inputPatentPath)
                 .addArg("-trustLevelThreshold", trustLevelThreshold)
+                .addArg("-collectedFromValue", RELATION_COLLECTED_FROM_VALUE)
                 .addArg("-patentDateOfCollection", PATENT_DATE_OF_COLLECTION)
                 .addArg("-patentEpoUrlRoot", PATENT_EPO_URL_ROOT)
                 .addArg("-outputRelationPath", outputRelationPath)

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJobTest.java
@@ -45,6 +45,8 @@ public class SoftwareExporterJobTest {
     private String outputEntityPath;
     private String reportPath;
 
+    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
+    
     @BeforeEach
     public void before() {
         inputDocumentToSoftwareUrlPath = workingDir.resolve("software_exporter").resolve("input_software").toString();
@@ -160,6 +162,7 @@ public class SoftwareExporterJobTest {
                 .addArg("-inputDocumentToSoftwareUrlPath", inputDocumentToSoftwareUrlPath)
                 .addArg("-inputDocumentMetadataPath", inputDocumentMetadataPath)
                 .addArg("-trustLevelThreshold", trustLevelThreshold)
+                .addArg("-collectedFromValue", RELATION_COLLECTED_FROM_VALUE)
                 .addArg("-outputEntityPath", outputEntityPath)
                 .addArg("-outputRelationPath", outputRelationPath)
                 .addArg("-outputReportPath", reportPath)

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/entity/software/SoftwareExporterJobTest.java
@@ -45,7 +45,7 @@ public class SoftwareExporterJobTest {
     private String outputEntityPath;
     private String reportPath;
 
-    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
+    private static final String RELATION_COLLECTED_FROM_KEY = "someRepo";
     
     @BeforeEach
     public void before() {
@@ -162,7 +162,7 @@ public class SoftwareExporterJobTest {
                 .addArg("-inputDocumentToSoftwareUrlPath", inputDocumentToSoftwareUrlPath)
                 .addArg("-inputDocumentMetadataPath", inputDocumentMetadataPath)
                 .addArg("-trustLevelThreshold", trustLevelThreshold)
-                .addArg("-collectedFromValue", RELATION_COLLECTED_FROM_VALUE)
+                .addArg("-collectedFromKey", RELATION_COLLECTED_FROM_KEY)
                 .addArg("-outputEntityPath", outputEntityPath)
                 .addArg("-outputRelationPath", outputRelationPath)
                 .addArg("-outputReportPath", reportPath)

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelperTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelperTest.java
@@ -1,0 +1,290 @@
+package eu.dnetlib.iis.wf.export.actionmanager.module;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import eu.dnetlib.dhp.schema.oaf.DataInfo;
+import eu.dnetlib.dhp.schema.oaf.KeyValue;
+import eu.dnetlib.dhp.schema.oaf.Relation;
+import eu.dnetlib.iis.common.InfoSpaceConstants;
+import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
+
+/**
+ * Test class for {@link BuilderModuleHelper}.
+ * @author mhorst
+ */
+public class BuilderModuleHelperTest {
+    
+    String collectedFromValue = "some-repo-id";
+    String relType = "someRelType"; 
+    String subRelType = "someSubRelType";
+    String relClass = "someRelClass";
+    
+    float confidenceLevel = 0.4f;
+    String inferenceProvenance = "some-inference-provenance";
+
+    @Test
+    public void testBuildCollectedFromValue() throws Exception {
+        // execute
+        KeyValue result = BuilderModuleHelper.buildCollectedFromKeyValue(collectedFromValue);
+        
+        // assert        
+        assertNotNull(result);
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getKey());
+        assertEquals(collectedFromValue, result.getValue());
+    }
+    
+    @Test
+    public void testBuildWithNullCollectedFromValue() throws Exception {
+        // execute
+        KeyValue result = BuilderModuleHelper.buildCollectedFromKeyValue(null);
+        
+        // assert
+        assertNotNull(result);
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getKey());
+        assertNull(result.getValue());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelShort() throws Exception {
+        // given
+        String trustLevel = "0.1";
+        
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(trustLevel, inferenceProvenance);
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals(trustLevel, result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelShortWithNullProvenance() throws Exception {
+        // given
+        String trustLevel = "0.1";
+        
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(trustLevel, null);
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals(trustLevel, result.getTrust());
+        assertNull(result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelShortWithNullTrustLevel() throws Exception {
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(null, inferenceProvenance);
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertNull(result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevel() throws Exception {
+        // given
+        boolean inferred = true;
+        String trustLevel = "0.1";
+        String provenanceClass = "someProvenanceClass";
+        
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(inferred, trustLevel, inferenceProvenance, provenanceClass);
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals(trustLevel, result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassid());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelWithNullProvenance() throws Exception {
+        // given
+        boolean inferred = false;
+        String trustLevel = "0.1";
+        String provenanceClass = "someProvenanceClass";
+        
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(inferred, trustLevel, null, provenanceClass);
+        // assert
+        assertNotNull(result);
+        assertFalse(result.getInferred());
+        assertEquals(trustLevel, result.getTrust());
+        assertNull(result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassid());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelWithNullTrustLevel() throws Exception {
+        // given
+        boolean inferred = false;
+        String provenanceClass = "someProvenanceClass";
+        
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(inferred, null, inferenceProvenance, provenanceClass);
+        // assert
+        assertNotNull(result);
+        assertFalse(result.getInferred());
+        assertNull(result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassid());
+        assertEquals(provenanceClass, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForTrustLevelWithNullProvenanceClass() throws Exception {
+        // given
+        boolean inferred = false;
+        String trustLevel = "0.1";
+
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForTrustLevel(inferred, trustLevel, inferenceProvenance, null);
+        // assert
+        assertNotNull(result);
+        assertFalse(result.getInferred());
+        assertEquals(trustLevel, result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertNull(result.getProvenanceaction().getClassid());
+        assertNull(result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForConfidenceLevel() throws Exception {
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, inferenceProvenance);
+
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals("0.36", result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForConfidenceLevelWithNegativeConfidenceLevel() throws Exception {
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForConfidenceLevel(-1, inferenceProvenance);
+
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals("-0.9", result.getTrust());
+        assertEquals(inferenceProvenance, result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testBuildInferenceForConfidenceLevelWithNullInferencceProvenance() throws Exception {
+        // execute
+        DataInfo result = BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, null);
+
+        // assert
+        assertNotNull(result);
+        assertTrue(result.getInferred());
+        assertEquals("0.36", result.getTrust());
+        assertNull(result.getInferenceprovenance());
+        assertNotNull(result.getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getProvenanceaction().getSchemename());
+    }
+    
+    @Test
+    public void testCreateRelation() throws Exception {
+        // given
+        String source = "srcId1";
+        String target = "targetId1";
+        DataInfo dataInfo = BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel, inferenceProvenance);
+        KeyValue keyValue = new KeyValue();
+        String propertyKey = "propKey";
+        String propertyValue = "propVal";
+        keyValue.setKey(propertyKey);
+        keyValue.setValue(propertyValue);
+        List<KeyValue> properties = Collections.singletonList(keyValue);
+        
+        // execute
+        Relation result = BuilderModuleHelper.createRelation(source, target, relType, subRelType, relClass, properties,
+                dataInfo, collectedFromValue);
+        
+        // assert        
+        assertNotNull(result);
+        assertEquals(source, result.getSource());
+        assertEquals(target, result.getTarget());
+        assertEquals(relType, result.getRelType());
+        assertEquals(subRelType, result.getSubRelType());
+        assertEquals(relClass, result.getRelClass());
+        
+        assertNotNull(result.getProperties());
+        assertEquals(1, result.getProperties().size());
+        assertEquals(propertyKey, result.getProperties().get(0).getKey());
+        assertEquals(propertyValue, result.getProperties().get(0).getValue());
+        
+        assertNotNull(result.getDataInfo());
+        assertEquals("0.36", result.getDataInfo().getTrust());
+        assertEquals(inferenceProvenance, result.getDataInfo().getInferenceprovenance());
+        assertNotNull(result.getDataInfo().getProvenanceaction());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getDataInfo().getProvenanceaction().getClassid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_CLASS_IIS, result.getDataInfo().getProvenanceaction().getClassname());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getDataInfo().getProvenanceaction().getSchemeid());
+        assertEquals(InfoSpaceConstants.SEMANTIC_SCHEME_DNET_PROVENANCE_ACTIONS, result.getDataInfo().getProvenanceaction().getSchemename());
+        
+        assertNotNull(result.getCollectedfrom());
+        assertEquals(1, result.getCollectedfrom().size());
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getCollectedfrom().get(0).getKey());
+        assertEquals(collectedFromValue, result.getCollectedfrom().get(0).getValue());
+        
+        assertNotNull(result.getLastupdatetimestamp());
+    }
+    
+}

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelperTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/module/BuilderModuleHelperTest.java
@@ -23,7 +23,7 @@ import eu.dnetlib.iis.wf.export.actionmanager.cfg.StaticConfigurationProvider;
  */
 public class BuilderModuleHelperTest {
     
-    String collectedFromValue = "some-repo-id";
+    String collectedFromKey = "some-repo-id";
     String relType = "someRelType"; 
     String subRelType = "someSubRelType";
     String relClass = "someRelClass";
@@ -32,25 +32,25 @@ public class BuilderModuleHelperTest {
     String inferenceProvenance = "some-inference-provenance";
 
     @Test
-    public void testBuildCollectedFromValue() throws Exception {
+    public void testBuildCollectedFromKey() throws Exception {
         // execute
-        KeyValue result = BuilderModuleHelper.buildCollectedFromKeyValue(collectedFromValue);
+        KeyValue result = BuilderModuleHelper.buildCollectedFromKeyValue(collectedFromKey);
         
         // assert        
         assertNotNull(result);
-        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getKey());
-        assertEquals(collectedFromValue, result.getValue());
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_VALUE, result.getValue());
+        assertEquals(collectedFromKey, result.getKey());
     }
     
     @Test
-    public void testBuildWithNullCollectedFromValue() throws Exception {
+    public void testBuildWithNullCollectedFromKey() throws Exception {
         // execute
         KeyValue result = BuilderModuleHelper.buildCollectedFromKeyValue(null);
         
         // assert
         assertNotNull(result);
-        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getKey());
-        assertNull(result.getValue());
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_VALUE, result.getValue());
+        assertNull(result.getKey());
     }
     
     @Test
@@ -255,7 +255,7 @@ public class BuilderModuleHelperTest {
         
         // execute
         Relation result = BuilderModuleHelper.createRelation(source, target, relType, subRelType, relClass, properties,
-                dataInfo, collectedFromValue);
+                dataInfo, collectedFromKey);
         
         // assert        
         assertNotNull(result);
@@ -281,8 +281,8 @@ public class BuilderModuleHelperTest {
         
         assertNotNull(result.getCollectedfrom());
         assertEquals(1, result.getCollectedfrom().size());
-        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_KEY, result.getCollectedfrom().get(0).getKey());
-        assertEquals(collectedFromValue, result.getCollectedfrom().get(0).getValue());
+        assertEquals(StaticConfigurationProvider.COLLECTED_FROM_VALUE, result.getCollectedfrom().get(0).getValue());
+        assertEquals(collectedFromKey, result.getCollectedfrom().get(0).getKey());
         
         assertNotNull(result.getLastupdatetimestamp());
     }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
 
-    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
+    private static final String RELATION_COLLECTED_FROM_KEY= "someRepo";
     
     @Test
     @DisplayName("Citation matching results are exported as atomic actions and report is generated")
@@ -62,7 +62,7 @@ class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
                 "-outputRelationPath", outputRelationPath.toString(),
                 "-outputReportPath", outputReportPath.toString(),
                 "-trustLevelThreshold", Float.toString(trustLevelThreshold),
-                "-collectedFromValue", RELATION_COLLECTED_FROM_VALUE,
+                "-collectedFromKey", RELATION_COLLECTED_FROM_KEY,
         });
 
         List<AtomicAction<Relation>> atomicActions = spark().sparkContext().sequenceFile(outputRelationPath.toString(), Text.class, Text.class)
@@ -121,7 +121,7 @@ class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
         return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
                 OafConstants.SUBREL_TYPE_CITATION, relClass, BuilderModuleHelper.buildInferenceForConfidenceLevel(
                         confidenceLevel, "iis::document_referencedDocuments"),
-                RELATION_COLLECTED_FROM_VALUE);
+                RELATION_COLLECTED_FROM_KEY);
 
     }
 

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterJobTest.java
@@ -34,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
 
+    private static final String RELATION_COLLECTED_FROM_VALUE = "someRepo";
+    
     @Test
     @DisplayName("Citation matching results are exported as atomic actions and report is generated")
     public void givenInputCitationsPath_whenRun_thenSerializedAtomicActionsAndReportsAreCreated(@TempDir Path rootInputPath,
@@ -59,7 +61,8 @@ class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
                 "-inputCitationsPath", inputCitationsPath.toString(),
                 "-outputRelationPath", outputRelationPath.toString(),
                 "-outputReportPath", outputReportPath.toString(),
-                "-trustLevelThreshold", Float.toString(trustLevelThreshold)
+                "-trustLevelThreshold", Float.toString(trustLevelThreshold),
+                "-collectedFromValue", RELATION_COLLECTED_FROM_VALUE,
         });
 
         List<AtomicAction<Relation>> atomicActions = spark().sparkContext().sequenceFile(outputRelationPath.toString(), Text.class, Text.class)
@@ -115,15 +118,11 @@ class CitationRelationExporterJobTest extends TestWithSharedSparkSession {
     }
 
     private static Relation createRelation(String source, String target, String relClass, Float confidenceLevel) {
-        Relation relation = new Relation();
-        relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-        relation.setSubRelType(OafConstants.SUBREL_TYPE_CITATION);
-        relation.setRelClass(relClass);
-        relation.setSource(source);
-        relation.setTarget(target);
-        relation.setDataInfo(BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel,
-                "iis::document_referencedDocuments"));
-        return relation;
+        return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                OafConstants.SUBREL_TYPE_CITATION, relClass, BuilderModuleHelper.buildInferenceForConfidenceLevel(
+                        confidenceLevel, "iis::document_referencedDocuments"),
+                RELATION_COLLECTED_FROM_VALUE);
+
     }
 
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtilsTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtilsTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
 
-    private static final String collectedFromValue = "someCollectedFromValue";
+    private static final String collectedFromKey = "somecollectedFromKey";
     
     @Nested
     public class ProcessCitationsTest {
@@ -51,7 +51,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
                     DataTypes.BooleanType);
 
             List<Relation> results = processCitations(avroDataFrameSupport.createDataFrame(Collections.emptyList(), Citations.SCHEMA$),
-                    isValidConfidenceLevel, collectedFromValue).collectAsList();
+                    isValidConfidenceLevel, collectedFromKey).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -69,7 +69,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromKey).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -87,7 +87,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromKey).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -105,7 +105,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromKey).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -124,7 +124,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromKey).collectAsList();
 
             assertEquals(2, results.size());
             assertThat(results, hasItem(matchingRelation(
@@ -185,6 +185,6 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
         return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
                 OafConstants.SUBREL_TYPE_CITATION, relClass, BuilderModuleHelper.buildInferenceForConfidenceLevel(
                         confidenceLevel, "iis::document_referencedDocuments"),
-                collectedFromValue);
+                collectedFromKey);
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtilsTest.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/CitationRelationExporterUtilsTest.java
@@ -38,9 +38,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
 
+    private static final String collectedFromValue = "someCollectedFromValue";
+    
     @Nested
     public class ProcessCitationsTest {
-
+        
         @Test
         @DisplayName("Processing returns empty dataset for input with empty citation entries")
         public void givenCitationsWithEmptyCitationEntries_whenProcessed_thenEmptyDataSetIsReturned() {
@@ -49,7 +51,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
                     DataTypes.BooleanType);
 
             List<Relation> results = processCitations(avroDataFrameSupport.createDataFrame(Collections.emptyList(), Citations.SCHEMA$),
-                    isValidConfidenceLevel).collectAsList();
+                    isValidConfidenceLevel, collectedFromValue).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -67,7 +69,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -85,7 +87,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -103,7 +105,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
 
             assertTrue(results.isEmpty());
         }
@@ -122,7 +124,7 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
             Dataset<Row> citationsDF = avroDataFrameSupport.createDataFrame(Collections.singletonList(citations),
                     Citations.SCHEMA$);
 
-            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel).collectAsList();
+            List<Relation> results = processCitations(citationsDF, isValidConfidenceLevel, collectedFromValue).collectAsList();
 
             assertEquals(2, results.size());
             assertThat(results, hasItem(matchingRelation(
@@ -180,14 +182,9 @@ class CitationRelationExporterUtilsTest extends TestWithSharedSparkSession {
     }
 
     private static Relation createRelation(String source, String target, String relClass, Float confidenceLevel) {
-        Relation relation = new Relation();
-        relation.setRelType(OafConstants.REL_TYPE_RESULT_RESULT);
-        relation.setSubRelType(OafConstants.SUBREL_TYPE_CITATION);
-        relation.setRelClass(relClass);
-        relation.setSource(source);
-        relation.setTarget(target);
-        relation.setDataInfo(BuilderModuleHelper.buildInferenceForConfidenceLevel(confidenceLevel,
-                "iis::document_referencedDocuments"));
-        return relation;
+        return BuilderModuleHelper.createRelation(source, target, OafConstants.REL_TYPE_RESULT_RESULT,
+                OafConstants.SUBREL_TYPE_CITATION, relClass, BuilderModuleHelper.buildInferenceForConfidenceLevel(
+                        confidenceLevel, "iis::document_referencedDocuments"),
+                collectedFromValue);
     }
 }

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/Matchers.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/Matchers.java
@@ -37,29 +37,16 @@ public class Matchers {
     }
     
     private static boolean matchesCollectedFrom(List<KeyValue> source, List<KeyValue> target) {
-        if (source != null) {
-            if (target != null) {
-                if (source.size() == target.size()) {
-                    for (int i = 0; i < source.size(); i++) {
-                        if (!source.get(i).getKey().equals(target.get(i).getKey()) || 
-                                !source.get(i).getValue().equals(target.get(i).getValue())) {
-                            return false;
-                        }
-                    }
-                    return true;
-                } else {
+        if (source != null && target != null && source.size() == target.size()) {
+            for (int i = 0; i < source.size(); i++) {
+                if (!source.get(i).getKey().equals(target.get(i).getKey()) || 
+                        !source.get(i).getValue().equals(target.get(i).getValue())) {
                     return false;
                 }
-            } else {
-                return false;
             }
-        } else {
-            if (target == null) {
-                return true;
-            } else {
-                return false;
-            }
+            return true;
         }
+        return source == null && target == null;
     }
 
     public static Matcher<AtomicAction<Relation>> matchingAtomicAction(AtomicAction<Relation> atomicAction) {

--- a/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/Matchers.java
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/java/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/Matchers.java
@@ -1,7 +1,11 @@
 package eu.dnetlib.iis.wf.export.actionmanager.relation.citation;
 
 import eu.dnetlib.dhp.schema.action.AtomicAction;
+import eu.dnetlib.dhp.schema.oaf.KeyValue;
 import eu.dnetlib.dhp.schema.oaf.Relation;
+
+import java.util.List;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -21,7 +25,8 @@ public class Matchers {
                         relation.getSource().equals(item.getSource()) &&
                         relation.getTarget().equals(item.getTarget()) &&
                         Float.parseFloat(relation.getDataInfo().getTrust()) == Float.parseFloat(item.getDataInfo().getTrust()) &&
-                        relation.getDataInfo().getInferenceprovenance().equals(item.getDataInfo().getInferenceprovenance());
+                        relation.getDataInfo().getInferenceprovenance().equals(item.getDataInfo().getInferenceprovenance()) &&
+                        matchesCollectedFrom(relation.getCollectedfrom(), item.getCollectedfrom());
             }
 
             @Override
@@ -29,6 +34,32 @@ public class Matchers {
                 description.appendText("matching relation " + relation);
             }
         };
+    }
+    
+    private static boolean matchesCollectedFrom(List<KeyValue> source, List<KeyValue> target) {
+        if (source != null) {
+            if (target != null) {
+                if (source.size() == target.size()) {
+                    for (int i = 0; i < source.size(); i++) {
+                        if (!source.get(i).getKey().equals(target.get(i).getKey()) || 
+                                !source.get(i).getValue().equals(target.get(i).getValue())) {
+                            return false;
+                        }
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            if (target == null) {
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 
     public static Matcher<AtomicAction<Relation>> matchingAtomicAction(AtomicAction<Relation> atomicAction) {

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/oozie_app/workflow.xml
@@ -66,7 +66,7 @@
                     <value>0.5</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
+                    <name>collectedfrom_key</name>
                     <value>repo-id-1</value>
                 </property>
                 <property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/oozie_app/workflow.xml
@@ -66,6 +66,10 @@
                     <value>0.5</value>
                 </property>
                 <property>
+                    <name>collectedfrom_value</name>
+                    <value>repo-id-1</value>
+                </property>
+                <property>
                     <name>patent_date_of_collection</name>
                     <value>2019-11-20T23:59</value>
                 </property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=document1
 payload.target=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.81
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document1_to_patent1.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=document1
 payload.target=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.81

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=document2
 payload.target=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent1.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=document2
 payload.target=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=document2
 payload.target=50|epopatstat__::6124072c17594dec919a7465b1697bf1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.63
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/document2_to_patent2.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=document2
 payload.target=50|epopatstat__::6124072c17594dec919a7465b1697bf1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.63

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 payload.target=document1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.81

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document1.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 payload.target=document1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.81
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 payload.target=document2
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent1_to_document2.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::a7c39f7f55a8b97defd39b9bb4f87e36
 payload.target=document2
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::6124072c17594dec919a7465b1697bf1
 payload.target=document2
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.63

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/patent/default/output/patent2_to_document2.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=50|epopatstat__::6124072c17594dec919a7465b1697bf1
 payload.target=document2
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.63
 payload.dataInfo.inferenceprovenance=iis::document_patent

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/oozie_app/workflow.xml
@@ -66,7 +66,7 @@
                     <value>0.5</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
+                    <name>collectedfrom_key</name>
                     <value>repo-id-1</value>
                 </property>
                 <property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/oozie_app/workflow.xml
@@ -66,6 +66,10 @@
                     <value>0.5</value>
                 </property>
                 <property>
+                    <name>collectedfrom_value</name>
+                    <value>repo-id-1</value>
+                </property>
+                <property>
                     <name>output_root_entities</name>
                     <value>${workingDir}/output/entities_software</value>
                 </property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/document_to_software.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/document_to_software.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=id-1
 payload.target=50|openaire____::4835133649d4a88133ebd460198d19a2
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_software_url

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/document_to_software.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/document_to_software.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=id-1
 payload.target=50|openaire____::4835133649d4a88133ebd460198d19a2
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/software_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/software_to_document.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=50|openaire____::4835133649d4a88133ebd460198d19a2
 payload.target=id-1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_software_url

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/software_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/default/output/software_to_document.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=50|openaire____::4835133649d4a88133ebd460198d19a2
 payload.target=id-1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/oozie_app/workflow.xml
@@ -66,7 +66,7 @@
                     <value>0.5</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
+                    <name>collectedfrom_key</name>
                     <value>repo-id-1</value>
                 </property>
                 <property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/oozie_app/workflow.xml
@@ -66,6 +66,10 @@
                     <value>0.5</value>
                 </property>
                 <property>
+                    <name>collectedfrom_value</name>
+                    <value>repo-id-1</value>
+                </property>
+                <property>
                     <name>output_root_entities</name>
                     <value>${workingDir}/output/entities_software</value>
                 </property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/document_to_software.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/document_to_software.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=id-1
 payload.target=50|openaire____::4835133649d4a88133ebd460198d19a2
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_software_url

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/document_to_software.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/document_to_software.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=id-1
 payload.target=50|openaire____::4835133649d4a88133ebd460198d19a2
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/software_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/software_to_document.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=50|openaire____::4835133649d4a88133ebd460198d19a2
 payload.target=id-1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72
 payload.dataInfo.inferenceprovenance=iis::document_software_url

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/software_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/entity/software/heritage/output/software_to_document.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=50|openaire____::4835133649d4a88133ebd460198d19a2
 payload.target=id-1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.72

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/oozie_app/workflow.xml
@@ -64,6 +64,10 @@
                     <name>trust_level_threshold_document_referencedDocuments</name>
                     <value>0.5</value>
                 </property>
+                <property>
+                    <name>collectedfrom_value</name>
+                    <value>repo-id-1</value>
+                </property>
             </configuration>
         </sub-workflow>
         <ok to="consumer"/>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/oozie_app/workflow.xml
@@ -65,7 +65,7 @@
                     <value>0.5</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
+                    <name>collectedfrom_key</name>
                     <value>repo-id-1</value>
                 </property>
             </configuration>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/document_to_referencedDocument.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/document_to_referencedDocument.properties
@@ -6,8 +6,8 @@ payload.relClass=Cites
 payload.source=50|oaid-3
 payload.target=50|oaid-4
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.6738

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/document_to_referencedDocument.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/document_to_referencedDocument.properties
@@ -6,6 +6,9 @@ payload.relClass=Cites
 payload.source=50|oaid-3
 payload.target=50|oaid-4
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.6738
 payload.dataInfo.inferenceprovenance=iis::document_referencedDocuments

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/referencedDocument_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/referencedDocument_to_document.properties
@@ -6,8 +6,8 @@ payload.relClass=IsCitedBy
 payload.source=50|oaid-4
 payload.target=50|oaid-3
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.6738

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/referencedDocument_to_document.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/relation/citation/default/output/referencedDocument_to_document.properties
@@ -6,6 +6,9 @@ payload.relClass=IsCitedBy
 payload.source=50|oaid-4
 payload.target=50|oaid-3
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.6738
 payload.dataInfo.inferenceprovenance=iis::document_referencedDocuments

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
@@ -194,7 +194,7 @@
                     <value>0.2</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
+                    <name>collectedfrom_key</name>
                     <value>repo-id-1</value>
                 </property>
                 <property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/oozie_app/workflow.xml
@@ -194,6 +194,10 @@
                     <value>0.2</value>
                 </property>
                 <property>
+                    <name>collectedfrom_value</name>
+                    <value>repo-id-1</value>
+                </property>
+                <property>
                     <name>referenceextraction_pdb_url_root</name>
                     <value>http://www.rcsb.org/pdb/explore/explore.do?structureId=</value>
                 </property>

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_1.properties
@@ -9,6 +9,9 @@ payload.target=id-2
 payload.properties[0].key=similarityLevel
 payload.properties[0].value=0.95
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.9
 payload.dataInfo.inferenceprovenance=iis::document_similarities_standard

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_1.properties
@@ -9,8 +9,8 @@ payload.target=id-2
 payload.properties[0].key=similarityLevel
 payload.properties[0].value=0.95
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.9

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_2.properties
@@ -9,6 +9,9 @@ payload.target=id-1
 payload.properties[0].key=similarityLevel
 payload.properties[0].value=0.95
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.9
 payload.dataInfo.inferenceprovenance=iis::document_similarities_standard

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_similarity_2.properties
@@ -9,8 +9,8 @@ payload.target=id-1
 payload.properties[0].key=similarityLevel
 payload.properties[0].value=0.95
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.9

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_1.properties
@@ -6,6 +6,9 @@ payload.relClass=References
 payload.source=id-10
 payload.target=oai:oai.datacite.org:1390724
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348
 payload.dataInfo.inferenceprovenance=iis::document_referencedDatasets

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_1.properties
@@ -6,8 +6,8 @@ payload.relClass=References
 payload.source=id-10
 payload.target=oai:oai.datacite.org:1390724
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_2.properties
@@ -6,8 +6,8 @@ payload.relClass=IsReferencedBy
 payload.source=oai:oai.datacite.org:1390724
 payload.target=id-10
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_dataset_2.properties
@@ -6,6 +6,9 @@ payload.relClass=IsReferencedBy
 payload.source=oai:oai.datacite.org:1390724
 payload.target=id-10
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348
 payload.dataInfo.inferenceprovenance=iis::document_referencedDatasets

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_1.properties
@@ -6,6 +6,9 @@ payload.relClass=isProducedBy
 payload.source=id-2
 payload.target=ec::226639
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.897
 payload.dataInfo.inferenceprovenance=iis::document_referencedProjects

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_1.properties
@@ -6,8 +6,8 @@ payload.relClass=isProducedBy
 payload.source=id-2
 payload.target=ec::226639
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.897

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_2.properties
@@ -6,8 +6,8 @@ payload.relClass=produces
 payload.source=ec::226639
 payload.target=id-2
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.897

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_project_2.properties
@@ -6,6 +6,9 @@ payload.relClass=produces
 payload.source=ec::226639
 payload.target=id-2
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.897
 payload.dataInfo.inferenceprovenance=iis::document_referencedProjects

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_service.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_service.properties
@@ -6,6 +6,9 @@ payload.relClass=IsRelatedTo
 payload.source=id-10
 payload.target=dsid-1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348
 payload.dataInfo.inferenceprovenance=iis::document_eoscServices

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_service.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/document_to_service.properties
@@ -6,8 +6,8 @@ payload.relClass=IsRelatedTo
 payload.source=id-10
 payload.target=dsid-1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.7348

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_1.properties
@@ -6,6 +6,9 @@ payload.relClass=hasAuthorInstitution
 payload.source=doc-id1
 payload.target=org-id1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.45
 payload.dataInfo.inferenceprovenance=iis::document_affiliations

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_1.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_1.properties
@@ -6,8 +6,8 @@ payload.relClass=hasAuthorInstitution
 payload.source=doc-id1
 payload.target=org-id1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.45

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_2.properties
@@ -6,6 +6,9 @@ payload.relClass=isAuthorInstitutionOf
 payload.source=org-id1
 payload.target=doc-id1
 
+payload.collectedfrom[0].key=OpenAIRE
+payload.collectedfrom[0].value=repo-id-1
+
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.45
 payload.dataInfo.inferenceprovenance=iis::document_affiliations

--- a/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_2.properties
+++ b/iis-wf/iis-wf-export-actionmanager/src/test/resources/eu/dnetlib/iis/wf/export/actionmanager/sequencefile/sampledataproducer/output/matched_doc_organizations_2.properties
@@ -6,8 +6,8 @@ payload.relClass=isAuthorInstitutionOf
 payload.source=org-id1
 payload.target=doc-id1
 
-payload.collectedfrom[0].key=OpenAIRE
-payload.collectedfrom[0].value=repo-id-1
+payload.collectedfrom[0].key=repo-id-1
+payload.collectedfrom[0].value=OpenAIRE
 
 payload.dataInfo.inferred=true
 payload.dataInfo.trust=0.45

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
@@ -215,6 +215,10 @@
             <value>$UNDEFINED$</value>
             <description>document_referencedDocuments trust level threshold</description>
         </property>
+        <property>
+            <name>collectedfrom_value</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+        </property>
 
         <!-- -->
         <property>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/export/oozie_app/workflow.xml
@@ -216,8 +216,8 @@
             <description>document_referencedDocuments trust level threshold</description>
         </property>
         <property>
-            <name>collectedfrom_value</name>
-            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+            <name>collectedfrom_key</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].key</description>
         </property>
 
         <!-- -->

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -377,6 +377,10 @@
             <description>document to patent trust level threshold</description>
         </property>
         <property>
+            <name>export_relation_collectedfrom_value</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+        </property>
+        <property>
             <name>export_referenceextraction_pdb_url_root</name>
             <value>http://www.rcsb.org/pdb/explore/explore.do?structureId=</value>
             <description>protein databank URL root part to be concatenated with pdb identifier when forming final URL</description>
@@ -989,6 +993,10 @@
                 <property>
                     <name>trust_level_threshold_document_eoscServices</name>
                     <value>${export_trust_level_threshold_document_eoscServices}</value>
+                </property>
+                <property>
+                    <name>collectedfrom_value</name>
+                    <value>${export_relation_collectedfrom_value}</value>
                 </property>
                 <property>
                     <name>documentssimilarity_threshold</name>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/main/oozie_app/workflow.xml
@@ -377,8 +377,8 @@
             <description>document to patent trust level threshold</description>
         </property>
         <property>
-            <name>export_relation_collectedfrom_value</name>
-            <description>datasource identifier to be stored in Relation#collectedfrom[].value</description>
+            <name>export_relation_collectedfrom_key</name>
+            <description>datasource identifier to be stored in Relation#collectedfrom[].key</description>
         </property>
         <property>
             <name>export_referenceextraction_pdb_url_root</name>
@@ -995,8 +995,8 @@
                     <value>${export_trust_level_threshold_document_eoscServices}</value>
                 </property>
                 <property>
-                    <name>collectedfrom_value</name>
-                    <value>${export_relation_collectedfrom_value}</value>
+                    <name>collectedfrom_key</name>
+                    <value>${export_relation_collectedfrom_key}</value>
                 </property>
                 <property>
                     <name>documentssimilarity_threshold</name>


### PR DESCRIPTION
My initial impression was it is going to be just a simple addition/extension but it turned out I had to modify quite a substantial part of the exporter module. Mostly due to having different Spark exporter classes for different relation types bound to exported entities (patent, software, citation relations) and a whole different stack for plain relations coming from text mining algorithms covered with classes extending `AbstractRelationBuilderModule`.

I am adding support for `export_relation_collectedfrom_value` IIS input parameter specifying datasource identifier of all relations exported by the IIS. 

So every exported relation is going to have `Relation#collectedfrom[0]#key` set to predefined `OpenAIRE` value and `Relation#collectedfrom[0]#value` set to `export_relation_collectedfrom_value` input parameter value provided at runtime (already added to `default-config.xml` file: https://git.icm.edu.pl/openaire/iis-deployment/-/commit/e12d3e4a23517b8e1d5601aa077c0293d8f08d40).

The already existing exporter modules class hierarchy was changed by introducing `AbstractRelationBuilderModule` to cover `collectedfrom` related processing when building `Relation` object.
 
The existing code is simplified by moving the code responsible for building `Relation` object to `BuilderModuleHelper` class. Supplementing unit tests suite with the relevant tests in `BuilderModuleHelperTest` also covering missing tests for other utiliy methods from the `BuilderModuleHelper` class.

`export_relation_collectedfrom_value` was introduced in multiple `workflow.xml` files starting from IIS primary main workflow and going down to the exporter subworkflow.

Integration tests were extended with additional "expectations" encoded in multiple `*.properties` files with expected `collectedfrom` `key` and `value`.

        
