### PR TITLE
Closes #1563: Resolve scala-library conflicts between oozie package and sharelibs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,9 +526,15 @@
                 <groupId>com.jsuereth</groupId>
                 <artifactId>scala-arm_2.11</artifactId>
                 <version>1.4</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- conflicting scala binary versions -->
+                        <groupId>org.scala-lang</groupId>
+                        <artifactId>scala-library</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- -->
-
             <dependency>
                 <groupId>pl.edu.icm.coansys</groupId>
                 <artifactId>document-similarity-oap-uberworkflow</artifactId>


### PR DESCRIPTION
Excluding `org.scala-lang:scala-library` dependency from `com.jsuereth:scala-arm_2.11` in the `dependencyManagement` section.