### PR TITLE
Closes #1551: Increase SectionedNameLevenshteinMatchVoter similarity level to drop identified false positives

### DIFF
--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/FirstWordsHashBucketMatcherFactory.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/FirstWordsHashBucketMatcherFactory.java
@@ -80,7 +80,7 @@ public final class FirstWordsHashBucketMatcherFactory {
                 createNameCountryStrictMatchVoter(0.981f, new GetOrgNameFunction()),
                 createNameStrictCountryLooseMatchVoter(0.966f, new GetOrgNameFunction()),
                 createSectionedNameStrictCountryLooseMatchVoter(0.815f, new GetOrgNameFunction()),
-                createSectionedNameLevenshteinCountryLooseMatchVoter(0.798f, new GetOrgNameFunction()),
+                createSectionedNameLevenshteinCountryLooseMatchVoter(0.793f, new GetOrgNameFunction()),
                 createSectionedNameStrictCountryLooseMatchVoter(0.682f, new GetOrgShortNameFunction()),
                 commonAffOrgNameWordsVoter);
     }

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/MainSectionHashBucketMatcherFactory.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/MainSectionHashBucketMatcherFactory.java
@@ -75,7 +75,7 @@ public final class MainSectionHashBucketMatcherFactory {
                 createNameCountryStrictMatchVoter(0.981f, new GetOrgNameFunction()),
                 createNameStrictCountryLooseMatchVoter(0.966f, new GetOrgNameFunction()),
                 createSectionedNameStrictCountryLooseMatchVoter(0.978f, new GetOrgNameFunction()),
-                createSectionedNameLevenshteinCountryLooseMatchVoter(0.964f, new GetOrgNameFunction()),
+                createSectionedNameLevenshteinCountryLooseMatchVoter(0.969f, new GetOrgNameFunction()),
                 createSectionedNameStrictCountryLooseMatchVoter(0.937f, new GetOrgShortNameFunction())
                 );
     }

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/voter/AffOrgMatchVotersFactory.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/match/voter/AffOrgMatchVotersFactory.java
@@ -62,7 +62,7 @@ public final class AffOrgMatchVotersFactory {
     
     public static AffOrgMatchVoter createSectionedNameLevenshteinCountryLooseMatchVoter(float matchStrength, Function<AffMatchOrganization, List<String>> getOrgNamesFunction) {
         
-        SectionedNameLevenshteinMatchVoter orgNameVoter = new SectionedNameLevenshteinMatchVoter(0.9);
+        SectionedNameLevenshteinMatchVoter orgNameVoter = new SectionedNameLevenshteinMatchVoter(0.91);
         orgNameVoter.setGetOrgNamesFunction(getOrgNamesFunction);
         
         CompositeMatchVoter voter = new CompositeMatchVoter(ImmutableList.of(new CountryCodeLooseMatchVoter(), orgNameVoter));

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/match/voter/SectionedNameLevenshteinMatchVoterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/match/voter/SectionedNameLevenshteinMatchVoterTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SectionedNameLevenshteinMatchVoterTest {
 
     @InjectMocks
-    private SectionedNameLevenshteinMatchVoter voter = new SectionedNameLevenshteinMatchVoter(0.9);
+    private SectionedNameLevenshteinMatchVoter voter = new SectionedNameLevenshteinMatchVoter(0.91);
     
     @Mock
     private Function<AffMatchOrganization, List<String>> getOrgNamesFunction;
@@ -70,6 +70,42 @@ public class SectionedNameLevenshteinMatchVoterTest {
         
         // execute & assert
         assertTrue(voter.voteMatch(affiliation, organization));
+        
+    }
+    
+    @Test
+    public void voteMatch_dont_match_similar_single_sectioned_italian_case() {
+
+        // given
+        affiliation.setOrganizationName("university of pavia");
+        resetOrgNames("university of pisa");
+        
+        // execute & assert
+        assertFalse(voter.voteMatch(affiliation, organization));
+        
+    }
+    
+    @Test
+    public void voteMatch_dont_match_similar_single_sectioned_italian_case_native_language_pisa() {
+
+        // given
+        affiliation.setOrganizationName("universita degli studi di pavia");
+        resetOrgNames("universita degli studi di pisa");
+        
+        // execute & assert
+        assertFalse(voter.voteMatch(affiliation, organization));
+        
+    }
+    
+    @Test
+    public void voteMatch_dont_match_similar_single_sectioned_italian_case_native_language_padova() {
+
+        // given
+        affiliation.setOrganizationName("universita degli studi di pavia");
+        resetOrgNames("universita degli studi di padova");
+        
+        // execute & assert
+        assertFalse(voter.voteMatch(affiliation, organization));
         
     }
     

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/expectedOutput/matchedOrganizations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/expectedOutput/matchedOrganizations.json
@@ -16,7 +16,7 @@
 {
     "documentId":"DOC_3",
     "organizationId":"20|ICMUW",
-    "matchStrength":0.9999731
+    "matchStrength":0.99997675
 }
 {
     "documentId":"DOC_4",
@@ -26,10 +26,10 @@
 {
     "documentId":"DOC_6",
     "organizationId":"20|WSU",
-    "matchStrength":0.9999501
+    "matchStrength":0.999957
 }
 {
     "documentId":"DOC_6",
     "organizationId":"20|WSU_DUP",
-    "matchStrength":0.9999501
+    "matchStrength":0.999957
 }

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/expectedOutput/report.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/expectedOutput/report.json
@@ -1,0 +1,2 @@
+{"key": "processing.docOrgMatching.docOrgReferences.affiliationBased", "type":"COUNTER", "value": "0"}
+{"key": "processing.docOrgMatching.docs.affiliationBased", "type":"COUNTER", "value": "0"}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/affiliations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/affiliations.json
@@ -1,0 +1,36 @@
+{
+    "id":"50|doi_________::d36eeb1f95335af209276f15e052a51f",
+    "title":"irrelevant",
+    "abstract":null,
+    "language":null,
+    "keywords":null,
+    "externalIdentifiers":null,
+    "journal":null,
+    "year":null,
+    "publisher":null,
+    "references":null,
+    "authors": [
+        {"authorFullName": "author3", "affiliationPositions": [0,1]}
+    ],
+    "affiliations": [
+    {
+      "organization": "Politecnico di Milano",
+      "countryName": null,
+      "countryCode": null,
+      "address": null,
+      "rawText": "Politecnico di Milano"
+    },
+    {
+      "organization": "Università degli Studi di Pisa",
+      "countryName": null,
+      "countryCode": null,
+      "address": null,
+      "rawText": "Università degli Studi di Pisa"
+    }
+  	],
+    "volume":null,
+    "issue":null,
+    "pages":null,
+    "publicationTypeName":null,
+    "text":""
+}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/docProj.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/docProj.json
@@ -1,0 +1,1 @@
+{"documentId":"nonexisting-doc", "projectId":"nonexisting-proj"}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/docProjInferred.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/docProjInferred.json
@@ -1,0 +1,1 @@
+{"documentId":"nonexisting-doc", "projectId":"nonexisting-proj", "confidenceLevel":0.99666107, "textsnippet": null}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/organizations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/organizations.json
@@ -1,0 +1,8 @@
+{
+     "id":"20|anr_________::23fc43b6be73d1d1a9914f8dcc709b36",
+     "name":"Universita Degli Studi di Pavia",
+     "shortName":null,
+     "countryName":"Italy",
+     "countryCode":"IT",
+     "websiteUrl":null
+}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/projOrg.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/reallife_example2/input/projOrg.json
@@ -1,0 +1,1 @@
+{"projectId":"nonexisting-proj", "organizationId":"nonexisting-org"}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/log4j.properties
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/log4j.properties
@@ -7,3 +7,5 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 log4j.logger.eu.dnetlib.iis=DEBUG
+# the properties below should be enabled in local environment to simplify debugging process
+# log4j.logger.eu.dnetlib.iis.wf.affmatching.match=TRACE


### PR DESCRIPTION


Changing SectionedNameLevenshteinMatchVoter similarity level from 0.9 to 0.91. Adjusting predefined trust levels for matchers as the similarity level affects the matching results in the test set. Adding relevant test cases.