### PR TITLE
Closes #1573: Remove explicitly defined affiliationmatchingSparkDriverOverhead and citationmatchingFuzzySparkDriverOverhead to rely on default values

### DIFF
--- a/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/main/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/main/oozie_app/workflow.xml
@@ -56,10 +56,6 @@
             <description>memory for driver process</description>
         </property>
         <property>
-            <name>sparkDriverOverhead</name>
-            <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
-        </property>
-        <property>
             <name>sparkNetworkTimeout</name>
             <value>1200s</value>
             <description>default timeout for all network interactions</description>
@@ -137,7 +133,6 @@
                 --executor-memory=${sparkExecutorMemory}
                 --executor-cores=${sparkExecutorCores}
                 --driver-memory=${sparkDriverMemory}
-                --conf spark.yarn.driver.memoryOverhead=${sparkDriverOverhead}
                 --conf spark.network.timeout=${sparkNetworkTimeout}
                 --conf spark.executor.heartbeatInterval=${sparkExecutorHeartbeatInterval}
                 --conf spark.driver.maxResultSize=${sparkDriverMaxResultSize}

--- a/iis-wf/iis-wf-affmatching/src/test/resources/eu/dnetlib/iis/wf/affmatching/test/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/eu/dnetlib/iis/wf/affmatching/test/oozie_app/workflow.xml
@@ -95,10 +95,6 @@
                     <value>0.8</value>
                 </property>
                 <property>
-                    <name>sparkDriverOverhead</name>
-                    <value>513</value>
-                </property>
-                <property>
                     <name>affiliation_matching_number_of_emitted_files</name>
                     <value>1</value>
                 </property>

--- a/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-citationmatching/src/main/resources/eu/dnetlib/iis/wf/citationmatching/fuzzy/oozie_app/workflow.xml
@@ -43,10 +43,6 @@
             <name>sparkDriverMemory</name>
             <description>memory for driver process</description>
         </property>
-        <property>
-            <name>sparkDriverOverhead</name>
-            <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
-        </property>
 
         <property>
             <name>sparkExecutorMemory</name>
@@ -180,7 +176,6 @@
                 --executor-cores=${sparkExecutorCores}
                 --executor-memory=${sparkExecutorMemory}
                 --driver-memory=${sparkDriverMemory}
-                --conf spark.yarn.driver.memoryOverhead=${sparkDriverOverhead}
                 --conf spark.yarn.executor.memoryOverhead=${sparkExecutorOverhead}
                 --conf spark.extraListeners=${spark2ExtraListeners}
                 --conf spark.sql.queryExecutionListeners=${spark2SqlQueryExecutionListeners}

--- a/iis-wf/iis-wf-citationmatching/src/test/resources/eu/dnetlib/iis/wf/citationmatching/main_workflow/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-citationmatching/src/test/resources/eu/dnetlib/iis/wf/citationmatching/main_workflow/oozie_app/workflow.xml
@@ -84,10 +84,6 @@
                     <value>512</value>
                 </property>
                 <property>
-                    <name>sparkDriverOverhead</name>
-                    <value>512</value>
-                </property>
-                <property>
                     <name>numberOfPartitions</name>
                     <value>400</value>
                 </property>

--- a/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/main/resources/eu/dnetlib/iis/wf/primary/processing/oozie_app/workflow.xml
@@ -259,10 +259,6 @@
             <description>memory for driver process</description>
         </property>
         <property>
-            <name>affiliationmatchingSparkDriverOverhead</name>
-            <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
-        </property>
-        <property>
             <name>affiliationmatchingProjectFundingclassWhitelistRegex</name>
             <value>a^</value>
             <description>regex accepting project references by funding class, limiting set of projects allowed to be used in matching publications with organizations. 
@@ -297,10 +293,6 @@
             <name>citationmatchingFuzzySparkDriverMemory</name>
             <value>${sparkDriverMemory}</value>
             <description>memory for driver process</description>
-        </property>
-        <property>
-            <name>citationmatchingFuzzySparkDriverOverhead</name>
-            <description>The amount of off heap memory (in megabytes) to be allocated for the driver</description>
         </property>
         <property>
             <name>citationmatchingFuzzySparkExecutorMemory</name>
@@ -1564,10 +1556,6 @@
                     <value>${citationmatchingFuzzySparkDriverMemory}</value>
                 </property>
                 <property>
-                    <name>sparkDriverOverhead</name>
-                    <value>${citationmatchingFuzzySparkDriverOverhead}</value>
-                </property>
-                <property>
                     <name>sparkExecutorMemory</name>
                     <value>${citationmatchingFuzzySparkExecutorMemory}</value>
                 </property>
@@ -1876,11 +1864,6 @@
                     <name>sparkDriverMemory</name>
                     <value>${affiliationmatchingSparkDriverMemory}</value>
                 </property>
-                <property>
-                    <name>sparkDriverOverhead</name>
-                    <value>${affiliationmatchingSparkDriverOverhead}</value>
-                </property>
-                
             </configuration>
         </sub-workflow>
         <ok to="affiliation-matching-project-based" />

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/oozie_app/workflow.xml
@@ -388,10 +388,6 @@
                     <value>512</value>
                 </property>
                 <property>
-                    <name>citationmatchingFuzzySparkDriverOverhead</name>
-                    <value>512</value>
-                </property>
-                <property>
                     <name>citationmatchingFuzzySparkExecutorOverhead</name>
                     <value>512</value>
                 </property>
@@ -409,10 +405,6 @@
                 </property>
                 <property>
                     <name>researchInitiativeReferenceExtractionSparkExecutorOverhead</name>
-                    <value>512</value>
-                </property>
-                <property>
-                    <name>affiliationmatchingSparkDriverOverhead</name>
                     <value>512</value>
                 </property>
                 <property>


### PR DESCRIPTION
Removing `affiliationmatchingSparkDriverOverhead` and `citationmatchingFuzzySparkDriverOverhead` from the primary workflow and `sparkDriverOverhead` from the relevant subworkflow definitions.

The default values were already removed from the config-default.template file stored in the config repo:
https://git.icm.edu.pl/openaire/iis-deployment/-/commit/35dd43840ce80821909b1503145108078ce5081e