### PR TITLE
Closes #1494: Prepare a command line tool allowing generation of an output of PMC ingestion parsing run on a particular XML file

### DIFF
--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/AffiliationMetadataExtractorMain.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/AffiliationMetadataExtractorMain.java
@@ -1,0 +1,74 @@
+package eu.dnetlib.iis.wf.ingest.pmc.metadata;
+
+import java.io.ByteArrayOutputStream;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.commons.lang.StringUtils;
+import org.jdom.Element;
+import org.xml.sax.SAXException;
+
+import eu.dnetlib.iis.common.importer.CermineAffiliation;
+import eu.dnetlib.iis.common.importer.CermineAffiliationBuilder;
+import eu.dnetlib.iis.ingest.pmc.metadata.schemas.Affiliation;
+import pl.edu.icm.cermine.exception.AnalysisException;
+import pl.edu.icm.cermine.exception.TransformationException;
+import pl.edu.icm.cermine.metadata.affiliation.CRFAffiliationParser;
+
+/**
+ * 
+ * Simple command line tool accepting affiliation string, to be provided as a single cmdline argument 
+ * (so needs to be specified in quotes), and producing extracted affiliations metadata.
+ * 
+ * @author mhorst
+ */
+public class AffiliationMetadataExtractorMain {
+
+    private static final String encoding = "utf-8";
+    
+    private static final CermineAffiliationBuilder cermineAffiliationBuilder = new CermineAffiliationBuilder();
+    private static final CermineToIngestAffConverter cermineToIngestAffConverter = new CermineToIngestAffConverter();
+    
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            Affiliation aff = buildAffiliationFromText(args[0]);
+            if (aff == null) {
+                throw new RuntimeException("unable to build affiliation from string: " + args[0]);
+            }
+            DatumWriter<Affiliation> writer = new SpecificDatumWriter<>(Affiliation.class);
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(Affiliation.getClassSchema(), stream);
+            writer.write(aff, jsonEncoder);
+            jsonEncoder.flush();
+            System.out.println(new String(stream.toByteArray(), encoding));
+        } else {
+            throw new RuntimeException("invalid number of input arguments: " + args.length 
+                    + ", expecting a single argument with an affiliation string!");
+        }
+    }
+    
+    /**
+     * Parses string representation of an affiliation and extracts affiliation metadata.
+     * @param affiliationText affiliation text to be parsed
+     * @throws SAXException thrown whenever affiliation parsing fails
+     */
+    private static Affiliation buildAffiliationFromText(String affiliationText) throws SAXException {
+        try {
+            if (StringUtils.isNotBlank(affiliationText)) {
+                CRFAffiliationParser affiliationParser = new CRFAffiliationParser();
+                Element parsedAffiliation = affiliationParser.parse(affiliationText);
+                if (parsedAffiliation!=null) {
+                    CermineAffiliation cAff = cermineAffiliationBuilder.build(parsedAffiliation);
+                    return cermineToIngestAffConverter.convert(cAff);
+                }
+            }
+        } catch (TransformationException | AnalysisException e) {
+            throw new SAXException("unexpected exception while parsing "
+                    + "affiliations for document", e);
+        }
+        
+        return null;
+    }
+}

--- a/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/MetadataImporterMain.java
+++ b/iis-wf/iis-wf-ingest-pmc/src/test/java/eu/dnetlib/iis/wf/ingest/pmc/metadata/MetadataImporterMain.java
@@ -1,0 +1,84 @@
+package eu.dnetlib.iis.wf.ingest.pmc.metadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.commons.lang.StringUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import eu.dnetlib.iis.ingest.pmc.metadata.schemas.ExtractedDocumentMetadata;
+
+/**
+ * This class is responsible for performing metadata extraction out of the JATS XML file which location is provided as input parameter.
+ * @author mhorst
+ */
+public class MetadataImporterMain {
+    
+    private static final String encoding = "utf-8"; 
+    
+    public static void main(String[] args) throws IOException, ParserConfigurationException, SAXException {
+        if (args.length == 1) {
+            if (StringUtils.isBlank(args[0])) {
+                throw new RuntimeException("No valid location provided!");
+            }
+            
+            ExtractedDocumentMetadata.Builder builder  = ExtractedDocumentMetadata.newBuilder();
+            builder.setId("");
+            builder.setText("");
+            extractMetadata(getFileContent(args[0]), builder);
+            
+            DatumWriter<ExtractedDocumentMetadata> writer = new SpecificDatumWriter<>(ExtractedDocumentMetadata.class);
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(ExtractedDocumentMetadata.getClassSchema(), stream);
+            writer.write(builder.build(), jsonEncoder);
+            jsonEncoder.flush();
+            System.out.println(new String(stream.toByteArray(), encoding));
+            
+        } else {
+            throw new RuntimeException("invalid number of input arguments: " + args.length 
+                    + ", expecting a single argument with JATS XML file location!");
+        }
+    }
+    
+    /**
+     * Extracts metadata from given xml input by supplementing metada in output builder.
+     * 
+     * @param xmlInput JATS XML file content
+     * @param output extracted metadata
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     * @throws IOException
+     */
+    protected static void extractMetadata(byte[] xmlInput, ExtractedDocumentMetadata.Builder output)
+            throws ParserConfigurationException, SAXException, IOException {
+        SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        saxFactory.setValidating(false);
+        SAXParser saxParser = saxFactory.newSAXParser();
+        XMLReader reader = saxParser.getXMLReader();
+        reader.setFeature("http://xml.org/sax/features/validation", false);
+        reader.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+        reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        JatsXmlHandler pmcXmlHandler = new JatsXmlHandler(output);
+        saxParser.parse(new InputSource(new ByteArrayInputStream(xmlInput)), pmcXmlHandler);
+    }
+    
+    /**
+     * Reads file content from the location provided as input parameter.
+     */
+    private static byte[] getFileContent(String location) throws IOException {
+        return Files.readAllBytes(Paths.get(location));
+    }
+}


### PR DESCRIPTION
This commit brings two utility classes (command line tools) helping in an XML JATS file analysis and affiliation parsing.

`MetadataImporterMain` class is responsible for triggering PMC ingestion from the XML file provided at input and producing the JSON representation of extracted metadata.

`AffiliationMetadataExtractorMain` extracts affiliation metadata directly from the affiliation text provided at input (as a single cmndline parameter so it needs to be wrapped with quotes) and produces JSON representation of parsed affiliation object.

Those are utility classes aimed to be used in debugging process, they are not meant to be used in production environment, so they are defined in `src/test`.