### PR TITLE
Closes #1598: Update affiliation writer module to persist affiliation position in the output

### DIFF
--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJob.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDedupJob.java
@@ -84,6 +84,7 @@ public class AffMatchingDedupJob {
     private static MatchedOrganizationWithProvenance buildMatchedOrganizationWithProvenance(Tuple2<MatchedOrganization,String> source) {
         MatchedOrganizationWithProvenance.Builder builder = MatchedOrganizationWithProvenance.newBuilder();
         builder.setDocumentId(source._1.getDocumentId());
+        builder.setAffiliationPositions(source._1.getAffiliationPositions());
         builder.setOrganizationId(source._1.getOrganizationId());
         builder.setMatchStrength(source._1.getMatchStrength());
         builder.setProvenance(source._2);

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/AffMatchResultConverter.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/AffMatchResultConverter.java
@@ -1,6 +1,7 @@
 package eu.dnetlib.iis.wf.affmatching.write;
 
 import java.io.Serializable;
+import java.util.Collections;
 
 import com.google.common.base.Preconditions;
 
@@ -32,6 +33,8 @@ public class AffMatchResultConverter implements Serializable {
         MatchedOrganization matchedOrganization = new MatchedOrganization();
         
         matchedOrganization.setDocumentId(affMatchResult.getAffiliation().getDocumentId());
+
+        matchedOrganization.setAffiliationPositions(Collections.singletonList(affMatchResult.getAffiliation().getPosition()));
         
         matchedOrganization.setOrganizationId(affMatchResult.getOrganization().getId());
         

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
@@ -52,8 +52,8 @@ public class DuplicateMatchedOrgStrengthRecalculator implements Serializable {
     /**
      * Combines affiliation positions of two {@link MatchedOrganization}s. Resulting list of positions is sorted and does not contain duplicates.
      * @param match1 first {@link MatchedOrganization} to combine positions from
-     * @param match2 second {@link MatchedOrganization}s to combine positions from
-     * @return combined list of affiliation positions of two {@link MatchedOrganization}s
+     * @param match2 second {@link MatchedOrganization} to combine positions from
+     * @return sorted list of distinct affiliation positions from both {@link MatchedOrganization}s
      */
     private List<Integer> combinePositions(MatchedOrganization match1, MatchedOrganization match2) {
         Stream<Integer> positions1 = match1.getAffiliationPositions() != null ? match1.getAffiliationPositions().stream() : Stream.empty();

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
@@ -56,9 +56,11 @@ public class DuplicateMatchedOrgStrengthRecalculator implements Serializable {
      * @return combined list of affiliation positions of two {@link MatchedOrganization}s
      */
     private List<Integer> combinePositions(MatchedOrganization match1, MatchedOrganization match2) {
-        return Stream.concat(match1.getAffiliationPositions().stream(), match2.getAffiliationPositions().stream())
-                                       .distinct()
-                                       .sorted()
-                                       .collect(Collectors.toList());
+        Stream<Integer> positions1 = match1.getAffiliationPositions() != null ? match1.getAffiliationPositions().stream() : Stream.empty();
+        Stream<Integer> positions2 = match2.getAffiliationPositions() != null ? match2.getAffiliationPositions().stream() : Stream.empty();
+        return Stream.concat(positions1, positions2)
+                     .distinct()
+                     .sorted()
+                     .collect(Collectors.toList());
     }
 }

--- a/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
+++ b/iis-wf/iis-wf-affmatching/src/main/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculator.java
@@ -1,6 +1,9 @@
 package eu.dnetlib.iis.wf.affmatching.write;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.Preconditions;
 
@@ -41,6 +44,21 @@ public class DuplicateMatchedOrgStrengthRecalculator implements Serializable {
         float newMatchStrength = match1.getMatchStrength() + (remainingMatchStrength * match2.getMatchStrength());
         
         
-        return new MatchedOrganization(match1.getDocumentId(), match1.getOrganizationId(), newMatchStrength);
+        return new MatchedOrganization(match1.getDocumentId(), combinePositions(match1, match2), match1.getOrganizationId(), newMatchStrength);
+    }
+
+    //------------------------ PRIVATE --------------------------
+
+    /**
+     * Combines affiliation positions of two {@link MatchedOrganization}s. Resulting list of positions is sorted and does not contain duplicates.
+     * @param match1 first {@link MatchedOrganization} to combine positions from
+     * @param match2 second {@link MatchedOrganization}s to combine positions from
+     * @return combined list of affiliation positions of two {@link MatchedOrganization}s
+     */
+    private List<Integer> combinePositions(MatchedOrganization match1, MatchedOrganization match2) {
+        return Stream.concat(match1.getAffiliationPositions().stream(), match2.getAffiliationPositions().stream())
+                                       .distinct()
+                                       .sorted()
+                                       .collect(Collectors.toList());
     }
 }

--- a/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/model/MatchedOrganization.avdl
+++ b/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/model/MatchedOrganization.avdl
@@ -7,6 +7,9 @@ protocol IIS {
 
         // eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata#id
         string documentId;
+
+        // related affiliation positions in the document, can be null when the match comes from the project based matching
+        union { null , array<int> } affiliationPositions = null;
         
         // eu.dnetlib.iis.importer.schemas.Organization#id       
         string organizationId;

--- a/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/model/MatchedOrganizationWithProvenance.avdl
+++ b/iis-wf/iis-wf-affmatching/src/main/resources/eu/dnetlib/iis/wf/affmatching/model/MatchedOrganizationWithProvenance.avdl
@@ -7,6 +7,9 @@ protocol IIS {
 
         // eu.dnetlib.iis.metadataextraction.schemas.ExtractedDocumentMetadata#id
         string documentId;
+
+        // related affiliation positions in the document, can be null when the match comes from the project based matching
+        union { null , array<int> } affiliationPositions = null;
         
         // eu.dnetlib.iis.importer.schemas.Organization#id       
         string organizationId;

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
@@ -1,5 +1,23 @@
 package eu.dnetlib.iis.wf.affmatching;
 
+import static com.google.common.collect.ImmutableList.of;
+import static com.google.common.collect.Lists.newArrayList;
+import static eu.dnetlib.iis.common.utils.AvroTestUtils.createLocalAvroDataStore;
+import static eu.dnetlib.iis.common.utils.AvroTestUtils.readLocalAvroDataStore;
+import static eu.dnetlib.iis.common.utils.JsonAvroTestUtils.readMultipleJsonDataStores;
+import static eu.dnetlib.iis.common.utils.JsonTestUtils.readMultipleJsons;
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import eu.dnetlib.iis.common.SlowTest;
 import eu.dnetlib.iis.importer.schemas.Organization;
 import eu.dnetlib.iis.importer.schemas.ProjectToOrganization;
@@ -11,27 +29,9 @@ import eu.dnetlib.iis.wf.affmatching.read.AffiliationConverter;
 import eu.dnetlib.iis.wf.affmatching.read.AffiliationReader;
 import eu.dnetlib.iis.wf.affmatching.read.AffiliationReaderFactory;
 import eu.dnetlib.iis.wf.affmatching.read.IisAffiliationReader;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import pl.edu.icm.sparkutils.test.SparkJob;
 import pl.edu.icm.sparkutils.test.SparkJobBuilder;
 import pl.edu.icm.sparkutils.test.SparkJobExecutor;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
-import static com.google.common.collect.ImmutableList.of;
-import static com.google.common.collect.Lists.newArrayList;
-import static eu.dnetlib.iis.common.utils.AvroTestUtils.createLocalAvroDataStore;
-import static eu.dnetlib.iis.common.utils.AvroTestUtils.readLocalAvroDataStore;
-import static eu.dnetlib.iis.common.utils.JsonAvroTestUtils.readMultipleJsonDataStores;
-import static eu.dnetlib.iis.common.utils.JsonTestUtils.readMultipleJsons;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Affiliation matching module test that measures quality of matching.<br/>

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
@@ -22,9 +22,8 @@ import pl.edu.icm.sparkutils.test.SparkJobExecutor;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
-import java.util.function.BiFunction;
 
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Lists.newArrayList;
@@ -241,7 +240,9 @@ public class AffMatchingDocOrgQualityTest {
         
         for (SimpleAffMatchResult simpleResult : simpleAffMatchResults) {
             
-            MatchedOrganization expectedResult = new MatchedOrganization(simpleResult.getDocumentId(), simpleResult.getOrganizationId(), 1f);
+            MatchedOrganization expectedResult = new MatchedOrganization(simpleResult.getDocumentId(), 
+            Collections.singletonList(simpleResult.getAffiliationPosition()),
+            simpleResult.getOrganizationId(), 1f);
             
             
             if (!expectedResults.contains(expectedResult)) {

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingDocOrgQualityTest.java
@@ -241,7 +241,7 @@ public class AffMatchingDocOrgQualityTest {
         for (SimpleAffMatchResult simpleResult : simpleAffMatchResults) {
             
             MatchedOrganization expectedResult = new MatchedOrganization(simpleResult.getDocumentId(), 
-            Collections.singletonList(simpleResult.getAffiliationPosition()),
+            null,
             simpleResult.getOrganizationId(), 1f);
             
             

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculatorTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculatorTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author madryk
  */
@@ -16,10 +20,13 @@ public class DuplicateMatchedOrgStrengthRecalculatorTest {
     
     private DuplicateMatchedOrgStrengthRecalculator strengthRecalculator = new DuplicateMatchedOrgStrengthRecalculator();
     
+    private List<Integer> positions1 = Collections.singletonList(1);
+
+    private List<Integer> positions2 = Collections.singletonList(2);
+
+    private MatchedOrganization matchedOrganization1 = new MatchedOrganization("DOC_ID", positions1, "ORG_ID", 0.6f);
     
-    private MatchedOrganization matchedOrganization1 = new MatchedOrganization("DOC_ID", "ORG_ID", 0.6f);
-    
-    private MatchedOrganization matchedOrganization2 = new MatchedOrganization("DOC_ID", "ORG_ID", 0.3f);
+    private MatchedOrganization matchedOrganization2 = new MatchedOrganization("DOC_ID", positions2, "ORG_ID", 0.3f);
     
     
     //------------------------ TESTS --------------------------
@@ -63,6 +70,7 @@ public class DuplicateMatchedOrgStrengthRecalculatorTest {
         // assert
         assertEquals("DOC_ID", retMatchedOrganization.getDocumentId());
         assertEquals("ORG_ID", retMatchedOrganization.getOrganizationId());
+        assertEquals(Arrays.asList(1, 2), retMatchedOrganization.getAffiliationPositions());
         assertEquals(0.72f, retMatchedOrganization.getMatchStrength(), FLOAT_COMPARE_EPSILON);
     }
     

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculatorTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/DuplicateMatchedOrgStrengthRecalculatorTest.java
@@ -74,4 +74,19 @@ public class DuplicateMatchedOrgStrengthRecalculatorTest {
         assertEquals(0.72f, retMatchedOrganization.getMatchStrength(), FLOAT_COMPARE_EPSILON);
     }
     
+    @Test
+    public void recalculateStrength_NULL_AFFILIATION_POSITIONS() {
+        
+        // given
+        matchedOrganization1.setAffiliationPositions(null);
+        matchedOrganization2.setAffiliationPositions(null);        
+        // execute
+        MatchedOrganization retMatchedOrganization = strengthRecalculator.recalculateStrength(matchedOrganization1, matchedOrganization2);
+        
+        // assert
+        assertEquals("DOC_ID", retMatchedOrganization.getDocumentId());
+        assertEquals("ORG_ID", retMatchedOrganization.getOrganizationId());
+        assertEquals(Collections.emptyList(), retMatchedOrganization.getAffiliationPositions());
+        assertEquals(0.72f, retMatchedOrganization.getMatchStrength(), FLOAT_COMPARE_EPSILON);
+    }
 }

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
@@ -1,8 +1,18 @@
 package eu.dnetlib.iis.wf.affmatching.write;
 
-import eu.dnetlib.iis.common.schemas.ReportEntry;
-import eu.dnetlib.iis.wf.affmatching.model.AffMatchResult;
-import eu.dnetlib.iis.wf.affmatching.model.MatchedOrganization;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -15,15 +25,12 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import eu.dnetlib.iis.common.schemas.ReportEntry;
+import eu.dnetlib.iis.wf.affmatching.model.AffMatchResult;
+import eu.dnetlib.iis.wf.affmatching.model.MatchedOrganization;
 import pl.edu.icm.sparkutils.avro.SparkAvroSaver;
 import scala.Tuple2;
-
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 /**
 * @author Łukasz Dumiszewski

--- a/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
+++ b/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/write/IisAffMatchResultWriterTest.java
@@ -18,9 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import pl.edu.icm.sparkutils.avro.SparkAvroSaver;
 import scala.Tuple2;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -203,7 +205,8 @@ public class IisAffMatchResultWriterTest {
     private void assertExtractDocOrgIdFunction(Function<MatchedOrganization, Tuple2<CharSequence, CharSequence>> function) throws Exception {
         
         // given
-        MatchedOrganization matchedOrg = new MatchedOrganization("DOC_ID", "ORG_ID", 0.6f);
+        List<Integer> positions = Collections.singletonList(1);
+        MatchedOrganization matchedOrg = new MatchedOrganization("DOC_ID", positions, "ORG_ID", 0.6f);
         
         // execute
         Tuple2<CharSequence, CharSequence> extractedDocOrgId = function.call(matchedOrg);

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/expectedOutput/matchedOrganizations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/expectedOutput/matchedOrganizations.json
@@ -1,23 +1,27 @@
 {
     "documentId":"DOC_1",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999999,
     "provenance":"affmatch"
 }
 {
     "documentId":"DOC_2",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999999,
     "provenance":"docmatch"
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [1],
     "organizationId":"20|UCB",
     "matchStrength":1.0,
     "provenance":"affmatch"
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [1],
     "organizationId":"20|WSU",
     "matchStrength":0.1,
     "provenance":"docmatch"

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/input/input1.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/input/input1.json
@@ -1,15 +1,18 @@
 {
     "documentId":"DOC_1",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999999
 }
 {
     "documentId":"DOC_2",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.1
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [1],
     "organizationId":"20|UCB",
     "matchStrength":1.0
 }

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/input/input2.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/dedup/input/input2.json
@@ -1,15 +1,18 @@
 {
     "documentId":"DOC_1",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.1
 }
 {
     "documentId":"DOC_2",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999999
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [1],
     "organizationId":"20|WSU",
     "matchStrength":0.1
 }

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/expectedOutput/matchedOrganizations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/expectedOutput/matchedOrganizations.json
@@ -1,35 +1,42 @@
 {
     "documentId":"ABC",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999995
 }
 {
     "documentId":"20002AX",
+    "affiliationPositions": [1],
     "organizationId":"20|UW",
     "matchStrength":0.9999995
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [1,2],
     "organizationId":"20|UCB",
     "matchStrength":1.0
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": [3],
     "organizationId":"20|ICMUW",
     "matchStrength":0.99997675
 }
 {
     "documentId":"DOC_4",
+    "affiliationPositions": [1],
     "organizationId":"20|UCB",
     "matchStrength":1.0
 }
 {
     "documentId":"DOC_6",
+    "affiliationPositions": [1],
     "organizationId":"20|WSU",
     "matchStrength":0.999957
 }
 {
     "documentId":"DOC_6",
+    "affiliationPositions": [1],
     "organizationId":"20|WSU_DUP",
     "matchStrength":0.999957
 }

--- a/iis-wf/iis-wf-affmatching/src/test/resources/data/projectbased/expectedOutput/matchedOrganizations.json
+++ b/iis-wf/iis-wf-affmatching/src/test/resources/data/projectbased/expectedOutput/matchedOrganizations.json
@@ -1,20 +1,24 @@
 {
     "documentId":"DOC_1",
+    "affiliationPositions": null,
     "organizationId":"20|CNR",
     "matchStrength":1.0
 }
 {
     "documentId":"DOC_2",
+    "affiliationPositions": null,
     "organizationId":"20|UCB",
     "matchStrength":1.0
 }
 {
     "documentId":"DOC_3",
+    "affiliationPositions": null,
     "organizationId":"20|UCB",
     "matchStrength":1.0
 }
 {
     "documentId":"DOC_1",
+    "affiliationPositions": null,
     "organizationId":"20|UCB",
     "matchStrength":0.9
 }

--- a/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/matched_organization.json
+++ b/iis-wf/iis-wf-primary/src/test/resources/eu/dnetlib/iis/wf/primary/processing/sampledataproducer/output/matched_organization.json
@@ -1,17 +1,20 @@
 {
   "documentId": "id-2",
+  "affiliationPositions": [1],
   "organizationId": "20|WIS",
   "matchStrength": 1.0,
   "provenance": "iis::document_referencedOrganizations_by_affiliation"
 }
 {
   "documentId": "id-4",
+  "affiliationPositions": [1],
   "organizationId": "20|UCB",
   "matchStrength": 1.0,
   "provenance": "iis::document_referencedOrganizations_by_affiliation"
 }
 {
   "documentId": "id-4",
+  "affiliationPositions": [2],
   "organizationId": "20|UW",
   "matchStrength": 0.9999995,
   "provenance": "iis::document_referencedOrganizations_by_affiliation"


### PR DESCRIPTION

Updating `MatchedOrganization` and `MatchedOrganizationWithProvenance` avro schema with an additional field: `affiliationPositions`. 
Handling this newly introduced field in the matching pipeline by tracking the matched affiliation position. 
Updating unit and integration tests to honor this newly introduced field.