### PR TITLE
Marekhorst 1534 repartition affiliation matching final output before generating reports

### DIFF
--- a/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/main/oozie_app/workflow.xml
@@ -61,7 +61,7 @@
         </property>
         <property>
             <name>sparkNetworkTimeout</name>
-            <value>600s</value>
+            <value>1200s</value>
             <description>default timeout for all network interactions</description>
         </property>
         <property>

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
@@ -147,7 +147,7 @@ public class IisAffMatchResultWriterTest {
         when(matchedOrganizationsDocOrgIdKey.reduceByKey(any())).thenReturn(distinctMatchedOrganizations);
         when(distinctMatchedOrganizations.values()).thenReturn(distinctMatchedOrganizationsValues);
         when(distinctMatchedOrganizationsValues.repartition(2)).thenReturn(distinctMatchedOrganizationsValuesRepartition);
-        when(reportGenerator.generateReport(distinctMatchedOrganizationsValues)).thenReturn(reportEntries);
+        when(reportGenerator.generateReport(distinctMatchedOrganizationsValuesRepartition)).thenReturn(reportEntries);
         when(sc.parallelize(reportEntries, 1)).thenReturn(rddReportEntries);
         
         


### PR DESCRIPTION
This Pull Reqest solves the problem originally described in [#10546](https://support.openaire.eu/issues/10546) redmine ticket:


> The most recent IIS run in the production environment has failed with the following error:
> ```
> org.apache.spark.SparkException: Error communicating with MapOutputTracker
> ``` 
> caused by the:
> ``` 
> java.util.concurrent.TimeoutException: Futures timed out after [600 seconds]
> ``` 

In the past we've been usually dealing with this kind of issues by increasing the timeout parameter mentioned in the detailed stack trace (`spark.network.timeout`).

This time, after deeper inspection and looking into the data, I decided to introduce data repartitioning because it was quite evident we are dealing with ids data skew. Since we already repartition data just before saving the output of processing I decided to simply move this operation one step earlier to rely on repartitioning data when generating report.

Tests has proven this eliminated the problem because the report was successfully generated. 

Apart from that, in order to be on a safe side and reduce the probability of the algorithm fatal failure, I doubled the `sparkNetworkTimeout` value. During multiple runs relying on the repartitioning solution mentioned above there were still individual task timeouts (non-fatal this time) reported in the logs.



