### PR TITLE
Closes #1547: Make running metadata extraction phase during the IIS primary workflow optional

### DIFF
--- a/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/main/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/oozie_app/workflow.xml
@@ -2,6 +2,11 @@
 
 	<parameters>
         <property>
+            <name>active_metadata_extraction</name>
+            <value>false</value>
+            <description>flag indicating metadata extraction from the newly introduced PDF files should be performed</description>
+        </property>
+        <property>
             <name>metadata_extractor_app_name</name>
             <description>metadata_extractor application name</description>
         </property>
@@ -178,9 +183,47 @@
                 </property>
 			</configuration>
 		</sub-workflow>
-		<ok to="cache_update" />
+		<ok to="decision-cache_update" />
 		<error to="fail" />
 	</action>
+	
+	<decision name="decision-cache_update">
+        <switch>
+            <case to="cache_update">${active_metadata_extraction eq "true"}</case>
+            <default to="init-output-and-generate-empty-fault" />
+        </switch>
+    </decision>
+    
+    <action name="init-output-and-generate-empty-fault">
+        <java>
+            <prepare>
+                <!-- notice: directory have to aligned with skipped action output -->
+                <delete path="${nameNode}${output_root}" />
+                <mkdir path="${nameNode}${output_root}" />
+            </prepare>
+            <main-class>eu.dnetlib.iis.common.java.ProcessWrapper</main-class>
+            <arg>eu.dnetlib.iis.common.java.jsonworkflownodes.Producer</arg>
+            <arg>-C{fault,
+                eu.dnetlib.iis.audit.schemas.Fault,
+                eu/dnetlib/iis/common/data/empty.json}
+            </arg>
+            <arg>-Ofault=${output_root}/${output_name_fault}</arg>
+        </java>
+        <ok to="copy-tobereturned-meta" />
+        <error to="fail" />
+    </action>
+
+    <action name="copy-tobereturned-meta">
+        <distcp xmlns="uri:oozie:distcp-action:0.2">
+            <prepare>
+                <delete path="${nameNode}${output_root}/${output_name_meta}" />
+            </prepare>
+            <arg>${nameNode}${workingDir}/transformers_metadataextraction_skip_extracted/tobereturned_meta</arg>
+            <arg>${nameNode}${output_root}/${output_name_meta}</arg>
+        </distcp>
+        <ok to="end" />
+        <error to="fail" />
+    </action>
 
 	<action name="cache_update">
 		<sub-workflow>

--- a/iis-wf/iis-wf-metadataextraction/src/test/java/eu/dnetlib/iis/wf/metadataextraction/MetadataExtractionCacheWorkflowTest.java
+++ b/iis-wf/iis-wf-metadataextraction/src/test/java/eu/dnetlib/iis/wf/metadataextraction/MetadataExtractionCacheWorkflowTest.java
@@ -30,6 +30,12 @@ public class MetadataExtractionCacheWorkflowTest extends AbstractOozieWorkflowTe
     }
     
     @Test
