### PR TITLE
Closes #1544: Reduce the number of files generated by the citation matching algorithm

### DIFF
--- a/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
@@ -102,9 +102,14 @@
             <description>lock manager factory class name, to be used for synchronizing access to cache directory</description>
         </property>
         <property>
-            <name>citationmatchingCacheNumberOfEmittedFiles</name>
+            <name>citationmatchingNumberOfEmittedFilesInCache</name>
             <value>1000</value>
-            <description>number of files created by citation matching caching module</description>
+            <description>number of files created by citation matching caching module in cache</description>
+        </property>
+        <property>
+            <name>citationmatchingNumberOfEmittedFiles</name>
+            <value>1000</value>
+            <description>number of files generated as citation matching final outcome</description>
         </property>
     </parameters>
 
@@ -223,7 +228,8 @@
             <arg>-cacheRootDir=${cacheRootDir}</arg>
             <arg>-cacheOlderThanXYears=${cacheOlderThanXYears}</arg>
             <arg>-lockManagerFactoryClassName=${citationmatchingCacheLockManagerFactoryClassName}</arg>
-            <arg>-numberOfEmittedFiles=${citationmatchingCacheNumberOfEmittedFiles}</arg>
+            <arg>-numberOfEmittedFilesInCache=${citationmatchingNumberOfEmittedFilesInCache}</arg>
+            <arg>-numberOfEmittedFiles=${citationmatchingNumberOfEmittedFiles}</arg>
             <arg>-output=${output_citations}</arg>
         </spark>
         <ok to="end"/>

--- a/iis-wf/iis-wf-citationmatching/src/test/java/eu/dnetlib/iis/wf/citationmatching/output/CitationMatchingOutputTransformerJobTest.java
+++ b/iis-wf/iis-wf-citationmatching/src/test/java/eu/dnetlib/iis/wf/citationmatching/output/CitationMatchingOutputTransformerJobTest.java
@@ -175,6 +175,7 @@ public class CitationMatchingOutputTransformerJobTest {
                 .addArg("-cacheOlderThanXYears", "2")
                 .addArg("-output", outputDirPath)
                 .addArg("-numberOfEmittedFiles", "1")
+                .addArg("-numberOfEmittedFilesInCache", "1")
                 .addArg("-lockManagerFactoryClassName", ZookeeperLockManagerFactory.class.getName())
                 .addJobProperty("spark.driver.host", "localhost")
                 .addJobProperty(ZKFailoverController.ZK_QUORUM_KEY, "localhost:" + zookeeperServer.getPort())


### PR DESCRIPTION
Reducing the number of generated files by repartitioning, 1000 files is generated by default.

Fixing parameter names to avoid confusion: `citationmatchingCacheNumberOfEmittedFiles` was defined before which was pretty ambiguous knowing we are supporting now two parameters: one related to the number of files generated by the algorithm at output and the other one related to the number of files generated in cache.