### PR TITLE
Closes #1569: Both sparkExecutorOverhead and sparkExecutorMemory values should be declared in the same resource

### DIFF
--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/import/oozie_app/workflow.xml
@@ -30,7 +30,6 @@
         </property>
         <property>
             <name>infospaceImportSparkExecutorOverhead</name>
-            <value>2048</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the infospace importer executor</description>
         </property>
 		<property>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -219,7 +219,6 @@
         </property>
         <property>
             <name>researchInitiativeReferenceExtractionSparkExecutorOverhead</name>
-            <value>2048</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
         </property>
         <!-- spark related: documents classification -->
@@ -261,7 +260,6 @@
         </property>
         <property>
             <name>affiliationmatchingSparkDriverOverhead</name>
-            <value>513</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
         </property>
         <property>
@@ -278,7 +276,6 @@
         </property>
         <property>
             <name>citationmatchingDirectSparkExecutorOverhead</name>
-            <value>2048</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
         </property>
         <property>
@@ -303,7 +300,6 @@
         </property>
         <property>
             <name>citationmatchingFuzzySparkDriverOverhead</name>
-            <value>513</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
         </property>
         <property>
@@ -313,7 +309,6 @@
         </property>
         <property>
             <name>citationmatchingFuzzySparkExecutorOverhead</name>
-            <value>4096</value>
             <description>The amount of off heap memory (in megabytes) to be allocated for the executor</description>
         </property>        
         <property>

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -384,6 +384,10 @@
                     <value>$UNDEFINED$</value>
                 </property>
                 <property>
+                    <name>citationmatchingDirectSparkExecutorOverhead</name>
+                    <value>512</value>
+                </property>
+                <property>
                     <name>citationmatchingFuzzySparkDriverOverhead</name>
                     <value>512</value>
                 </property>
@@ -405,6 +409,10 @@
                 </property>
                 <property>
                     <name>researchInitiativeReferenceExtractionSparkExecutorOverhead</name>
+                    <value>512</value>
+                </property>
+                <property>
+                    <name>affiliationmatchingSparkDriverOverhead</name>
                     <value>512</value>
                 </property>
                 <property>


### PR DESCRIPTION
The following properties values were moved to an external `config-default.xml` file:
* `infospaceImportSparkExecutorOverhead`
* `researchInitiativeReferenceExtractionSparkExecutorOverhead`
* `affiliationmatchingSparkDriverOverhead`
* `citationmatchingDirectSparkExecutorOverhead`
* `citationmatchingFuzzySparkDriverOverhead`
* `citationmatchingFuzzySparkExecutorOverhead`

Default values were introduced in the integration test suite whenever missing.

The following commit introduces new values in an external `config-default.xml` file:
https://git.icm.edu.pl/openaire/iis-deployment/-/commit/97528b7c3e195f32ac48830274d8a4a9a6f8b917