+    public void testChainMetadataExtractionDisabled() throws Exception {
+        testWorkflow("eu/dnetlib/iis/wf/metadataextraction/cache/chain/extraction_disabled_test",
+                new OozieWorkflowTestConfiguration().setTimeoutInSeconds(2400));
+    }
+    
+    @Test
     public void testIdentifyByChecksum() throws Exception {
         testWorkflow("eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/test",
                 new OozieWorkflowTestConfiguration().setTimeoutInSeconds(2400));

--- a/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/extraction_disabled_test/oozie_app/import.txt
+++ b/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/extraction_disabled_test/oozie_app/import.txt
@@ -1,0 +1,3 @@
+## This is a classpath-based import file (this header is required)
+cache_chain classpath eu/dnetlib/iis/wf/metadataextraction/cache/chain/oozie_app
+metadata_extractor_mock classpath eu/dnetlib/iis/wf/metadataextraction/mock/oozie_app

--- a/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/extraction_disabled_test/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/extraction_disabled_test/oozie_app/workflow.xml
@@ -1,4 +1,4 @@
-<workflow-app xmlns="uri:oozie:workflow:0.4" name="test-metadataextraction_cache_identify_by_checksum">
+<workflow-app xmlns="uri:oozie:workflow:0.4" name="test-metadataextraction_cache_chain_extraction_disabled">
 	
     <global>
         <job-tracker>${jobTracker}</job-tracker>
@@ -14,7 +14,7 @@
             </property>
             <property>
                 <name>metadata_extractor_app_name</name>
-                <value>../../metadata_extractor_mock</value>
+                <value>../metadata_extractor_mock</value>
             </property>
             <property>
                 <name>lock_managing_process</name>
@@ -56,13 +56,13 @@
             <!-- Specification of the output ports -->
             <arg>-C{content_url_1,
                 eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/input/document_content_url_1.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/chain/data/input/document_content_url_1.json}</arg>
             <arg>-C{content_url_2,
                 eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/input/document_content_url_2.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/chain/data/input/document_content_url_2.json}</arg>
             <arg>-C{content_url_1_2,
                 eu.dnetlib.iis.importer.auxiliary.schemas.DocumentContentUrl,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/input/document_content_url_1_2.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/chain/data/input/document_content_url_1_2.json}</arg>
             <!-- All input and output ports have to be bound to paths in HDFS -->
             <arg>-Ocontent_url_1=${workingDir}/producer/content_url_1</arg>
             <arg>-Ocontent_url_2=${workingDir}/producer/content_url_2</arg>
@@ -74,7 +74,7 @@
     
     <action name="cache_chain_1st_run">
 		<sub-workflow>
-            <app-path>${wf:appPath()}/cache_identify_by_checksum</app-path>
+            <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
                 <property>
@@ -84,11 +84,11 @@
                 <!-- metadataextraction_mock related parameters -->
                 <property>
                     <name>input_fault_json_location</name>
-                    <value>eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/mock/fault_1.json</value>
+                    <value>eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/fault_1.json</value>
                 </property>
                 <property>
                     <name>input_meta_json_location</name>
-                    <value>eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/mock/meta_1.json</value>
+                    <value>eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/meta_1.json</value>
                 </property>
                 <property>
                     <name>input</name>
@@ -118,17 +118,12 @@
     
     <action name="cache_chain_2nd_run">
         <sub-workflow>
-            <app-path>${wf:appPath()}/cache_identify_by_checksum</app-path>
+            <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
                 <property>
                     <name>active_metadata_extraction</name>
-                    <value>true</value>
-                </property>
-                <!-- metadataextraction_mock related parameters -->
-                <property>
-                    <name>input_meta_json_location</name>
-                    <value>eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/mock/meta_2.json</value>
+                    <value>false</value>
                 </property>
                 <property>
                     <name>input</name>
@@ -158,12 +153,12 @@
     
     <action name="cache_chain_3rd_run">
         <sub-workflow>
-            <app-path>${wf:appPath()}/cache_identify_by_checksum</app-path>
+            <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
                 <property>
                     <name>active_metadata_extraction</name>
-                    <value>true</value>
+                    <value>false</value>
                 </property>
                 <property>
                     <name>input</name>
@@ -212,39 +207,39 @@
 			<!-- Specification of the input ports -->
             <arg>-C{meta_out_1st,
                 eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/output/meta_1.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/meta_1.json}</arg>
             <arg>-C{fault_out_1st,
             eu.dnetlib.iis.audit.schemas.Fault,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/output/fault_1.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/fault_1.json}</arg>
             <!-- no reports for 1st run since cache was initialized and metadataextractor module was mocked -->
 
             <arg>-C{meta_out_2nd,
                 eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/output/meta_2.json}</arg>
+                eu/dnetlib/iis/common/data/empty.json}</arg>
             <arg>-C{fault_out_2nd,
             eu.dnetlib.iis.audit.schemas.Fault,
                 eu/dnetlib/iis/common/data/empty.json}</arg>
             <arg>-C{report_2nd,
                 eu.dnetlib.iis.common.schemas.ReportEntry,
-                eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_2nd.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_empty.json}</arg>
             
             <arg>-C{meta_out_3rd,
                 eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/output/meta_2.json}</arg>
+                eu/dnetlib/iis/common/data/empty.json}</arg>
             <!-- notice: fault was persisted in previous run therefore it is not expected to be returned -->
             <arg>-C{fault_out_3rd,
             eu.dnetlib.iis.audit.schemas.Fault,
                 eu/dnetlib/iis/common/data/empty.json}</arg>
             <arg>-C{report_3rd,
                 eu.dnetlib.iis.common.schemas.ReportEntry,
-                eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_3rd.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_empty.json}</arg>
 
             <arg>-C{meta_cache,
                 eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/cache/meta_1_2.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/meta_1.json}</arg>
             <arg>-C{fault_cache,
             eu.dnetlib.iis.audit.schemas.Fault,
-                eu/dnetlib/iis/wf/metadataextraction/cache/identify_by_checksum/data/cache/fault_1.json}</arg>
+                eu/dnetlib/iis/wf/metadataextraction/cache/data/mock/fault_1.json}</arg>
 
             <arg>-Imeta_out_1st=${workingDir}/cache_chain_1st/out/meta</arg>
             <arg>-Ifault_out_1st=${workingDir}/cache_chain_1st/out/fault</arg>

--- a/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/test/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/chain/test/oozie_app/workflow.xml
@@ -77,6 +77,10 @@
             <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
+                <property>
+                    <name>active_metadata_extraction</name>
+                    <value>true</value>
+                </property>
                 <!-- metadataextraction_mock related parameters -->
                 <property>
                     <name>input_fault_json_location</name>
@@ -117,6 +121,10 @@
             <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
+                <property>
+                    <name>active_metadata_extraction</name>
+                    <value>true</value>
+                </property>
                 <!-- metadataextraction_mock related parameters -->
                 <property>
                     <name>input_meta_json_location</name>
@@ -153,6 +161,10 @@
             <app-path>${wf:appPath()}/cache_chain</app-path>
             <propagate-configuration/>
             <configuration>
+                <property>
+                    <name>active_metadata_extraction</name>
+                    <value>true</value>
+                </property>
                 <property>
                     <name>input</name>
                     <value>${workingDir}/producer/content_url_1_2</value>

--- a/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_empty.json
+++ b/iis-wf/iis-wf-metadataextraction/src/test/resources/eu/dnetlib/iis/wf/metadataextraction/cache/data/output/report_empty.json
@@ -1,0 +1,1 @@
+{"key": "import.metadataExtraction.fromCache.docMetadata", "type":"COUNTER", "value": "0"}


### PR DESCRIPTION
Metadata extraction is disabled by default from now on. Can be re-enabled by setting `active_metadata_extraction` flag to `true` (set to `false` by default).

Cache is still being used in a read-only mode so metadata will be retrieved for all the PDFs which were processed so far.

Introducing a dedicated integration test case proving metadata extraction can be disabled.