### PR TITLE
Closes #1566: Increase the default executor memory overhead for the InfoSpace importer module

### DIFF
--- a/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/infospace/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/main/resources/eu/dnetlib/iis/wf/importer/infospace/oozie_app/workflow.xml
@@ -128,6 +128,10 @@
             <description>memory for individual executor</description>
         </property>
         <property>
+            <name>sparkExecutorOverhead</name>
+            <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
+        </property>
+        <property>
             <name>sparkExecutorCores</name>
             <description>number of cores used by single executor</description>
         </property>
@@ -187,6 +191,7 @@
                 --executor-memory=${sparkExecutorMemory}
                 --executor-cores=${sparkExecutorCores}
                 --driver-memory=${sparkDriverMemory}
+                --conf spark.yarn.executor.memoryOverhead=${sparkExecutorOverhead}
                 --conf spark.extraListeners=${spark2ExtraListeners}
                 --conf spark.sql.queryExecutionListeners=${spark2SqlQueryExecutionListeners}
                 --conf spark.yarn.historyServer.address=${spark2YarnHistoryServerAddress}

--- a/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-import/src/test/resources/eu/dnetlib/iis/wf/importer/infospace/sampledataproducer/oozie_app/workflow.xml
@@ -219,6 +219,10 @@
                     <name>output_report_relative_path</name>
                     <value>import_infospace</value>
                 </property>
+                <property>
+                    <name>sparkExecutorOverhead</name>
+                    <value>512</value>
+                </property>
             </configuration>
         </sub-workflow>
 

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -28,6 +28,11 @@
             <value>${sparkExecutorMemory}</value>
             <description>infospace importer module spark executor memory</description>
         </property>
+        <property>
+            <name>infospaceImportSparkExecutorOverhead</name>
+            <value>2048</value>
+            <description>The amount of off heap memory (in megabytes) to be allocated for the infospace importer executor</description>
+        </property>
 		<property>
 			<name>inference_provenance_blacklist</name>
 			<value>iis::.*</value>
@@ -282,6 +287,10 @@
                 <property>
                     <name>sparkExecutorMemory</name>
                     <value>${infospaceImportSparkExecutorMemory}</value>
+                </property>
+                <property>
+                    <name>sparkExecutorOverhead</name>
+                    <value>${infospaceImportSparkExecutorOverhead}</value>
                 </property>
                 <property>
                     <name>workingDir</name>


### PR DESCRIPTION
Introducing InfoSpace importer module executor memory overhead in the importer workflow definition. Defining default values for the primary workflow (2048) similarly to other mining modules and setting up default value in test workflow definition.