### PR TITLE
Closes #1540: Improve the way size limit is applied for pages obtained by software mining from URLs referenced in papers

### DIFF
--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/HttpServiceFacade.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/HttpServiceFacade.java
@@ -149,7 +149,7 @@ public class HttpServiceFacade extends FacadeContentRetriever<String, String> {
             StringBuilder pageContent = new StringBuilder();
             String inputLine;
             while ((inputLine = reader.readLine()) != null) {
-                if (inputLine.length() < maxPageContentLength && pageContent.length() < maxPageContentLength) {
+                if (inputLine.length() + pageContent.length() < maxPageContentLength) {
                     if (pageContent.length() > 0) {
                         pageContent.append('\n');    
                     }

--- a/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/HttpServiceFacade.java
+++ b/iis-wf/iis-wf-referenceextraction/src/main/java/eu/dnetlib/iis/wf/referenceextraction/softwareurl/HttpServiceFacade.java
@@ -149,7 +149,7 @@ public class HttpServiceFacade extends FacadeContentRetriever<String, String> {
             StringBuilder pageContent = new StringBuilder();
             String inputLine;
             while ((inputLine = reader.readLine()) != null) {
-                if (pageContent.length() < maxPageContentLength) {
+                if (inputLine.length() < maxPageContentLength && pageContent.length() < maxPageContentLength) {
                     if (pageContent.length() > 0) {
                         pageContent.append('\n');    
                     }


### PR DESCRIPTION
Checking not only totally accumalted text length but also currently read line length to prevent exceeding the total size limit once there is a first line exceeding that limit. Adding relevant unit test case to prove the fix is working as expected.

This a fixed pull request which is meant to replace previous #1542 pull request which included an unrelated commit (related to #1535 which was already integrated with the master branch).
